### PR TITLE
refactor(ixgbe): refactored `read_i2c_byte_generic_int`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -5,7 +5,6 @@ use super::{
 };
 use crate::pcie::{capability::pcie_cap::PCIeCap, PCIeInfo};
 use awkernel_lib::delay::{wait_microsec, wait_millisec};
-use embedded_hal::i2c;
 use ixgbe_hw::{EepromType, IxgbeHw, MacType, MediaType, PhyType, SfpType};
 
 /// clear_tx_pending - Clear pending TX work from the PCIe fifo


### PR DESCRIPTION
## Description

Refactored `read_i2c_byte_generic_int`.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe_phy.c#L2048

## How was this PR tested?

## Notes for reviewers
