### PR TITLE
feat(scheduler): generalize the time quantum check in RR based schedulers

### DIFF
--- a/awkernel_async_lib/src/scheduler/priority_based_rr.rs
+++ b/awkernel_async_lib/src/scheduler/priority_based_rr.rs
@@ -1,10 +1,14 @@
 //! A Priority Based RR scheduler
 
 use super::{Scheduler, SchedulerType, Task};
+use crate::task::{get_last_executed_by_task_id, get_raw_cpu_id, set_need_preemption};
 use alloc::{collections::VecDeque, sync::Arc};
 use awkernel_lib::sync::mutex::Mutex;
 
 pub struct PriorityBasedRRScheduler {
+    // Time quantum
+    interval: u64,
+
     // Run queue
     _data: Mutex<Option<PriorityBasedRRData>>,
 }
@@ -41,5 +45,22 @@ impl Scheduler for PriorityBasedRRScheduler {
 }
 
 pub static SCHEDULER: PriorityBasedRRScheduler = PriorityBasedRRScheduler {
+    // Time quantum (100 ms)
+    interval: 100_000,
+
     _data: Mutex::new(None),
 };
+
+impl PriorityBasedRRScheduler {
+    // Invoke a preemption if the task exceeds the time quantum
+    pub fn invoke_preemption(&self, cpu_id: usize, task_id: u32) {
+        let preempt_irq = awkernel_lib::interrupt::get_preempt_irq();
+        if let Some(last_executed) = get_last_executed_by_task_id(task_id) {
+            let elapsed = awkernel_lib::delay::uptime() - last_executed;
+            if last_executed != 0 && elapsed > self.interval {
+                set_need_preemption(task_id);
+                awkernel_lib::interrupt::send_ipi(preempt_irq, get_raw_cpu_id(cpu_id) as u32);
+            }
+        }
+    }
+}

--- a/awkernel_async_lib/src/scheduler/rr.rs
+++ b/awkernel_async_lib/src/scheduler/rr.rs
@@ -1,15 +1,9 @@
 //! A basic RR scheduler
 
 use super::{Scheduler, SchedulerType, Task};
-use crate::task::{
-    get_current_task, get_last_executed_by_task_id, get_raw_cpu_id, get_scheduler_type_by_task_id,
-    set_need_preemption, State,
-};
+use crate::task::{get_last_executed_by_task_id, get_raw_cpu_id, set_need_preemption, State};
 use alloc::{collections::VecDeque, sync::Arc};
-use awkernel_lib::{
-    cpu::num_cpu,
-    sync::mutex::{MCSNode, Mutex},
-};
+use awkernel_lib::sync::mutex::{MCSNode, Mutex};
 
 pub struct RRScheduler {
     // Time quantum
@@ -90,32 +84,14 @@ pub static SCHEDULER: RRScheduler = RRScheduler {
 };
 
 impl RRScheduler {
-    /// Check whether each running task does not exceed the time quantum
-    pub fn check_time_quantum(&self) {
+    // Invoke a preemption if the task exceeds the time quantum
+    pub fn invoke_preemption(&self, cpu_id: usize, task_id: u32) {
         let preempt_irq = awkernel_lib::interrupt::get_preempt_irq();
-
-        for cpu_id in 1..num_cpu() {
-            if let Some(task_id) = get_current_task(cpu_id) {
-                if let (Some(last_executed), Some(scheduler_type)) = (
-                    get_last_executed_by_task_id(task_id),
-                    get_scheduler_type_by_task_id(task_id),
-                ) {
-                    let elapsed = awkernel_lib::delay::uptime() - last_executed;
-
-                    if scheduler_type == SchedulerType::RR
-                            // Omit checking for a task that has not been started yet
-                            && last_executed != 0
-                            // Compare the elapsed time with the time quantum 
-                            && elapsed > self.interval
-                    {
-                        set_need_preemption(task_id);
-
-                        awkernel_lib::interrupt::send_ipi(
-                            preempt_irq,
-                            get_raw_cpu_id(cpu_id) as u32,
-                        );
-                    }
-                }
+        if let Some(last_executed) = get_last_executed_by_task_id(task_id) {
+            let elapsed = awkernel_lib::delay::uptime() - last_executed;
+            if last_executed != 0 && elapsed > self.interval {
+                set_need_preemption(task_id);
+                awkernel_lib::interrupt::send_ipi(preempt_irq, get_raw_cpu_id(cpu_id) as u32);
             }
         }
     }


### PR DESCRIPTION
Genralized the time quentum checkings for RR based schedulers.

`interval` in PriorityBasedRRScheduler is set to 100ms for now, which is the same value as in RR.