### PR TITLE
fix(ixgbe): handle IXGBE_DEV_ID_82598AT_DUAL_PORT

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_hw.rs
@@ -94,6 +94,7 @@ pub fn get_mac_type(device: u16) -> Result<MacType, IxgbeDriverErr> {
         | IXGBE_DEV_ID_82598AF_DUAL_PORT
         | IXGBE_DEV_ID_82598AT
         | IXGBE_DEV_ID_82598AT2
+        | IXGBE_DEV_ID_82598AT_DUAL_PORT
         | IXGBE_DEV_ID_82598EB_CX4
         | IXGBE_DEV_ID_82598_CX4_DUAL_PORT
         | IXGBE_DEV_ID_82598_DA_DUAL_PORT


### PR DESCRIPTION
## Description

`IXGBE_DEV_ID_82598AT_DUAL_PORT` is not handled in `get_mac_type` function.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe.c#L4230

## How was this PR tested?

## Notes for reviewers
