### PR TITLE
update rust toolchain version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,8 @@ RUN . /usr/local/cargo/env && \
     cargo install mdbook-mermaid
 
 RUN . /usr/local/cargo/env && \
-    rustup toolchain install nightly-2024-05-08 && \
-    rustup default nightly-2024-05-08 && \
+    rustup toolchain install nightly-2024-10-16 && \
+    rustup default nightly-2024-10-16 && \
     rustup component add rust-src llvm-tools-preview && \
     rustup target add x86_64-unknown-none aarch64-unknown-none riscv32imac-unknown-none-elf
 


### PR DESCRIPTION
This small PR updates the rust toolchain designated on Dockerfile to 2024-10-16 as done in #168.