### PR TITLE
fix(ixgbe): need to wait for 1 millisec not 1 microsec

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -16,7 +16,7 @@ use alloc::{
 use awkernel_async_lib_verified::ringq::RingQ;
 use awkernel_lib::{
     addr::Addr,
-    delay::{wait_microsec, wait_millisec},
+    delay::wait_millisec,
     dma_pool::DMAPool,
     interrupt::IRQ,
     net::{


### PR DESCRIPTION
## Description
We need to wait for 1 milli second not 1 micro second.

## Related links
https://github.com/openbsd/src/blob/8a8057a73cb1964915a1105b223ec749e2c82eb7/sys/dev/pci/if_ix.c#L825

## How was this PR tested?

## Notes for reviewers
