### PR TITLE
fix(ixgbe): if condition is always true

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -2644,7 +2644,7 @@ fn get_eeprom_semaphore(info: &PCIeInfo) -> Result<(), IxgbeDriverErr> {
     while i < timeout {
         // If the SMBI bit is 0 when we read it, then the bit will be set and we have the semaphore
         swsm = ixgbe_hw::read_reg(info, swsm_offset)?;
-        if !(swsm & IXGBE_SWSM_SMBI) != 0 {
+        if swsm & IXGBE_SWSM_SMBI == 0 {
             status = Ok(());
             break;
         }
@@ -2659,7 +2659,7 @@ fn get_eeprom_semaphore(info: &PCIeInfo) -> Result<(), IxgbeDriverErr> {
 
         // one last try
         swsm = ixgbe_hw::read_reg(info, swsm_offset)?;
-        if !(swsm & IXGBE_SWSM_SMBI) != 0 {
+        if swsm & IXGBE_SWSM_SMBI == 0 {
             status = Ok(());
         }
     }


### PR DESCRIPTION
## Description

`!x` in C is a syntax to check whether `x` is zero or not,
but `!x` in Rust is a syntax for bitwise inversion of `x`.

Therefore, `!(swsm & IXGBE_SWSM_SMBI) != 0` always becomes true.

## Related links

https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe.c#L1409
https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/ixgbe.c#L1434

## How was this PR tested?

## Notes for reviewers
