### PR TITLE
fix(ixgbe): Should wait 100 millisec

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -626,7 +626,7 @@ pub fn enable_tx_laser_multispeed_fiber(info: &PCIeInfo) -> Result<(), IxgbeDriv
     esdp_reg &= !IXGBE_ESDP_SDP3;
     ixgbe_hw::write_reg(info, IXGBE_ESDP, esdp_reg)?;
     ixgbe_hw::write_flush(info)?;
-    wait_microsec(100);
+    wait_millisec(100);
 
     Ok(())
 }


### PR DESCRIPTION
## Description
Should wait 100 millisec, not 100 microsec.

## Related links
https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe_82599.c#L728

## How was this PR tested?

## Notes for reviewers
