### PR TITLE
feat: allocate a memory region for the DMA pool

### DIFF
--- a/kernel/src/arch/aarch64/bsp/raspi5.rs
+++ b/kernel/src/arch/aarch64/bsp/raspi5.rs
@@ -1,7 +1,7 @@
 use super::{DeviceTreeNodeRef, DeviceTreeRef, StaticArrayedNode};
 
 use crate::{
-    arch::aarch64::vm::{self,MemoryRange, VM},
+    arch::aarch64::vm::{self, MemoryRange, VM},
     config::DMA_SIZE,
 };
 


### PR DESCRIPTION
DMAPool Settings

The same method as raspi4 causes an error in mbox, thus the same method as aarch64_virt is used to configure the DMA pool.

Output when debugging with print

> DMA pool: start = 0000000040000000, end = 0000000044000000
> Device Memory:
>     0x000000107c000000 - 0x0000001080000000
>     0x0000000040000000 - 0x0000000044000000