### PR TITLE
LIB: use oncecell and refcell to refactor local heap

### DIFF
--- a/awkernel_lib/src/device_tree/error.rs
+++ b/awkernel_lib/src/device_tree/error.rs
@@ -2,6 +2,7 @@ pub type Result<T> = core::result::Result<T, DeviceTreeError>;
 
 #[derive(Debug)]
 pub enum DeviceTreeError {
+    AllocatorInitFailed,
     InvalidMagicNumber,
     NotEnoughLength,
     InvalidToken,

--- a/kernel/src/arch/aarch64/bsp.rs
+++ b/kernel/src/arch/aarch64/bsp.rs
@@ -14,13 +14,14 @@ use awkernel_lib::{
 pub mod config;
 pub mod memory;
 
-pub(super) type DeviceTreeRef = &'static DeviceTree<'static, local_heap::LocalHeap<'static>>;
+pub(super) type DeviceTreeRef =
+    &'static DeviceTree<'static, local_heap::LocalHeap<'static, 'static>>;
 
 #[allow(dead_code)]
 pub(super) type DeviceTreeNodeRef =
-    &'static DeviceTreeNode<'static, local_heap::LocalHeap<'static>>;
+    &'static DeviceTreeNode<'static, local_heap::LocalHeap<'static, 'static>>;
 
-pub(super) type StaticArrayedNode = ArrayedNode<'static, local_heap::LocalHeap<'static>>;
+pub(super) type StaticArrayedNode = ArrayedNode<'static, local_heap::LocalHeap<'static, 'static>>;
 
 #[cfg(feature = "aarch64_virt")]
 pub mod aarch64_virt;


### PR DESCRIPTION
Used `OnceCell` and `RefCell`  to refactor local heap related implementation