### PR TITLE
fix(ixgbe): must be `IxgbeMac82598EB` istead of `IxgbeMac82599EB`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -725,7 +725,7 @@ impl IxgbeInner {
             txctrl &= !(IXGBE_DCA_TXCTRL_DESC_WRO_EN);
 
             match self.hw.mac.mac_type {
-                IxgbeMac82599EB => {
+                IxgbeMac82598EB => {
                     ixgbe_hw::write_reg(&self.info, IXGBE_DCA_TXCTRL(que.me), txctrl)?
                 }
                 _ => ixgbe_hw::write_reg(&self.info, IXGBE_DCA_TXCTRL_82599(que.me), txctrl)?,


### PR DESCRIPTION
## Description

The mach condition must be `IxgbeMac82598EB`.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/if_ix.c#L2392

## How was this PR tested?

## Notes for reviewers
