### PR TITLE
fix(ixgbe): should take upper 16bits of LINK_STATUS register

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -3955,7 +3955,7 @@ pub trait IxgbeOperations: Send {
             return Err(NotPciExpress);
         };
         let val = cap.get_link_status_control();
-        let link_status = (val.bits() & 0xFFFF) as u16;
+        let link_status = (val.bits() >> 16) as u16;
 
         set_pci_config_data(self, info, hw, link_status)
     }


### PR DESCRIPTION
## Description
We should take upper 16bits of LINK_STATUS register, not the lower 16bits.

## Related links
https://www.intel.com/content/www/us/en/docs/programmable/683686/20-4/pci-express-capability-structure.html

## How was this PR tested?

## Notes for reviewers
