### PR TITLE
fix(ixgbe): negate `IXGBE_AUTOC_SYM_PAUSE`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -3525,7 +3525,7 @@ pub trait IxgbeOperations: Send {
 		        reg &= !IXGBE_PCS1GANA_SYM_PAUSE;
 		        match hw.phy.media_type {
                 IxgbeMediaTypeBackplane =>
-			        (reg, (reg_bp | IXGBE_AUTOC_ASM_PAUSE) & IXGBE_AUTOC_SYM_PAUSE, reg_cu),
+			        (reg, (reg_bp | IXGBE_AUTOC_ASM_PAUSE) & !IXGBE_AUTOC_SYM_PAUSE, reg_cu),
 		        IxgbeMediaTypeCopper =>
 			        (reg, reg_bp, (reg_cu | IXGBE_TAF_ASM_PAUSE) & !IXGBE_TAF_SYM_PAUSE),
                 _ => (reg, reg_bp, reg_cu),


### PR DESCRIPTION
## Description

`IXGBE_AUTOC_SYM_PAUSE` must be negated.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe.c#L352

## How was this PR tested?

## Notes for reviewers
