### PR TITLE
fix(preempt): fix timing of need_preemption flag reset to prevent unintended preemption

### DIFF
--- a/awkernel_async_lib/src/scheduler/fifo.rs
+++ b/awkernel_async_lib/src/scheduler/fifo.rs
@@ -47,6 +47,9 @@ impl Scheduler for FIFOScheduler {
                     continue;
                 }
 
+                if task_info.state == State::Preempted {
+                    task_info.need_preemption = false;
+                }
                 task_info.state = State::Running;
             }
 

--- a/awkernel_async_lib/src/scheduler/gedf.rs
+++ b/awkernel_async_lib/src/scheduler/gedf.rs
@@ -109,6 +109,9 @@ impl Scheduler for GEDFScheduler {
                     continue;
                 }
 
+                if task_info.state == State::Preempted {
+                    task_info.need_preemption = false;
+                }
                 task_info.state = State::Running;
             }
 

--- a/awkernel_async_lib/src/scheduler/panicked.rs
+++ b/awkernel_async_lib/src/scheduler/panicked.rs
@@ -61,6 +61,9 @@ impl Scheduler for PanickedScheduler {
                     continue;
                 }
 
+                if task_info.state == State::Preempted {
+                    task_info.need_preemption = false;
+                }
                 task_info.state = State::Running;
             }
 

--- a/awkernel_async_lib/src/scheduler/prioritized_fifo.rs
+++ b/awkernel_async_lib/src/scheduler/prioritized_fifo.rs
@@ -89,6 +89,9 @@ impl Scheduler for PrioritizedFIFOScheduler {
                     continue;
                 }
 
+                if task_info.state == State::Preempted {
+                    task_info.need_preemption = false;
+                }
                 task_info.state = State::Running;
             }
 

--- a/awkernel_async_lib/src/scheduler/priority_based_rr.rs
+++ b/awkernel_async_lib/src/scheduler/priority_based_rr.rs
@@ -70,6 +70,9 @@ impl Scheduler for PriorityBasedRRScheduler {
                     continue;
                 }
 
+                if task_info.state == State::Preempted {
+                    task_info.need_preemption = false;
+                }
                 task_info.state = State::Running;
             }
 

--- a/awkernel_async_lib/src/scheduler/rr.rs
+++ b/awkernel_async_lib/src/scheduler/rr.rs
@@ -41,6 +41,9 @@ impl Scheduler for RRScheduler {
                     continue;
                 }
 
+                if task_info.state == State::Preempted {
+                    task_info.need_preemption = false;
+                }
                 task_info.state = State::Running;
             }
 

--- a/awkernel_async_lib/src/task.rs
+++ b/awkernel_async_lib/src/task.rs
@@ -117,7 +117,7 @@ pub struct TaskInfo {
     last_executed_time: awkernel_lib::time::Time,
     absolute_deadline: Option<u64>,
     need_sched: bool,
-    need_preemption: bool,
+    pub(crate) need_preemption: bool,
     panicked: bool,
 
     #[cfg(not(feature = "no_preempt"))]

--- a/awkernel_async_lib/src/task/preempt.rs
+++ b/awkernel_async_lib/src/task/preempt.rs
@@ -192,11 +192,9 @@ unsafe fn do_preemption() {
         let task = tasks.id_to_task.get(&task_id.0).unwrap();
 
         let mut node = MCSNode::new();
-        let mut info = task.info.lock(&mut node);
+        let info = task.info.lock(&mut node);
         if !info.need_preemption {
             return;
-        } else {
-            info.need_preemption = false;
         }
     }
 


### PR DESCRIPTION
The following execution sequence can occur, where the arguments represent the values of `need_sched` and `need_preemption`, respectively:
```
cpu_id: 1| Running(false,true)    ― PreemptionStart   → Running(false,false)
cpu_id: 1| Running(false,false)   ― SetPreempted      → Preempted(false,false)
cpu_id: 1| Preempted(false,false) ― GetNext           → Running(false,false)
cpu_id: 0| Running(false,false)   ― SetNeedPreemption → Running(false,true)
cpu_id: 1| Running(false,true)    ― PreemptionStart   → Running(false,false)
cpu_id: 0| Running(false,true)    ― SetNeedPreemption → Running(false,true)
cpu_id: 1| Running(false,true)    ― SetPreempted      → Preempted(false,true)
```

The current code assumes that `need_preemption` flag of preempted tasks is always `false`. However, if the execution of the call to `set_need_preemption()` is slightly delayed and occurs after preemption has started, the `need_preemption` flag will be true even though the task is already preempted. Consequently, the preempted task will be preempted again after entering the Running state immediately. I found this bug using the runtime verification technique; that is, this execution sequence does occur in practice.

This pull request fixes this bug by modifying the timing of when the `need_preemption` flag is reset. In this modified code, the flag is reset  in `get_next()` implemented in each scheduler, right before the state transitions to `State::Running`, but only if the task was in `State::Preempted`.

After this modification, the `need_preemption` flag of preempted tasks is always true. Therefore, even if `set_need_preemption()` is called after preemption has started, it does not affect the already preempted task.

I have verified once again using runtime verification that this modification fixes the above bug. The model for the verification, which is called monitor in runtime verification, is as follows:
![state-machine](https://github.com/user-attachments/assets/c7195a25-3ba0-4c87-a007-59f0bb73e495)