### PR TITLE
fix(ixgbe): write to srrctl register

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -799,7 +799,7 @@ impl IxgbeInner {
         hlreg |= IXGBE_HLREG0_RXCRCSTRP;
         ixgbe_hw::write_reg(&self.info, IXGBE_HLREG0, hlreg)?;
 
-        let bufsz = MCLBYTES >> IXGBE_SRRCTL_BSIZEHDRSIZE_SHIFT;
+        let bufsz = MCLBYTES >> IXGBE_SRRCTL_BSIZEPKT_SHIFT;
         for que in que.iter() {
             let mut node = MCSNode::new();
             let rx = que.rx.lock(&mut node);


### PR DESCRIPTION
## Description
Receive buffer size has to be written in SRRCTL.IXGBE_SRRCTL_BSIZEPKT_SHIFT not SRRCTL.IXGBE_SRRCTL_BSIZEHDR_SHIFT

## Related links
https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/if_ix.c#L2928

## How was this PR tested?

## Notes for reviewers
