### PR TITLE
fix(ixgbe): invalid loop condition

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -3688,7 +3688,7 @@ pub trait IxgbeOperations: Send {
 
         // Configure pause time (2 TCs per register)
         let reg = hw.fc.pause_time as u32 * 0x00010001;
-        for i in 0..IXGBE_DCB_MAX_TRAFFIC_CLASS {
+        for i in 0..IXGBE_DCB_MAX_TRAFFIC_CLASS / 2 {
             ixgbe_hw::write_reg(info, IXGBE_FCTTV(i), reg)?;
         }
 


### PR DESCRIPTION
## Description

`0..IXGBE_DCB_MAX_TRAFFIC_CLASS / 2` must be used at the loop condition instead of `0..IXGBE_DCB_MAX_TRAFFIC_CLASS`.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe.c#L2381

## How was this PR tested?

## Notes for reviewers
