### PR TITLE
solve clippy warning for bit rotation

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/igb/igb_hw.rs
@@ -5870,7 +5870,7 @@ impl IgbHw {
                     // starting from any offset.
                     for d in data.iter_mut() {
                         let word_in = hw.shift_in_ee_bits(info, 16)?;
-                        *d = (word_in >> 8) | (word_in << 8);
+                        *d = word_in.rotate_left(8);
                     }
 
                     Ok(())
@@ -6003,7 +6003,7 @@ impl IgbHw {
             // Loop to allow for up to whole page write (32 bytes) of eeprom
             while widx < data.len() {
                 let word_out = data[widx];
-                let word_out = (word_out >> 8) | (word_out << 8);
+                let word_out = word_out.rotate_left(8);
                 self.shift_out_ee_bits(info, word_out, 16)?;
                 widx += 1;
 

--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -2906,7 +2906,7 @@ fn read_eeprom_buffer_bit_bang<T: IxgbeOperations + ?Sized>(
 
             // Read the data.
             let word_in = shift_in_eeprom_bits(info, 16)?;
-            *d = (word_in >> 8) | (word_in << 8);
+            *d = word_in.rotate_left(8);
         }
 
         Ok(())


### PR DESCRIPTION
This PR addresses the following warnings issued by clippy in preparation for updating the Rust Nightly version.
```
warning: there is no need to manually implement bit rotation
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:5873:30
     |
5873 |                         *d = (word_in >> 8) | (word_in << 8);
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `word_in.rotate_left(8)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
     = note: `#[warn(clippy::manual_rotate)]` on by default

warning: there is no need to manually implement bit rotation
    --> awkernel_drivers/src/pcie/intel/igb/igb_hw.rs:6006:32
     |
6006 |                 let word_out = (word_out >> 8) | (word_out << 8);
     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `word_out.rotate_left(8)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
warning: there is no need to manually implement bit rotation
    --> awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs:2909:18
     |
2909 |             *d = (word_in >> 8) | (word_in << 8);
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `word_in.rotate_left(8)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
```