### PR TITLE
solve clippy warning for replacing with unwrap

### DIFF
--- a/awkernel_drivers/src/pcie/capability/msi.rs
+++ b/awkernel_drivers/src/pcie/capability/msi.rs
@@ -69,7 +69,7 @@ pub enum MultipleMessage {
 /// 1. Allocation of Four Messages to the Device
 ///     - The device has been allocated four different messages for interrupt signaling.
 ///     - This means it can differentiate among four separate events or conditions for which it needs to notify the system.
-/// 2. Message Data Register Value (49A0h)
+/// 2 Message Data Register Value (49A0h)
 ///     - This value is assigned to the device's Message Data register.
 ///     - In MSI, the Message Data register typically contains the interrupt vector that the device should use when signaling an interrupt.
 /// 3. Message Address Register Value (FEEF_F00Ch)

--- a/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
@@ -2319,7 +2319,6 @@ impl IgbHw {
     /// 3) if not set the link is locked (all is good), otherwise...
     /// 4) reset the PHY
     /// 5) repeat up to 10 times
-    ///
     /// Note: this is only called for IGP3 copper when speed is 1gb.
     fn kumeran_lock_loss_workaround(&mut self, info: &PCIeInfo) -> Result<(), IgbDriverErr> {
         // Make sure link is up before proceeding.  If not just return.


### PR DESCRIPTION
This PR addresses the following warnings issued by clippy in preparation for updating the Rust Nightly version.
```
warning: this pattern reimplements `Result::unwrap_or`
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:6184:30
     |
6184 |               let flash_bank = if let Ok(bank) = hw.valid_nvm_bank_detect_ich8lan(info) {
     |  ______________________________^
6185 | |                 bank
6186 | |             } else {
6187 | |                 0
6188 | |             };
     | |_____________^ help: replace with: `hw.valid_nvm_bank_detect_ich8lan(info).unwrap_or(0)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or
     = note: `#[warn(clippy::manual_unwrap_or)]` on by default

warning: if let can be simplified with `.unwrap_or_default()`
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:6184:30
     |
6184 |               let flash_bank = if let Ok(bank) = hw.valid_nvm_bank_detect_ich8lan(info) {
     |  ______________________________^
6185 | |                 bank
6186 | |             } else {
6187 | |                 0
6188 | |             };
     | |_____________^ help: replace it with: `hw.valid_nvm_bank_detect_ich8lan(info).unwrap_or_default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or_default
     = note: `#[warn(clippy::manual_unwrap_or_default)]` on by default

    Checking awkernel_shell v0.1.0 (/home/koichiimai2/Awkernel/awkernel/applications/awkernel_shell)
warning: this pattern reimplements `Result::unwrap_or`
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:6220:30
     |
6220 |               let flash_bank = if let Ok(bank) = hw.valid_nvm_bank_detect_ich8lan(info) {
     |  ______________________________^
6221 | |                 bank
6222 | |             } else {
6223 | |                 0
6224 | |             };
     | |_____________^ help: replace with: `hw.valid_nvm_bank_detect_ich8lan(info).unwrap_or(0)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or

warning: if let can be simplified with `.unwrap_or_default()`
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:6220:30
     |
6220 |               let flash_bank = if let Ok(bank) = hw.valid_nvm_bank_detect_ich8lan(info) {
     |  ______________________________^
6221 | |                 bank
6222 | |             } else {
6223 | |                 0
6224 | |             };
     | |_____________^ help: replace it with: `hw.valid_nvm_bank_detect_ich8lan(info).unwrap_or_default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or_default

```