### PR TITLE
solve clippy warning for doc comment

### DIFF
--- a/awkernel_drivers/src/pcie/capability/msi.rs
+++ b/awkernel_drivers/src/pcie/capability/msi.rs
@@ -69,7 +69,7 @@ pub enum MultipleMessage {
 /// 1. Allocation of Four Messages to the Device
 ///     - The device has been allocated four different messages for interrupt signaling.
 ///     - This means it can differentiate among four separate events or conditions for which it needs to notify the system.
-/// 2 Message Data Register Value (49A0h)
+/// 2. Message Data Register Value (49A0h)
 ///     - This value is assigned to the device's Message Data register.
 ///     - In MSI, the Message Data register typically contains the interrupt vector that the device should use when signaling an interrupt.
 /// 3. Message Address Register Value (FEEF_F00Ch)

--- a/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
@@ -2319,6 +2319,7 @@ impl IgbHw {
     /// 3) if not set the link is locked (all is good), otherwise...
     /// 4) reset the PHY
     /// 5) repeat up to 10 times
+    ///
     /// Note: this is only called for IGP3 copper when speed is 1gb.
     fn kumeran_lock_loss_workaround(&mut self, info: &PCIeInfo) -> Result<(), IgbDriverErr> {
         // Make sure link is up before proceeding.  If not just return.


### PR DESCRIPTION
This PR addresses the following warnings issued by clippy in preparation for updating the Rust Nightly version.
```
warning: doc list item without indentation
  --> awkernel_drivers/src/pcie/capability/msi.rs:72:5
   |
72 | /// 2 Message Data Register Value (49A0h)
   |     ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
   |
72 | ///       2 Message Data Register Value (49A0h)
   |     ++++++

warning: doc list item without indentation
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:2322:9
     |
2322 |     /// Note: this is only called for IGP3 copper when speed is 1gb.
     |         ^
     |
     = help: if this is supposed to be its own paragraph, add a blank line
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
     |
2322 |     ///    Note: this is only called for IGP3 copper when speed is 1gb.
     |         +++
```