### PR TITLE
fix(ixgbe): `stopped_i` never becomes `IXGBE_EERD_EEWR_ATTEMPTS`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -2339,7 +2339,7 @@ fn poll_eerd_eewr_done(info: &PCIeInfo, ee_reg: u32) -> Result<(), IxgbeDriverEr
     }
 
     log::error!("EEPROM read/write done polling timed out");
-    return Err(Eeprom);
+    Err(Eeprom)
 }
 
 pub fn read_eerd_buffer_generic<T: IxgbeOperations + ?Sized>(


### PR DESCRIPTION
## Description

`if stopped_i == IXGBE_EERD_EEWR_ATTEMPTS` never becomes true.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe.c#L1324

## How was this PR tested?

## Notes for reviewers
