### PR TITLE
fix(kernel):fixed to set affinfity

### DIFF
--- a/awkernel_lib/src/arch/aarch64/cpu.rs
+++ b/awkernel_lib/src/arch/aarch64/cpu.rs
@@ -50,10 +50,10 @@ pub unsafe fn set_max_affinity(aff0_max: u64, aff1_max: u64, aff2_max: u64, aff3
     AFF0_X_AFF1_X_AFF2 = aff0_max * aff1_max * aff2_max;
 
     let mut id = 0;
-    for aff3 in 0..aff3_max {
-        for aff2 in 0..aff2_max {
-            for aff1 in 0..aff1_max {
-                for aff0 in 0..aff0_max {
+    for aff3 in 0..=aff3_max {
+        for aff2 in 0..=aff2_max {
+            for aff1 in 0..=aff1_max {
+                for aff0 in 0..=aff0_max {
                     CPU_LIST[id] = Some((aff0 as u8, aff1 as u8, aff2 as u8, aff3 as u8));
                     id += 1;
                 }

--- a/kernel/src/arch/aarch64/bsp/aarch64_virt.rs
+++ b/kernel/src/arch/aarch64/bsp/aarch64_virt.rs
@@ -324,9 +324,9 @@ impl AArch64Virt {
             .find_child("cpu-map")
             .ok_or(err_msg!("could not find cpu-map"))?;
 
-        let mut aff2_max = 1;
-        let mut aff1_max = 1;
-        let mut aff0_max = 1;
+        let mut aff2_max = 0;
+        let mut aff1_max = 0;
+        let mut aff0_max = 0;
         for socket in cpu_map
             .nodes()
             .iter()
@@ -376,7 +376,7 @@ impl AArch64Virt {
             }
         }
 
-        unsafe { set_max_affinity(aff0_max, aff1_max, aff2_max, 1) };
+        unsafe { set_max_affinity(aff0_max, aff1_max, aff2_max, 0) };
 
         Ok(())
     }


### PR DESCRIPTION
The method of setting affinity in `aarch64_virt` was incorrect and has been corrected.
In the original implementation, affinity is set only up to the maximum number of `CPUs -1` due to the way `for` is written.

cpu-map
```
        "cpu-map"
            "socket0"
                "cluster0"
                    "core0"
                        cpu: 0x0000000000008004
                    "core1"
                        cpu: 0x0000000000008003
                    "core2"
                        cpu: 0x0000000000008002
                    "core3"
                        cpu: 0x0000000000008001
```

test code
```
    log::info!("Start test_affinity.");
    if let Some((aff0, aff1, aff2, aff3)) = get_affinity(0 as usize) {
        log::info!("GICv3: CPU0 found with affinity: ({}, {}, {}, {})", aff0, aff1, aff2, aff3);
    } else {
        log::info!("GICv3: CPU0 is not found.");
    }
    if let Some((aff0, aff1, aff2, aff3)) = get_affinity(1 as usize) {
        log::info!("GICv3: CPU1 found with affinity: ({}, {}, {}, {})", aff0, aff1, aff2, aff3);
    } else {
        log::info!("GICv3: CPU1 is not found.");
    }
    if let Some((aff0, aff1, aff2, aff3)) = get_affinity(2 as usize) {
        log::info!("GICv3: CPU2 found with affinity: ({}, {}, {}, {})", aff0, aff1, aff2, aff3);
    } else {
        log::info!("GICv3: CPU2 is not found.");
    }
    if let Some((aff0, aff1, aff2, aff3)) = get_affinity(3 as usize) {
        log::info!("GICv3: CPU3 found with affinity: ({}, {}, {}, {})", aff0, aff1, aff2, aff3);
    } else {
        log::info!("GICv3: CPU3 is not found.");
    }
    if let Some((aff0, aff1, aff2, aff3)) = get_affinity(4 as usize) {
        log::info!("GICv3: CPU4 found with affinity: ({}, {}, {}, {})", aff0, aff1, aff2, aff3);
    } else {
        log::info!("GICv3: CPU4 is not found.");
    }
```


 original implementation (CPU4 is for checking if there is any extra set)
```
    [         4092 INFO] Start test_affinity.
    [         4092 INFO] GICv3: CPU0 found with affinity: (0, 0, 0, 0)
    [         4093 INFO] GICv3: CPU1 found with affinity: (1, 0, 0, 0)
    [         4093 INFO] GICv3: CPU2 found with affinity: (2, 0, 0, 0)
    [         4093 INFO] GICv3: CPU3 is not found.
    [         4093 INFO] GICv3: CPU4 is not found.
```

So, let's add for to a `for a in 0..= a` so that all affinities can be set correctly.

fix implementation (CPU4 is for checking if there is any extra set)
```
[         4090 INFO] Start test_affinity.
[         4090 INFO] GICv3: CPU0 found with affinity: (0, 0, 0, 0)
[         4091 INFO] GICv3: CPU1 found with affinity: (1, 0, 0, 0)
[         4091 INFO] GICv3: CPU2 found with affinity: (2, 0, 0, 0)
[         4091 INFO] GICv3: CPU3 found with affinity: (3, 0, 0, 0)
[         4091 INFO] GICv3: CPU4 is not found.
```



