### PR TITLE
fix(std_common): handle NUM_READY_WORKER correctly

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -133,13 +133,16 @@ fn main<Info: Debug>(kernel_info: KernelInfo<Info>) {
         }
     }
 
-    if let Err(_) = NUM_READY_WORKER.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| {
-        if x > 0 {
-            Some(x - 1)
-        } else {
-            None
-        }
-    }) {
+    if NUM_READY_WORKER
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| {
+            if x > 0 {
+                Some(x - 1)
+            } else {
+                None
+            }
+        })
+        .is_err()
+    {
         panic!(
             "NUM_READY_WORKER is already zero: num_cpu() must have returned incorrect CPU number"
         );


### PR DESCRIPTION
## Description
The following three points were fixed in kernel/src/main.rs because the shell would not start when executing std_common with make run-std:
1. num_cpu() is only available after each CPU has called increment_num_cpu(). If we don't wait for all CPUs to increment, NUM_READY_WORKER underflows and the following while loop never terminates. 

```
while NUM_READY_WORKER.load(Ordering::SeqCst) > 0 {
    awkernel_lib::delay::wait_microsec(10);
}
```

I added wait_microsec(100) before num_cpu() to avoid this. Ideally, we'd reference the CPU count obtained in each kernel/src/arch/ARCH/kernel_main.rs, but since this would require significant changes, I've decided not to include it in this PR.

2. Non-primary CPUs should only decrement NUM_READY_WORKER after PRIMARY_READY becomes true in std-common, as it is in other architectures. Therefore, I modified std_common to also check that PRIMARY_READY is TRUE before decrementing.

3. Replaced fetch_sub with fetch_update to prevent underflow when num_cpu is less than the actual number of CPU. Added a panic when NUM_READY_WORKER can't be decremented (already 0) as this indicates an unexpected state.

## Related links

## How was this PR tested?
Verified that the shell correctly enters the wait state by executing 'make run-std RELEASE=1' more than 10 times

## Notes for reviewers
