### PR TITLE
solve clippy warning for doc comment

### DIFF
--- a/kernel/src/arch/aarch64/vm.rs
+++ b/kernel/src/arch/aarch64/vm.rs
@@ -64,19 +64,19 @@ impl<A: awkernel_lib::addr::Addr> MemoryRange<A> {
     /// If
     /// - self:  `****----------****`
     /// - range: `******-----*******`
-    /// 
+    ///
     /// then, `ContainResult::Contain` will be returned.
     ///
     /// If
     /// - self:  `*********------***`
     /// - range: `**-----***********`
-    /// 
+    ///
     /// then, `ContainResult::NotContain` will be returned.
     ///
     /// If
     /// - self:  `****----------****`
     /// - range: `**--------********`
-    /// 
+    ///
     /// then, `ContainResult::Overlap` will be returned.
     fn contains(&self, range: Self) -> ContainResult {
         if self.start <= range.start && range.end <= self.end {
@@ -252,7 +252,7 @@ impl VM {
     /// If
     /// - heap:   `***---------***`
     /// - remove: `*****---*******`
-    /// 
+    ///
     /// then the heap will be `***--***----***`.
     pub fn remove_heap(&mut self, start: PhyAddr, end: PhyAddr) -> Result<(), &'static str> {
         if start >= end {


### PR DESCRIPTION
This PR addresses the following warnings issued by clippy in preparation for updating the Rust Nightly version.
```
warning: doc list item without indentation
  --> kernel/src/arch/aarch64/vm.rs:73:9
   |
73 |     /// then, `ContainResult::NotContain` will be returned.
   |         ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
   |
73 |     ///   then, `ContainResult::NotContain` will be returned.
   |         ++

warning: doc list item without indentation
  --> kernel/src/arch/aarch64/vm.rs:78:9
   |
78 |     /// then, `ContainResult::Overlap` will be returned.
   |         ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
   |
78 |     ///   then, `ContainResult::Overlap` will be returned.
   |         ++

warning: doc list item without indentation
   --> kernel/src/arch/aarch64/vm.rs:253:9
    |
253 |     /// then the heap will be `***--***----***`.
    |         ^
    |
    = help: if this is supposed to be its own paragraph, add a blank line
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
    |
253 |     ///   then the heap will be `***--***----***`.
    |         ++

warning: `awkernel` (bin "awkernel") generated 3 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
cargo +nightly-2024-08-13 clippy_raspi5
    Checking awkernel v0.1.0 (/home/koichiimai2/Awkernel/awkernel_orig/kernel)
warning: doc list item without indentation
  --> kernel/src/arch/aarch64/vm.rs:73:9
   |
73 |     /// then, `ContainResult::NotContain` will be returned.
   |         ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
   |
73 |     ///   then, `ContainResult::NotContain` will be returned.
   |         ++

warning: doc list item without indentation
  --> kernel/src/arch/aarch64/vm.rs:78:9
   |
78 |     /// then, `ContainResult::Overlap` will be returned.
   |         ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
   |
78 |     ///   then, `ContainResult::Overlap` will be returned.
   |         ++

warning: doc list item without indentation
   --> kernel/src/arch/aarch64/vm.rs:253:9
    |
253 |     /// then the heap will be `***--***----***`.
    |         ^
    |
    = help: if this is supposed to be its own paragraph, add a blank line
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
    |
253 |     ///   then the heap will be `***--***----***`.
    |         ++

warning: `awkernel` (bin "awkernel") generated 3 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
cargo +nightly-2024-08-13 clippy_aarch64_virt
    Checking awkernel v0.1.0 (/home/koichiimai2/Awkernel/awkernel_orig/kernel)
warning: doc list item without indentation
  --> kernel/src/arch/aarch64/vm.rs:73:9
   |
73 |     /// then, `ContainResult::NotContain` will be returned.
   |         ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
   |
73 |     ///   then, `ContainResult::NotContain` will be returned.
   |         ++

warning: doc list item without indentation
  --> kernel/src/arch/aarch64/vm.rs:78:9
   |
78 |     /// then, `ContainResult::Overlap` will be returned.
   |         ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
   |
78 |     ///   then, `ContainResult::Overlap` will be returned.
   |         ++

warning: doc list item without indentation
   --> kernel/src/arch/aarch64/vm.rs:253:9
    |
253 |     /// then the heap will be `***--***----***`.
    |         ^
    |
    = help: if this is supposed to be its own paragraph, add a blank line
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
    |
253 |     ///   then the heap will be `***--***----***`.
    |         ++
****
```