### PR TITLE
fix(ixgbe): `IxgbeMacX550EMX` should use `IXGBE_.*_X550EM_X`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_regs.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_regs.rs
@@ -4108,10 +4108,11 @@ pub fn get_fla_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let fla = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_FLA,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_FLA_X540,
-        IxgbeMacX550 | IxgbeMacX550Vf | IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_FLA_X540,
+        IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_FLA_X550,
+        IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_FLA_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_FLA_X550EM_A,
+        _ => IXGBE_FLA,
     };
 
     Ok(fla)
@@ -4121,10 +4122,11 @@ pub fn get_grc_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let grc = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_GRC,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_GRC_X540,
-        IxgbeMacX550 | IxgbeMacX550Vf | IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_GRC_X550,
+        IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_GRC_X550,
+        IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_GRC_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_GRC_X550EM_A,
+        _ => IXGBE_GRC,
     };
 
     Ok(grc)
@@ -4134,10 +4136,11 @@ pub fn get_sramrel_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let sramrel = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_SRAMREL,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_SRAMREL_X540,
-        IxgbeMacX550 | IxgbeMacX550Vf | IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_SRAMREL_X550,
+        IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_SRAMREL_X550,
+        IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_SRAMREL_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_SRAMREL_X550EM_A,
+        _ => IXGBE_SRAMREL,
     };
 
     Ok(sramrel)
@@ -4147,11 +4150,11 @@ pub fn get_factps_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let factps = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_FACTPS,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_FACTPS_X540,
         IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_FACTPS_X550,
         IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_FACTPS_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_FACTPS_X550EM_A,
+        _ => IXGBE_FACTPS,
     };
 
     Ok(factps)
@@ -4161,11 +4164,11 @@ pub fn get_swsm_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let swsm = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_SWSM,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_SWSM_X540,
         IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_SWSM_X550,
         IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_SWSM_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_SWSM_X550EM_A,
+        _ => IXGBE_SWSM,
     };
 
     Ok(swsm)
@@ -4175,11 +4178,11 @@ pub fn get_fwsm_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let fwsm = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_FWSM,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_FWSM_X540,
         IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_FWSM_X550,
         IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_FWSM_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_FWSM_X550EM_A,
+        _ => IXGBE_FWSM,
     };
 
     Ok(fwsm)
@@ -4189,11 +4192,11 @@ pub fn get_swfw_sync_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let swfw_sync = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_SWFW_SYNC,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_SWFW_SYNC_X540,
         IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_SWFW_SYNC_X550,
         IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_SWFW_SYNC_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_SWFW_SYNC_X550EM_A,
+        _ => IXGBE_SWFW_SYNC,
     };
 
     Ok(swfw_sync)
@@ -4203,11 +4206,11 @@ pub fn get_ciaa_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let ciaa = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_CIAA_82599,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_CIAA_X540,
         IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_CIAA_X550,
         IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_CIAA_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_CIAA_X550EM_A,
+        _ => IXGBE_CIAA,
     };
 
     Ok(ciaa)
@@ -4217,11 +4220,11 @@ pub fn get_ciad_offset(device: u16) -> Result<usize, IxgbeDriverErr> {
     use MacType::*;
 
     let ciad = match get_mac_type(device)? {
-        IxgbeMac82598EB | IxgbeMac82599EB | IxgbeMac82599Vf => IXGBE_CIAD_82599,
         IxgbeMacX540 | IxgbeMacX540Vf => IXGBE_CIAD_X540,
         IxgbeMacX550 | IxgbeMacX550Vf => IXGBE_CIAD_X550,
         IxgbeMacX550EMX | IxgbeMacX550EMXVf => IXGBE_CIAD_X550EM_X,
         IxgbeMacX550EMA | IxgbeMacX550EMAVf => IXGBE_CIAD_X550EM_A,
+        _ => IXGBE_CIAD,
     };
 
     Ok(ciad)


### PR DESCRIPTION
## Description

`IxgbeMacX550EMX` should use `IXGBE_.*_X550EM_X` registers.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe.c#L4275

## How was this PR tested?

## Notes for reviewers
