### PR TITLE
fix(ixgbe): invalid memory access of `IXGBE_FWSM` on X540 and x550

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_x540.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_x540.rs
@@ -565,11 +565,8 @@ impl IxgbeOperations for IxgbeX540 {
 pub fn set_mac_val(
     info: &PCIeInfo,
 ) -> Result<(u32, u32, u32, u32, u32, u32, u16, bool), IxgbeDriverErr> {
-    let arc_subsystem_valid =
-        match ixgbe_hw::read_reg(info, IXGBE_FWSM_X540 & IXGBE_FWSM_MODE_MASK as usize) {
-            Ok(val) => val != 0,
-            Err(e) => return Err(e),
-        };
+    let fwsm_offset = get_fwsm_offset(info.get_id())?;
+    let arc_subsystem_valid = (ixgbe_hw::read_reg(info, fwsm_offset)? & IXGBE_FWSM_MODE_MASK) != 0;
 
     Ok((
         IXGBE_X540_MC_TBL_SIZE,

--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_x550.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_x550.rs
@@ -439,11 +439,8 @@ impl IxgbeOperations for IxgbeX550 {
 pub fn set_mac_val(
     info: &PCIeInfo,
 ) -> Result<(u32, u32, u32, u32, u32, u32, u16, bool), IxgbeDriverErr> {
-    let arc_subsystem_valid =
-        match ixgbe_hw::read_reg(info, IXGBE_FWSM_X540 & IXGBE_FWSM_MODE_MASK as usize) {
-            Ok(val) => val != 0,
-            Err(e) => return Err(e),
-        };
+    let fwsm_offset = get_fwsm_offset(info.get_id())?;
+    let arc_subsystem_valid = (ixgbe_hw::read_reg(info, fwsm_offset)? & IXGBE_FWSM_MODE_MASK) != 0;
 
     Ok((
         IXGBE_X540_MC_TBL_SIZE,


### PR DESCRIPTION
## Description

`IXGBE_FWSM` register must read from `get_fwsm_offset(info.get_id())`,
but `IXGBE_FWSM_X540` & `IXGBE_FWSM_MODE_MASK` is used as the memory offset.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe_x540.c#L152

## How was this PR tested?

## Notes for reviewers
