### PR TITLE
fix(ixgbe): enable Tx if the media type is fiber

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -354,6 +354,7 @@ impl IxgbeInner {
 
         if hw.mac.mac_type == MacType::IxgbeMac82599EB
             && ops.mac_get_media_type(&info, &mut hw) == MediaType::IxgbeMediaTypeFiber
+            && !mng_enabled(&info, &hw)?
         {
             enable_tx_laser_multispeed_fiber(&info)?;
         }


### PR DESCRIPTION
## Description

`enable_tx_laser_multispeed_fiber` must be called only if
the media type is fiber and `mng_enabled` returns false.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe_82599.c#L107-L108

## How was this PR tested?

## Notes for reviewers
