### PR TITLE
fix(ixgbe): `reg` must be the value of `IXGBE_PCS1GANA`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -3477,7 +3477,11 @@ pub trait IxgbeOperations: Send {
             IxgbeMediaTypeBackplane =>
             // some MAC's need RMW protection on AUTOC
             {
-                (0, self.mac_prot_autoc_read(info)?, 0)
+                (
+                    ixgbe_hw::read_reg(info, IXGBE_PCS1GANA)?,
+                    self.mac_prot_autoc_read(info)?,
+                    0,
+                )
             }
             // only backplane uses autoc so fall though
             IxgbeMediaTypeFiberFixed | IxgbeMediaTypeFiberQsfp | IxgbeMediaTypeFiber => {


### PR DESCRIPTION
## Description

`reg` must be the value of `IXGBE_PCS1GANA`.

There is no `break` statement in the switch-case of OpenBSD.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe.c#L308-L312

## How was this PR tested?

## Notes for reviewers
