### PR TITLE
chore(igb, ixgbe): disable checksum capabilities temporary

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igb.rs
+++ b/awkernel_drivers/src/pcie/intel/igb.rs
@@ -487,16 +487,19 @@ impl IgbInner {
         let flags = NetFlags::BROADCAST | NetFlags::SIMPLEX | NetFlags::MULTICAST;
         let mut capabilities = NetCapabilities::VLAN_MTU | NetCapabilities::VLAN_HWTAGGING;
 
-        if hw.get_mac_type() as u32 >= MacType::Em82543 as u32 {
-            capabilities |= NetCapabilities::CSUM_TCPv4 | NetCapabilities::CSUM_UDPv4;
-        }
+        // TODO: enable checksum offload
+        // if hw.get_mac_type() as u32 >= MacType::Em82543 as u32 {
+        //     capabilities |= NetCapabilities::CSUM_TCPv4 | NetCapabilities::CSUM_UDPv4;
+        // }
 
         if MacType::Em82575 as u32 <= hw.get_mac_type() as u32
             && hw.get_mac_type() as u32 <= MacType::EmI210 as u32
         {
-            capabilities |= NetCapabilities::CSUM_IPv4
-                | NetCapabilities::CSUM_TCPv6
-                | NetCapabilities::CSUM_UDPv6;
+            capabilities |= NetCapabilities::CSUM_IPv4;
+
+            // TODO: enable checksum offload
+            // | NetCapabilities::CSUM_TCPv6
+            // | NetCapabilities::CSUM_UDPv6;
         }
 
         // Initialize statistics

--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -357,15 +357,18 @@ impl IxgbeInner {
         // setup interface
         // TODO: Check if these are correct
         let flags = NetFlags::BROADCAST | NetFlags::SIMPLEX | NetFlags::MULTICAST;
-        let mut capabilities = NetCapabilities::VLAN_MTU
-            | NetCapabilities::VLAN_HWTAGGING
-            | NetCapabilities::CSUM_IPv4
-            | NetCapabilities::CSUM_UDPv4
-            | NetCapabilities::CSUM_TCPv4
-            | NetCapabilities::CSUM_UDPv6
-            | NetCapabilities::CSUM_TCPv6
-            | NetCapabilities::TSOv4
-            | NetCapabilities::TSOv6;
+
+        let mut capabilities = NetCapabilities::empty();
+        // TODO: enable these capabilities
+        // let mut capabilities = NetCapabilities::VLAN_MTU
+        //     | NetCapabilities::VLAN_HWTAGGING
+        //     | NetCapabilities::CSUM_IPv4
+        //     | NetCapabilities::CSUM_UDPv4
+        //     | NetCapabilities::CSUM_TCPv4
+        //     | NetCapabilities::CSUM_UDPv6
+        //     | NetCapabilities::CSUM_TCPv6
+        //     | NetCapabilities::TSOv4
+        //     | NetCapabilities::TSOv6;
 
         if MacType::IxgbeMac82598EB != hw.get_mac_type() {
             // flags |= NetFlags::LR0;


### PR DESCRIPTION
## Description

Because current device drivers of igb and ixgbe does not support checksum offloading,
this PR disables the offloading temporary.

## Related links

## How was this PR tested?

## Notes for reviewers
