### PR TITLE
feat(dvfs): initial commit of hwpstate_intel

### DIFF
--- a/awkernel_lib/src/arch/x86_64/dvfs.rs
+++ b/awkernel_lib/src/arch/x86_64/dvfs.rs
@@ -6,6 +6,7 @@ use crate::{delay::wait_millisec, dvfs::Dvfs};
 
 use super::X86;
 
+#[allow(dead_code)] // TODO: remove this later
 mod hwpstate_intel;
 
 const MSR_PLATFORM_INFO: u32 = 0xCE;

--- a/awkernel_lib/src/arch/x86_64/dvfs/hwpstate_intel.rs
+++ b/awkernel_lib/src/arch/x86_64/dvfs/hwpstate_intel.rs
@@ -11,6 +11,7 @@ pub(super) struct HwPstateIntel {
     hwp_activity_window: bool,
     hwp_perf_pref: bool,
     hwp_pkg_ctrl: bool,
+    hwp_perf_bias: bool,
 }
 
 impl HwPstateIntel {
@@ -29,6 +30,7 @@ impl HwPstateIntel {
             hwp_activity_window,
             hwp_perf_pref,
             hwp_pkg_ctrl,
+            hwp_perf_bias,
         };
 
         hwpstate.set_autonomous_hwp().then_some(())?;


### PR DESCRIPTION
## Description

Implementing Intel Hardware-controlled Performance States (HWP).
This PR implements only `intel_hwpstate_attach()` of FreeBSD.

## Related links

1. Issue: #332
2. `intel_hwpstate_attach()`: https://github.com/freebsd/freebsd-src/blob/f7856fe81df2df3c4355e674d34a4c15a095a33c/sys/x86/cpufreq/hwpstate_intel.c#L473

## How was this PR tested?

## Notes for reviewers
