### PR TITLE
drop lock when heap allocation fail

### DIFF
--- a/kernel/src/heap.rs
+++ b/kernel/src/heap.rs
@@ -50,7 +50,12 @@ unsafe impl GlobalAlloc for Allocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let mut node = MCSNode::new();
         let mut guard = TALLOC.0.lock(&mut node);
-        guard.allocate(layout).unwrap().as_mut()
+        if let Some(mut ptr) = guard.allocate(layout) {
+            return ptr.as_mut();
+        } else {
+            drop(guard);
+            panic!("failed to allocate heap memory");
+        }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {

--- a/kernel/src/nostd.rs
+++ b/kernel/src/nostd.rs
@@ -11,7 +11,8 @@ fn on_oom(_layout: Layout) -> ! {
 
 #[cfg(any(feature = "x86", feature = "aarch64"))]
 #[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    log::error!("{}", info);
     unwinding::panic::begin_panic(Box::new(()));
     wait_forever();
 }


### PR DESCRIPTION
To avoid the deadlock like
```
alloc() --> panic() --> alloc()
```