### PR TITLE
fix(preempt): introduce need_preemption flag to avoid unintended wake() executions of Waiting tasks

### DIFF
--- a/awkernel_async_lib/src/scheduler/rr.rs
+++ b/awkernel_async_lib/src/scheduler/rr.rs
@@ -3,7 +3,7 @@
 use super::{Scheduler, SchedulerType, Task};
 use crate::task::{
     get_current_task, get_last_executed_by_task_id, get_raw_cpu_id, get_scheduler_type_by_task_id,
-    set_need_sched, State,
+    set_need_preemption, State,
 };
 use alloc::{collections::VecDeque, sync::Arc};
 use awkernel_lib::{
@@ -108,7 +108,7 @@ impl RRScheduler {
                             // Compare the elapsed time with the time quantum 
                             && elapsed > self.interval
                     {
-                        set_need_sched(task_id);
+                        set_need_preemption(task_id);
 
                         awkernel_lib::interrupt::send_ipi(
                             preempt_irq,

--- a/awkernel_async_lib/src/task.rs
+++ b/awkernel_async_lib/src/task.rs
@@ -117,6 +117,7 @@ pub struct TaskInfo {
     pub(crate) num_preempt: u64,
     last_executed_time: u64,
     need_sched: bool,
+    need_preemption: bool,
     panicked: bool,
 
     #[cfg(not(feature = "no_preempt"))]
@@ -220,6 +221,7 @@ impl Tasks {
                     num_preempt: 0,
                     last_executed_time: 0,
                     need_sched: false,
+                    need_preemption: false,
                     panicked: false,
 
                     #[cfg(not(feature = "no_preempt"))]
@@ -473,12 +475,6 @@ pub fn run_main() {
                         not(feature = "std")
                     ))]
                     {
-                        {
-                            let mut node = MCSNode::new();
-                            let mut info = task.info.lock(&mut node);
-                            info.need_sched = false;
-                        }
-
                         awkernel_lib::interrupt::enable();
                     }
 
@@ -688,14 +684,14 @@ pub fn get_scheduler_type_by_task_id(task_id: u32) -> Option<SchedulerType> {
 }
 
 #[inline(always)]
-pub fn set_need_sched(task_id: u32) {
+pub fn set_need_preemption(task_id: u32) {
     let mut node = MCSNode::new();
     let tasks = TASKS.lock(&mut node);
 
     if let Some(task) = tasks.id_to_task.get(&task_id) {
         let mut node = MCSNode::new();
         let mut info = task.info.lock(&mut node);
-        info.need_sched = true;
+        info.need_preemption = true;
     }
 }
 

--- a/awkernel_async_lib/src/task/preempt.rs
+++ b/awkernel_async_lib/src/task/preempt.rs
@@ -163,9 +163,11 @@ unsafe fn do_preemption() {
         let task = tasks.id_to_task.get(&task_id.0).unwrap();
 
         let mut node = MCSNode::new();
-        let info = task.info.lock(&mut node);
-        if !info.need_sched {
+        let mut info = task.info.lock(&mut node);
+        if !info.need_preemption {
             return;
+        } else {
+            info.need_preemption = false;
         }
     }
 


### PR DESCRIPTION
In the current implementation, the `need_sched` flag is used to specify that a task needs to be preempted. For example, when the primary core decides to preempt task A, the round-robin scheduler sets the `need_sched` flag for task A, and then an IPI is sent to trigger the preemption. If task A is no longer running on the non-primary core, the preemption will be canceled.

However, this procedure does not work as expected when a preempted task transitions to `State::Waiting`. For instance, the following sequence of events could occur:
1. The primary core sets the `need_sched` flag for task A and sends an IPI to the non-primary core, which is running task A.
2. Task A transitions to `State::Waiting` before the preemption occurs.
3. Task A detects that `need_sched == true` and unnecessarily calls the `wake()` function.

---

Another scenario can happen as follows:
1. The primary core calls the `wake()` function, but since task A is still running, the `need_sched` flag is set.
2. Meanwhile, the primary core detects that task A is a round-robin task that has exceeded its time slice.
3. Preemption is executed.
4. When the preempted task resumes and the `need_sched` flag is reset, the effect of the previous `wake()` function call to be lost.

To avoid such issues, I introduced `need_preemption` flag. 
For preemption, `need_preemption` flag will now be used instead of `need_sched`.

---

There is another bug in the current implementation: Sometimes, the `need_sched` flag will not be reset when a preempted task resumes. This could lead to unintended `wake()` function calls or unintended preemption executions. To fix this issue, I changed the reset timing of the flag from the start of task execution to the beginning of the preemption sequence.

For reference, I will attach a figure of task state changes in the current implementation. Note that this figure does not represent the complete model. `RunningTrue` indicates that the task is in the `State::Running` and the `need_sched` flag is true.

![automaton_updated_v6](https://github.com/user-attachments/assets/2bb091b4-0fb4-465b-b86c-b41d1021ee87)

After the update, the task state transitions will follow the model below:
![automaton_updated_v11](https://github.com/user-attachments/assets/bfe63479-885c-4f14-b653-24e4b40f74dc)

Again, this is not the complete model, as the model is incrementally generated by the model checker and is still in progress. `Running(true,false)` means that the task is in `State::Running`, the `need_sched` flag is true, but the `need_preemption` flag is false.
