### PR TITLE
fix(ixgbe): wait 2ms instead of 2us

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_x540.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_x540.rs
@@ -315,7 +315,7 @@ pub fn mac_release_swfw_sync_x540(info: &PCIeInfo, mask: u32) -> Result<(), Ixgb
     ixgbe_hw::write_reg(info, swfw_sync_offset, swfw_sync)?;
 
     release_swfw_sync_semaphore(info)?;
-    wait_microsec(2);
+    wait_millisec(2);
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Wait 2ms.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe_x540.c#L804

## How was this PR tested?

## Notes for reviewers
