### PR TITLE
fix(ixgbe): multiple init of `IXGBE_CTRL_EXT_DRV_LOAD`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_hw.rs
@@ -268,11 +268,6 @@ impl IxgbeHw {
 
         // TODO: sc->mta = mallocarray() : Allocate multicast array memory -> IxgbeInner new()?
 
-        // let hardware know driver is loaded
-        let mut ctrl_ext = read_reg(info, IXGBE_CTRL_EXT)?;
-        ctrl_ext |= IXGBE_CTRL_EXT_DRV_LOAD;
-        write_reg(info, IXGBE_CTRL_EXT, ctrl_ext)?;
-
         let ops = get_operations(&mac_type)?; // init_shared_code();
         let (
             mcft_size,


### PR DESCRIPTION
## Description

`IXGBE_CTRL_EXT_DRV_LOAD` of `IXGBE_CTRL_EXT` should be set after setting up the device driver once.
Currently, the flag is set up before the driver initialization.
Additionally, it is set up after the driver initialization as follows.

https://github.com/tier4/awkernel/blob/00185fa42294551e8826760443ed95491fb19c22/awkernel_drivers/src/pcie/intel/ixgbe.rs#L387-L390

This PR removes the first set up of `IXGBE_CTRL_EXT_DRV_LOAD`.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/if_ix.c#L337-L340

## How was this PR tested?

## Notes for reviewers
