### PR TITLE
fix(ixgbe): use RSS independent of interruption type

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -841,9 +841,7 @@ impl IxgbeInner {
         let mut rxcsum = ixgbe_hw::read_reg(&self.info, IXGBE_RXCSUM)?;
         rxcsum &= !IXGBE_RXCSUM_PCSD;
 
-        if let PCIeInt::MsiX(_) = self.pcie_int {
-            self.initialize_rss_mapping()?;
-        }
+        self.initialize_rss_mapping()?;
 
         // Setup RSS
         let que_num = get_num_queues(&self.hw.mac.mac_type);


### PR DESCRIPTION
## Description
RSS and MSIx are closely related, but RSS itself is independent from interruption type, such as MSIX, MSI, pin-interrupt, etc.

## Related links
https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/if_ix.c#L2973

## How was this PR tested?

## Notes for reviewers
