### PR TITLE
feat:calc preempt context switch overhead

### DIFF
--- a/applications/test_pubsub/src/lib.rs
+++ b/applications/test_pubsub/src/lib.rs
@@ -9,7 +9,7 @@ use awkernel_async_lib::{
     pubsub::{self, create_publisher, create_subscriber},
     scheduler::SchedulerType,
     sleep, spawn,
-    task::perf::add_yield_context_restore_end,
+    task::perf::{add_context_restore_end, ContextSwitchType},
     uptime,
 };
 use core::{
@@ -100,7 +100,11 @@ pub async fn run() {
                 loop {
                     subscriber.recv().await;
                     // Only the subscriber's cooperative context switch overhead is measured.
-                    add_yield_context_restore_end(awkernel_async_lib::cpu_id(), cpu_counter());
+                    add_context_restore_end(
+                        ContextSwitchType::Yield,
+                        awkernel_async_lib::cpu_id(),
+                        cpu_counter(),
+                    );
                 }
             },
             SchedulerType::FIFO,

--- a/awkernel_async_lib/src/task.rs
+++ b/awkernel_async_lib/src/task.rs
@@ -338,6 +338,18 @@ pub mod perf {
     static mut YIELD_CONTEXT_RESTORE_OVERHEADS: [u64; MAX_MEASURE_SIZE] = [0; MAX_MEASURE_SIZE];
     static YIELD_CRO_COUNT: AtomicUsize = AtomicUsize::new(0);
 
+    static mut PREEMPT_CONTEXT_SAVE_STARTS: [u64; NUM_MAX_CPU] = [0; NUM_MAX_CPU];
+    static mut PREEMPT_CONTEXT_SAVE_OVERHEADS: [u64; MAX_MEASURE_SIZE] = [0; MAX_MEASURE_SIZE];
+    static PREEMPT_CSO_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static mut PREEMPT_CONTEXT_RESTORE_STARTS: [u64; NUM_MAX_CPU] = [0; NUM_MAX_CPU];
+    static mut PREEMPT_CONTEXT_RESTORE_OVERHEADS: [u64; MAX_MEASURE_SIZE] = [0; MAX_MEASURE_SIZE];
+    static PREEMPT_CRO_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    pub enum ContextSwitchType {
+        Yield,
+        Preempt,
+    }
+
     pub fn add_task_start(cpu_id: usize, time: u64) {
         unsafe { write_volatile(&mut TASKS_STARTS[cpu_id], time) };
     }
@@ -374,43 +386,105 @@ pub mod perf {
         unsafe { read_volatile(&TASKS_EXEC_TIMES[task_index]) }
     }
 
-    pub fn add_yield_context_save_start(cpu_id: usize, time: u64) {
-        unsafe { write_volatile(&mut YIELD_CONTEXT_SAVE_STARTS[cpu_id], time) };
+    pub fn add_context_save_start(context_type: ContextSwitchType, cpu_id: usize, time: u64) {
+        unsafe {
+            match context_type {
+                ContextSwitchType::Yield => {
+                    write_volatile(&mut YIELD_CONTEXT_SAVE_STARTS[cpu_id], time)
+                }
+                ContextSwitchType::Preempt => {
+                    write_volatile(&mut PREEMPT_CONTEXT_SAVE_STARTS[cpu_id], time)
+                }
+            }
+        };
     }
 
-    pub fn add_yield_context_save_end(cpu_id: usize, time: u64) {
-        let start = unsafe { read_volatile(&YIELD_CONTEXT_SAVE_STARTS[cpu_id]) };
+    pub fn add_context_save_end(context_type: ContextSwitchType, cpu_id: usize, time: u64) {
+        let start = unsafe {
+            match context_type {
+                ContextSwitchType::Yield => read_volatile(&YIELD_CONTEXT_SAVE_STARTS[cpu_id]),
+                ContextSwitchType::Preempt => read_volatile(&PREEMPT_CONTEXT_SAVE_STARTS[cpu_id]),
+            }
+        };
+
         if start != 0 && time > start {
             let context_save_overhead = time - start;
-            let index = YIELD_CSO_COUNT.fetch_add(1, Ordering::Relaxed);
-            unsafe {
-                write_volatile(
-                    &mut YIELD_CONTEXT_SAVE_OVERHEADS[index & (MAX_MEASURE_SIZE - 1)],
-                    context_save_overhead,
-                )
+
+            let index = match context_type {
+                ContextSwitchType::Yield => YIELD_CSO_COUNT.fetch_add(1, Ordering::Relaxed),
+                ContextSwitchType::Preempt => PREEMPT_CSO_COUNT.fetch_add(1, Ordering::Relaxed),
             };
 
-            unsafe { write_volatile(&mut YIELD_CONTEXT_SAVE_STARTS[cpu_id], 0) };
+            unsafe {
+                match context_type {
+                    ContextSwitchType::Yield => {
+                        write_volatile(
+                            &mut YIELD_CONTEXT_SAVE_OVERHEADS[index & (MAX_MEASURE_SIZE - 1)],
+                            context_save_overhead,
+                        );
+                        write_volatile(&mut YIELD_CONTEXT_SAVE_STARTS[cpu_id], 0);
+                    }
+                    ContextSwitchType::Preempt => {
+                        write_volatile(
+                            &mut PREEMPT_CONTEXT_SAVE_OVERHEADS[index & (MAX_MEASURE_SIZE - 1)],
+                            context_save_overhead,
+                        );
+                        write_volatile(&mut PREEMPT_CONTEXT_SAVE_STARTS[cpu_id], 0);
+                    }
+                }
+            };
         }
     }
 
-    pub fn add_yield_context_restore_start(cpu_id: usize, time: u64) {
-        unsafe { write_volatile(&mut YIELD_CONTEXT_RESTORE_STARTS[cpu_id], time) };
+    pub fn add_context_restore_start(context_type: ContextSwitchType, cpu_id: usize, time: u64) {
+        unsafe {
+            match context_type {
+                ContextSwitchType::Yield => {
+                    write_volatile(&mut YIELD_CONTEXT_RESTORE_STARTS[cpu_id], time)
+                }
+                ContextSwitchType::Preempt => {
+                    write_volatile(&mut PREEMPT_CONTEXT_RESTORE_STARTS[cpu_id], time)
+                }
+            }
+        }
     }
 
-    pub fn add_yield_context_restore_end(cpu_id: usize, time: u64) {
-        let start = unsafe { read_volatile(&YIELD_CONTEXT_RESTORE_STARTS[cpu_id]) };
+    pub fn add_context_restore_end(context_type: ContextSwitchType, cpu_id: usize, time: u64) {
+        let start = unsafe {
+            match context_type {
+                ContextSwitchType::Yield => read_volatile(&YIELD_CONTEXT_RESTORE_STARTS[cpu_id]),
+                ContextSwitchType::Preempt => {
+                    read_volatile(&PREEMPT_CONTEXT_RESTORE_STARTS[cpu_id])
+                }
+            }
+        };
+
         if start != 0 && time > start {
             let context_restore_overhead = time - start;
-            let index = YIELD_CRO_COUNT.fetch_add(1, Ordering::Relaxed);
-            unsafe {
-                write_volatile(
-                    &mut YIELD_CONTEXT_RESTORE_OVERHEADS[index & (MAX_MEASURE_SIZE - 1)],
-                    context_restore_overhead,
-                )
+
+            let index = match context_type {
+                ContextSwitchType::Yield => YIELD_CRO_COUNT.fetch_add(1, Ordering::Relaxed),
+                ContextSwitchType::Preempt => PREEMPT_CRO_COUNT.fetch_add(1, Ordering::Relaxed),
             };
 
-            unsafe { write_volatile(&mut YIELD_CONTEXT_RESTORE_STARTS[cpu_id], 0) };
+            unsafe {
+                match context_type {
+                    ContextSwitchType::Yield => {
+                        write_volatile(
+                            &mut YIELD_CONTEXT_RESTORE_OVERHEADS[index & (MAX_MEASURE_SIZE - 1)],
+                            context_restore_overhead,
+                        );
+                        write_volatile(&mut YIELD_CONTEXT_RESTORE_STARTS[cpu_id], 0);
+                    }
+                    ContextSwitchType::Preempt => {
+                        write_volatile(
+                            &mut PREEMPT_CONTEXT_RESTORE_OVERHEADS[index & (MAX_MEASURE_SIZE - 1)],
+                            context_restore_overhead,
+                        );
+                        write_volatile(&mut PREEMPT_CONTEXT_RESTORE_STARTS[cpu_id], 0);
+                    }
+                }
+            };
         }
     }
 
@@ -438,11 +512,24 @@ pub mod perf {
         }
     }
 
-    pub fn calc_yield_context_switch_overhead() -> (f64, f64, f64, f64) {
-        let (avg_save, worst_save) =
-            calc_overheads(unsafe { &*addr_of!(YIELD_CONTEXT_SAVE_OVERHEADS) });
-        let (avg_restore, worst_restore) =
-            calc_overheads(unsafe { &*addr_of!(YIELD_CONTEXT_RESTORE_OVERHEADS) });
+    pub fn calc_context_switch_overhead(context_type: ContextSwitchType) -> (f64, f64, f64, f64) {
+        let (avg_save, worst_save, avg_restore, worst_restore) = match context_type {
+            ContextSwitchType::Yield => {
+                let (avg_save, worst_save) =
+                    calc_overheads(unsafe { &*addr_of!(YIELD_CONTEXT_SAVE_OVERHEADS) });
+                let (avg_restore, worst_restore) =
+                    calc_overheads(unsafe { &*addr_of!(YIELD_CONTEXT_RESTORE_OVERHEADS) });
+                (avg_save, worst_save, avg_restore, worst_restore)
+            }
+            ContextSwitchType::Preempt => {
+                let (avg_save, worst_save) =
+                    calc_overheads(unsafe { &*addr_of!(PREEMPT_CONTEXT_SAVE_OVERHEADS) });
+                let (avg_restore, worst_restore) =
+                    calc_overheads(unsafe { &*addr_of!(PREEMPT_CONTEXT_RESTORE_OVERHEADS) });
+                (avg_save, worst_save, avg_restore, worst_restore)
+            }
+        };
+
         (avg_save, worst_save, avg_restore, worst_restore)
     }
 }
@@ -518,7 +605,11 @@ pub fn run_main() {
 
                     // Only the subscriber's cooperative context switch overhead is measured.
                     if task.name.contains("subscriber") {
-                        perf::add_yield_context_restore_start(cpu_id, cpu_counter());
+                        perf::add_context_restore_start(
+                            perf::ContextSwitchType::Yield,
+                            cpu_id,
+                            cpu_counter(),
+                        );
                     }
                     perf::add_task_start(cpu_id, cpu_counter());
 
@@ -526,7 +617,11 @@ pub fn run_main() {
                     let result = guard.poll_unpin(&mut ctx);
 
                     perf::add_task_end(awkernel_lib::cpu::cpu_id(), cpu_counter());
-                    perf::add_yield_context_save_end(awkernel_lib::cpu::cpu_id(), cpu_counter());
+                    perf::add_context_save_end(
+                        perf::ContextSwitchType::Yield,
+                        awkernel_lib::cpu::cpu_id(),
+                        cpu_counter(),
+                    );
 
                     #[cfg(all(
                         any(target_arch = "aarch64", target_arch = "x86_64"),

--- a/awkernel_async_lib/src/task/preempt.rs
+++ b/awkernel_async_lib/src/task/preempt.rs
@@ -1,4 +1,8 @@
 use crate::task::{get_current_task, Task};
+use crate::{
+    cpu_counter,
+    task::perf::{add_context_restore_start, add_context_save_end, ContextSwitchType},
+};
 use alloc::{collections::VecDeque, sync::Arc};
 use array_macro::array;
 use awkernel_lib::{
@@ -70,9 +74,15 @@ fn yield_preempted_and_wake_task(current_task: Arc<Task>, next_thread: PtrWorker
     let next_cpu_ctx = next_thread.get_cpu_context();
 
     unsafe {
+        add_context_save_end(ContextSwitchType::Preempt, cpu_id, cpu_counter());
         // Save the current context.
         context_switch(current_cpu_ctx, next_cpu_ctx);
 
+        add_context_restore_start(
+            ContextSwitchType::Preempt,
+            awkernel_lib::cpu::cpu_id(),
+            cpu_counter(),
+        );
         thread::set_current_context(current_ctx);
     }
 

--- a/awkernel_async_lib/src/yield_task.rs
+++ b/awkernel_async_lib/src/yield_task.rs
@@ -1,6 +1,9 @@
 //! Task yielding.
 
-use crate::{cpu_counter, task::perf::add_yield_context_save_start};
+use crate::{
+    cpu_counter,
+    task::perf::{add_context_save_start, ContextSwitchType},
+};
 use core::task::Poll;
 use futures::Future;
 
@@ -24,7 +27,11 @@ impl Future for Yield {
 
             cx.waker().wake_by_ref();
 
-            add_yield_context_save_start(awkernel_lib::cpu::cpu_id(), cpu_counter());
+            add_context_save_start(
+                ContextSwitchType::Yield,
+                awkernel_lib::cpu::cpu_id(),
+                cpu_counter(),
+            );
             Poll::Pending
         }
     }

--- a/kernel/src/arch/aarch64/exception.rs
+++ b/kernel/src/arch/aarch64/exception.rs
@@ -1,6 +1,9 @@
 use awkernel_async_lib::{
     cpu_counter,
-    task::perf::{add_task_end, add_task_start},
+    task::perf::{
+        add_context_restore_end, add_context_save_start, add_task_end, add_task_start,
+        ContextSwitchType,
+    },
 };
 use awkernel_lib::{
     arch::aarch64::exception_saved_regs::Context, console::unsafe_puts, delay::wait_forever,
@@ -221,7 +224,19 @@ ESR  = 0x{:x}
 #[no_mangle]
 pub extern "C" fn curr_el_spx_irq_el1(_ctx: *mut Context, _sp: usize, _esr: usize) {
     add_task_end(awkernel_lib::cpu::cpu_id(), cpu_counter());
+    add_context_save_start(
+        ContextSwitchType::Preempt,
+        awkernel_lib::cpu::cpu_id(),
+        cpu_counter(),
+    );
+
     interrupt::handle_irqs();
+
+    add_context_restore_end(
+        ContextSwitchType::Preempt,
+        awkernel_lib::cpu::cpu_id(),
+        cpu_counter(),
+    );
     add_task_start(awkernel_lib::cpu::cpu_id(), cpu_counter());
 }
 

--- a/kernel/src/arch/x86_64/interrupt_handler.rs
+++ b/kernel/src/arch/x86_64/interrupt_handler.rs
@@ -1,6 +1,9 @@
 use awkernel_async_lib::{
     cpu_counter,
-    task::perf::{add_task_end, add_task_start},
+    task::perf::{
+        add_context_restore_end, add_context_save_start, add_task_end, add_task_start,
+        ContextSwitchType,
+    },
 };
 use awkernel_lib::delay::wait_forever;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
@@ -514,8 +517,20 @@ irq_handler!(irq254, 254);
 
 extern "x86-interrupt" fn preemption(_stack_frame: InterruptStackFrame) {
     add_task_end(awkernel_lib::cpu::cpu_id(), cpu_counter());
+    add_context_save_start(
+        ContextSwitchType::Preempt,
+        awkernel_lib::cpu::cpu_id(),
+        cpu_counter(),
+    );
+
     awkernel_lib::interrupt::eoi(); // End of interrupt.
     awkernel_lib::interrupt::handle_preemption();
+
+    add_context_restore_end(
+        ContextSwitchType::Preempt,
+        awkernel_lib::cpu::cpu_id(),
+        cpu_counter(),
+    );
     add_task_start(awkernel_lib::cpu::cpu_id(), cpu_counter());
 }
 


### PR DESCRIPTION
Implement a function to measure context overhead during preemption

The mechanism is the same as for yield, with the only difference being the variable that stores the result.
Since the processing is almost the same, the functions are combined into one by branching using enum and match.

save_start：`exception.rs` L227 (aarch64) or `interrupt_handler.rs` L520 (x86_64)
save_end：`preempt.rs`  L77
restore_start：`preempt.rs`  L83
restore_end：`exception.rs` L235 (aarch64) or `interrupt_handler.rs` L529 (x86_64)