### PR TITLE
Revert "fix: `Tasks::run()` must push back the future again when it returns `…"

### DIFF
--- a/awkernel_async_lib/src/mini_task.rs
+++ b/awkernel_async_lib/src/mini_task.rs
@@ -54,25 +54,14 @@ impl Tasks {
             let w = waker_ref(&head);
             let mut cx = Context::from_waker(&w);
 
-            let result = {
-                let mut node = MCSNode::new();
-                let mut future = head.future.lock(&mut node);
+            let mut node = MCSNode::new();
+            let mut future = head.future.lock(&mut node);
 
-                if future.is_terminated() {
-                    continue;
-                }
-
-                future.poll_unpin(&mut cx)
-            };
-
-            match result {
-                core::task::Poll::Ready(()) => {}
-                core::task::Poll::Pending => {
-                    let mut node = MCSNode::new();
-                    let mut queue = self.queue.lock(&mut node);
-                    queue.push_back(head);
-                }
+            if future.is_terminated() {
+                continue;
             }
+
+            let _ = future.poll_unpin(&mut cx);
         }
     }
 


### PR DESCRIPTION
Reverts tier4/awkernel#256