### PR TITLE
fix(ixgbe): invalid memory access of `IXGBE_FWSM`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_82599.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_82599.rs
@@ -1265,11 +1265,8 @@ impl IxgbeOperations for Ixgbe82599 {
 pub fn set_mac_val(
     info: &PCIeInfo,
 ) -> Result<(u32, u32, u32, u32, u32, u32, u16, bool), IxgbeDriverErr> {
-    let arc_subsystem_valid =
-        match ixgbe_hw::read_reg(info, IXGBE_FWSM_X540 & IXGBE_FWSM_MODE_MASK as usize) {
-            Ok(val) => val != 0,
-            Err(e) => return Err(e),
-        };
+    let fwsm_offset = get_fwsm_offset(info.get_id())?;
+    let arc_subsystem_valid = (ixgbe_hw::read_reg(info, fwsm_offset)? & IXGBE_FWSM_MODE_MASK) != 0;
 
     Ok((
         IXGBE_82599_MC_TBL_SIZE,


### PR DESCRIPTION
## Description

`IXGBE_FWSM` register must read from `get_fwsm_offset(info.get_id())`,
but `IXGBE_FWSM_X540 & IXGBE_FWSM_MODE_MASK` is used as the memory offset.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe_82599.c#L414

## How was this PR tested?

## Notes for reviewers
