### PR TITLE
fix(x86_64): raw_cpu_id() for x86_64

### DIFF
--- a/awkernel_lib/src/arch/x86_64/cpu.rs
+++ b/awkernel_lib/src/arch/x86_64/cpu.rs
@@ -38,12 +38,15 @@ impl CPU for super::X86 {
         if (cpuid_leaf_1.ecx & (1 << 21)) != 0 {
             // Get x2APIC ID from leaf 1FH or leaf 0BH (1FH is preferred)
             let max_leaf = unsafe { core::arch::x86_64::__cpuid(0) }.eax;
-            let edx = if max_leaf >= 0x1F {
-                unsafe { core::arch::x86_64::__cpuid(0x1F).edx }
-            } else {
-                unsafe { core::arch::x86_64::__cpuid(0x0B).edx }
-            };
-            edx as usize
+            if max_leaf >= 0x1F {
+                let leaf_1f = unsafe { core::arch::x86_64::__cpuid(0x1F) };
+                // Check if ecx has a valid value
+                if (leaf_1f.ecx >> 8) != 0 {
+                    return leaf_1f.edx as usize;
+                }
+            }
+
+            unsafe { core::arch::x86_64::__cpuid(0x0B).edx as usize }
         } else {
             (cpuid_leaf_1.ebx >> 24 & 0xff) as usize
         }


### PR DESCRIPTION
## Description
A case was identified where retrieving leaf 0x1f returned invalid values (eax, ebx, ecx, edx are all 0) even though max_leaf was 0x1f. This occurred on an Intel(R) Core(TM) i9-14900K running Linux kernel 6.5.0-44-generic kvm. Following guidance from Intel's Software Developer's Manual (Order Number: 253665-086US December 2024), I modified the implementation to use leaf 0x0b also in the cases where the upper 8 bits of ecx are invalid.

> If sub-leaf index “N” returns an invalid domain type in ECX[15:08] (00H), then all sub-leaves with an
> index greater than “N” shall also return an invalid domain type. A sub-leaf returning an invalid domain
> always returns 0 in EAX and EBX.
> 

## Related links
[Intel's Software Developer's Manual](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## How was this PR tested?
On the following environment.

> Intel(R) Core(TM) i9-14900K (kvm)
> Intel(R) Core(TM) i7-10750H (kvm)
> 12th Gen Intel(R) Core(TM) i7-12700
> 

## Notes for reviewers
