### PR TITLE
fix(lib): reset the state when calling `register_waker_for_transmitte…

### DIFF
--- a/awkernel_lib/src/net/if_net.rs
+++ b/awkernel_lib/src/net/if_net.rs
@@ -791,10 +791,13 @@ impl IfNet {
                 *guard = TransmitWakeState::Wake(waker);
                 Ok(true)
             }
-            TransmitWakeState::Notified => Ok(false),
+            TransmitWakeState::Notified => {
+                *guard = TransmitWakeState::None;
+                Ok(false)
+            }
             TransmitWakeState::Wake(_) => {
                 *guard = TransmitWakeState::Wake(waker);
-                Ok(false)
+                Ok(true)
             }
         }
     }


### PR DESCRIPTION
If the stat is `TransmitWakeState::Notified`,
it must be updated to `TransmitWakeState::None`.