### PR TITLE
I2C

### DIFF
--- a/awkernel_drivers/src/hal/rpi.rs
+++ b/awkernel_drivers/src/hal/rpi.rs
@@ -1,1 +1,2 @@
 pub mod gpio;
+pub mod i2c;

--- a/awkernel_drivers/src/hal/rpi/i2c.rs
+++ b/awkernel_drivers/src/hal/rpi/i2c.rs
@@ -1,0 +1,121 @@
+use core::ptr::{read_volatile, write_volatile};
+use embedded_hal::blocking::i2c::{Write, Read, WriteRead};
+
+pub static mut I2C_BASE: usize = 0;
+
+pub unsafe fn set_i2c_base(base: usize) {
+    write_volatile(&mut I2C_BASE, base);
+}
+
+// Define the addresses for the different I2C operations
+
+fn i2c_c() -> usize {
+    unsafe { read_volatile(&I2C_BASE) }
+}
+
+fn i2c_s() -> usize {
+    unsafe { read_volatile(&I2C_BASE) + 0x4 }
+}
+
+fn i2c_dlen() -> usize {
+    unsafe { read_volatile(&I2C_BASE) + 0x8 }
+}
+
+fn i2c_a() -> usize {
+    unsafe { read_volatile(&I2C_BASE) + 0xc }
+}
+
+fn i2c_fifo() -> usize {
+    unsafe { read_volatile(&I2C_BASE) + 0x10 }
+}
+
+pub enum I2cError {
+    WriteError,
+    ReadError,
+    OtherError,
+}
+
+pub struct I2C {
+    addr: u8,
+}
+
+impl I2C {
+    pub fn new(addr: u8) -> Self {
+        Self { addr }
+    }
+}
+
+impl Write for I2C {
+    type Error = I2cError;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        unsafe {
+            i2c_write(addr, bytes, i2c_a(), i2c_dlen(), i2c_fifo(), i2c_c(), i2c_s())
+        }
+    }
+}
+
+impl Read for I2C {
+    type Error = I2cError;
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        unsafe {
+            i2c_read(addr, buffer, i2c_a(), i2c_dlen(), i2c_fifo(), i2c_c(), i2c_s())
+        }
+    }
+}
+
+impl WriteRead for I2C {
+    type Error = I2cError;
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.write(addr, bytes)?;
+        self.read(addr, buffer)
+    }
+}
+
+unsafe fn i2c_write(
+    addr: u8,
+    bytes: &[u8],
+    i2c_a: usize,
+    i2c_dlen: usize,
+    i2c_fifo: usize,
+    i2c_c: usize,
+    i2c_s: usize,
+) -> Result<(), I2cError> {
+    write_volatile(i2c_a as *mut u8, addr);
+    write_volatile(i2c_dlen as *mut u16, bytes.len() as u16);
+    for byte in bytes {
+        write_volatile(i2c_fifo as *mut u8, *byte);
+    }
+    write_volatile(i2c_c as *mut u8, 0x80); 
+
+    if read_volatile(i2c_s as *mut u8) != 0 {
+        return Err(I2cError::WriteError);
+    }
+
+    Ok(())
+}
+
+unsafe fn i2c_read(
+    addr: u8,
+    buffer: &mut [u8],
+    i2c_a: usize,
+    i2c_dlen: usize,
+    i2c_fifo: usize,
+    i2c_c: usize,
+    i2c_s: usize,
+) -> Result<(), I2cError> {
+    write_volatile(i2c_a as *mut u8, addr);
+    write_volatile(i2c_dlen as *mut u16, buffer.len() as u16);
+    write_volatile(i2c_c as *mut u8, 0x81); 
+    for byte in buffer {
+        *byte = read_volatile(i2c_fifo as *mut u8);
+    }
+
+    if read_volatile(i2c_s as *mut u8) != 0 {
+        return Err(I2cError::ReadError);
+    }
+    
+    Ok(())
+}

--- a/kernel/src/arch/aarch64/bsp/raspi.rs
+++ b/kernel/src/arch/aarch64/bsp/raspi.rs
@@ -122,6 +122,7 @@ impl super::SoC for Raspi {
         self.init_interrupt_controller()?;
         self.init_timer()?;
         self.init_gpio()?;
+        self.init_i2c()?;
 
         Ok(())
     }
@@ -298,6 +299,20 @@ impl Raspi {
 
         unsafe { awkernel_drivers::hal::rpi::gpio::set_gpio_base(base_addr as usize) };
 
+        Ok(())
+    }
+
+    fn init_i2c(&self) -> Result<(), &'static str> {
+        let i2c_node = self.get_device_from_symbols("i2c")
+            .or(Err(err_msg!("could not find I2C's device node")))?;
+        let base_addr = i2c_node
+            .get_address(0)
+            .or(Err(err_msg!("could not find I2C's base address")))?;
+    
+        log::info!("I2C: 0x{base_addr:016x}");
+    
+        unsafe { awkernel_drivers::hal::rpi::i2c::set_i2c_base(base_addr as usize) };
+    
         Ok(())
     }
 


### PR DESCRIPTION
test code: 
```
    fn test_i2c(&self) {

        let mut i2c = awkernel_drivers::hal::rpi::i2c::I2C::new(0x50);

        let write_data = [0x07, 0x02, 0x03];

        let write_result =  i2c.write(0x50, &write_data);

        let mut read_data = [0; 3];
        let read_result = i2c.read(0x50, &mut read_data);

        log::info!("Read successful, data: {:?}", read_data);
    }
```
test result:

raspi4 

![image](https://github.com/tier4/awkernel/assets/82485734/57cb35e5-446e-40be-97a7-31050f2093ed)




