### PR TITLE
fix(ixgbe): add `mac_enable_tx_laser` method

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -40,7 +40,7 @@ use awkernel_lib::{
     },
 };
 use core::fmt::{self, Debug};
-use ixgbe_operations::{enable_tx_laser_multispeed_fiber, mng_enabled};
+use ixgbe_operations::mng_enabled;
 use memoffset::offset_of;
 use rand::rngs::SmallRng;
 use rand::Rng;
@@ -351,14 +351,7 @@ impl IxgbeInner {
         };
 
         ops.mac_init_hw(&mut info, &mut hw)?;
-
-        if hw.mac.mac_type == MacType::IxgbeMac82599EB
-            && ops.mac_get_media_type(&info, &mut hw) == MediaType::IxgbeMediaTypeFiber
-            && !mng_enabled(&info, &hw)?
-        {
-            enable_tx_laser_multispeed_fiber(&info)?;
-        }
-
+        ops.mac_enable_tx_laser(&info, &mut hw)?;
         ops.phy_set_power(&info, &hw, true)?;
 
         // setup interface
@@ -1146,7 +1139,7 @@ impl IxgbeInner {
         if self.is_sfp() {
             if self.hw.phy.multispeed_fiber {
                 self.ops.mac_setup_sfp(&self.info, &mut self.hw)?;
-                enable_tx_laser_multispeed_fiber(&self.info)?;
+                self.ops.mac_enable_tx_laser(&self.info, &mut self.hw)?;
                 self.handle_msf()?;
             } else {
                 self.handle_mod()?;

--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_82599.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_82599.rs
@@ -1,6 +1,6 @@
 use super::{
     ixgbe_hw,
-    ixgbe_operations::{self, start_hw_gen2, start_hw_generic, IxgbeOperations},
+    ixgbe_operations::{self, mng_enabled, start_hw_gen2, start_hw_generic, IxgbeOperations},
     ixgbe_regs::*,
     IxgbeDriverErr,
 };
@@ -1254,6 +1254,16 @@ impl IxgbeOperations for Ixgbe82599 {
             ixgbe_operations::read_eerd_buffer_generic(self, info, eeprom, offset, 1, data)
         } else {
             ixgbe_operations::read_eeprom_bit_bang_generic(self, info, eeprom, offset, data)
+        }
+    }
+
+    fn mac_enable_tx_laser(&self, info: &PCIeInfo, hw: &mut IxgbeHw) -> Result<(), IxgbeDriverErr> {
+        if self.mac_get_media_type(info, hw) == MediaType::IxgbeMediaTypeFiber
+            && !mng_enabled(info, hw)?
+        {
+            ixgbe_operations::enable_tx_laser_multispeed_fiber(info)
+        } else {
+            Ok(())
         }
     }
 }

--- a/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe/ixgbe_operations.rs
@@ -4358,4 +4358,12 @@ pub trait IxgbeOperations: Send {
 
         Ok(checksum)
     }
+
+    fn mac_enable_tx_laser(
+        &self,
+        _info: &PCIeInfo,
+        _hw: &mut IxgbeHw,
+    ) -> Result<(), IxgbeDriverErr> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Description

Add `mac_enable_tx_laser` method, and call it instead of `enable_tx_laser_multispeed_fiber`.
`enable_tx_laser_multispeed_fiber` must be called when `ixgbe_operations::mng_enabled` returns false,
but it was ignored.

## Related links

https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/ixgbe_82599.c#L107-L119
https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/if_ix.c#L322
https://github.com/openbsd/src/blob/b83f5574c0e515623aefa0e77b902fdf6ae24985/sys/dev/pci/if_ix.c#L2031

## How was this PR tested?

## Notes for reviewers
