### PR TITLE
test(scheduler): add PrioritizedFIFO test application

### DIFF
--- a/applications/test_prioritized_fifo/Cargo.toml
+++ b/applications/test_prioritized_fifo/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_prioritized_fifo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+log = "0.4"
+
+[dependencies.awkernel_async_lib]
+path = "../../awkernel_async_lib"
+default-features = false
+
+[dependencies.awkernel_lib]
+path = "../../awkernel_lib"
+default-features = false

--- a/applications/test_prioritized_fifo/src/lib.rs
+++ b/applications/test_prioritized_fifo/src/lib.rs
@@ -1,0 +1,48 @@
+#![no_std]
+
+use awkernel_async_lib::{scheduler::SchedulerType, spawn};
+use awkernel_lib::{cpu::num_cpu, delay::wait_millisec};
+
+/// This test confirms whether PrioritizedFIFO scheduler actually schedules
+/// high priority tasks prior to low priority tasks.
+pub async fn run() {
+    wait_millisec(1000);
+
+    for i in 1..num_cpu() {
+        spawn(
+            "sleep".into(),
+            async move {
+                log::debug!("sleeping, core={i}");
+                wait_millisec(1000);
+            },
+            SchedulerType::PrioritizedFIFO(0),
+        )
+        .await;
+    }
+
+    wait_millisec(500);
+
+    for i in 1..num_cpu() {
+        spawn(
+            "low_priority".into(),
+            async move {
+                log::debug!("low priority task, core={i}");
+                wait_millisec(100);
+            },
+            SchedulerType::PrioritizedFIFO(255),
+        )
+        .await;
+    }
+
+    for i in 1..num_cpu() {
+        spawn(
+            "high_priority".into(),
+            async move {
+                log::debug!("high priority task, core={i}");
+                wait_millisec(100);
+            },
+            SchedulerType::PrioritizedFIFO(0),
+        )
+        .await;
+    }
+}

--- a/userland/Cargo.toml
+++ b/userland/Cargo.toml
@@ -30,6 +30,10 @@ optional = true
 path = "../applications/test_graphics"
 optional = true
 
+[dependencies.test_prioritized_fifo]
+path = "../applications/test_prioritized_fifo"
+optional = true
+
 [features]
 default = ["test_graphics"]
 raspi = ["dep:test_rpi_hal"]
@@ -37,3 +41,4 @@ test_network = ["dep:test_network"]
 test_pubsub = ["dep:test_pubsub"]
 test_rpi_hal = ["dep:test_rpi_hal"]
 test_graphics = ["dep:test_graphics"]
+test_prioritized_fifo = ["dep:test_prioritized_fifo"]

--- a/userland/src/lib.rs
+++ b/userland/src/lib.rs
@@ -19,5 +19,8 @@ pub async fn main() -> Result<(), Cow<'static, str>> {
     #[cfg(feature = "test_graphics")]
     test_graphics::run().await; // test for graphics
 
+    #[cfg(feature = "test_prioritized_fifo")]
+    test_prioritized_fifo::run().await; // test for prioritized_fifo
+
     Ok(())
 }


### PR DESCRIPTION
Added test for `PrioritizedFIFO` scheduler

This PR is tested in `qemu-x86_64`.
When `test_prioritized_fifo` feature is enabled, the console looks like the following:
high priority tasks are scheduled earlier than low priority tasks.
```
Enjoy!

> [         3338 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=3
[         3339 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=1
[         3340 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=14
[         3340 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=7
[         3342 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=15
[         3348 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=13
[         3370 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=12
[         3386 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=11
[         3401 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=10
[         3403 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=9
[         3417 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=6
[         3419 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=5
[         3420 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=8
[         3421 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=2
[         3844 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:17: sleeping, core=4
[         4342 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=12
[         4343 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=15
[         4345 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=8
[         4345 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=14
[         4346 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=13
[         4350 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=9
[         4372 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=10
[         4388 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=11
[         4403 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=1
[         4404 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=4
[         4419 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=6
[         4421 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=7
[         4423 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=5
[         4423 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=2
[         4444 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:43: high priority task, core=3
[         4446 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=14
[         4448 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=6
[         4449 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=11
[         4450 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=13
[         4452 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=15
[         4474 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=5
[         4489 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=2
[         4506 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=9
[         4507 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=7
[         4521 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=1
[         4523 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=12
[         4524 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=3
[         4525 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=4
[         4546 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=10
[         4548 DEBUG] /home/veqcc/work/awkernel/applications/test_prioritized_fifo/src/lib.rs:31: low priority task, core=8
```