### PR TITLE
solve clippy warning for bit rotation

### DIFF
--- a/awkernel_drivers/src/pcie/capability/msi.rs
+++ b/awkernel_drivers/src/pcie/capability/msi.rs
@@ -69,7 +69,7 @@ pub enum MultipleMessage {
 /// 1. Allocation of Four Messages to the Device
 ///     - The device has been allocated four different messages for interrupt signaling.
 ///     - This means it can differentiate among four separate events or conditions for which it needs to notify the system.
-/// 2 Message Data Register Value (49A0h)
+/// 2. Message Data Register Value (49A0h)
 ///     - This value is assigned to the device's Message Data register.
 ///     - In MSI, the Message Data register typically contains the interrupt vector that the device should use when signaling an interrupt.
 /// 3. Message Address Register Value (FEEF_F00Ch)

--- a/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
@@ -2319,6 +2319,7 @@ impl IgbHw {
     /// 3) if not set the link is locked (all is good), otherwise...
     /// 4) reset the PHY
     /// 5) repeat up to 10 times
+    ///
     /// Note: this is only called for IGP3 copper when speed is 1gb.
     fn kumeran_lock_loss_workaround(&mut self, info: &PCIeInfo) -> Result<(), IgbDriverErr> {
         // Make sure link is up before proceeding.  If not just return.


### PR DESCRIPTION
This PR addresses the following warnings issued by clippy in preparation for updating the Rust Nightly version.
```
warning: there is no need to manually implement bit rotation
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:5873:30
     |
5873 |                         *d = (word_in >> 8) | (word_in << 8);
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `word_in.rotate_left(8)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
     = note: `#[warn(clippy::manual_rotate)]` on by default

warning: there is no need to manually implement bit rotation
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:6006:32
     |
6006 |                 let word_out = (word_out >> 8) | (word_out << 8);
     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `word_out.rotate_left(8)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
warning: there is no need to manually implement bit rotation
    --> awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs:2909:18
     |
2909 |             *d = (word_in >> 8) | (word_in << 8);
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `word_in.rotate_left(8)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
```