### PR TITLE
fix(ixgbe): handle IXGBE_DEV_ID_82598AT_DUAL_PORT

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_hw.rs
@@ -94,6 +94,7 @@ pub fn get_mac_type(device: u16) -> Result<MacType, IxgbeDriverErr> {
         | IXGBE_DEV_ID_82598AF_DUAL_PORT
         | IXGBE_DEV_ID_82598AT
         | IXGBE_DEV_ID_82598AT2
+        | IXGBE_DEV_ID_82598AT_DUAL_PORT
         | IXGBE_DEV_ID_82598EB_CX4
         | IXGBE_DEV_ID_82598_CX4_DUAL_PORT
         | IXGBE_DEV_ID_82598_DA_DUAL_PORT

--- a/awkernel_lib/src/net/if_net.rs
+++ b/awkernel_lib/src/net/if_net.rs
@@ -117,9 +117,9 @@ impl Device for NetDriverRef<'_> {
         //     cap.checksum.udp = Checksum::Rx;
         // }
 
-        if capabilities.contains(NetCapabilities::CSUM_UDPv4) {
-            cap.checksum.udp = Checksum::Rx;
-        }
+        // if capabilities.contains(NetCapabilities::CSUM_UDPv4) {
+        //     cap.checksum.udp = Checksum::Rx;
+        // }
 
         cap
     }

--- a/scripts/udp.py
+++ b/scripts/udp.py
@@ -3,7 +3,8 @@ import sys
 
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-addr = ('localhost', 26099)
+#addr = ('localhost', 26099)
+addr = ('192.168.100.1', 26099)
 #addr = ('10.0.2.2', 26099)
 print('listening on %s port %s' % addr, file=sys.stderr)
 sock.bind(addr)

--- a/userland/Cargo.toml
+++ b/userland/Cargo.toml
@@ -67,7 +67,7 @@ path = "../applications/tests/test_sched_preempt"
 optional = true
 
 [features]
-default = ["test_sched_preempt"]
+default = ["test_network"]
 perf = ["awkernel_services/perf"]
 
 # Test applications


### PR DESCRIPTION
## Description

`IXGBE_DEV_ID_82598AT_DUAL_PORT` is not handled in `get_mac_type` function.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe.c#L4230

## How was this PR tested?

## Notes for reviewers
