### PR TITLE
fix(ixgbe): `IXGBE_EIMS_EX(1)` must be used for `mask_hi`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -1398,7 +1398,7 @@ impl Ixgbe {
                         }
                         let mask_hi = (queue >> 32) as u32;
                         if mask_hi != 0 {
-                            ixgbe_hw::write_reg(&inner.info, IXGBE_EIMS_EX(0), mask_hi)?;
+                            ixgbe_hw::write_reg(&inner.info, IXGBE_EIMS_EX(1), mask_hi)?;
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Current implementation uses `IXGBE_EIMS_EX(0)` for `mask_hi`, but `IXGBE_EIMS_EX(1)` must be used.

## Related links

https://github.com/openbsd/src/blob/bd92615b04061daa96ce60d53401eedbb5c09e0d/sys/dev/pci/if_ix.c#L1084
https://github.com/openbsd/src/blob/bd92615b04061daa96ce60d53401eedbb5c09e0d/sys/dev/pci/if_ix.c#L1025

## How was this PR tested?

## Notes for reviewers
