### PR TITLE
feat(pvclock): use pvclock on KVM environments

### DIFF
--- a/awkernel_lib/src/arch/x86_64.rs
+++ b/awkernel_lib/src/arch/x86_64.rs
@@ -20,7 +20,7 @@ pub fn init(
     acpi: &AcpiTables<AcpiMapper>,
     page_table: &mut page_table::PageTable,
     page_allocator: &mut VecPageAllocator,
-) {
+) -> Result<(), &'static str> {
     // Initialize timer.
-    delay::init(acpi, page_table, page_allocator);
+    delay::init(acpi, page_table, page_allocator)
 }

--- a/kernel/src/arch/x86_64/kernel_main.rs
+++ b/kernel/src/arch/x86_64/kernel_main.rs
@@ -195,7 +195,12 @@ fn kernel_main2(
     let (type_apic, mpboot_start) = if let Some(page_allocator0) = page_allocators.get_mut(&0) {
         // 10. Initialize `awkernel_lib` and `awkernel_driver`
         let mut awkernel_page_table = page_table::PageTable::new(&mut page_table);
-        awkernel_lib::arch::x86_64::init(&acpi, &mut awkernel_page_table, page_allocator0);
+        if let Err(e) =
+            awkernel_lib::arch::x86_64::init(&acpi, &mut awkernel_page_table, page_allocator0)
+        {
+            log::error!("Failed to initialize `awkernel_lib`. {}", e);
+            wait_forever();
+        }
 
         // 11. Initialize APIC.
         let type_apic = awkernel_drivers::interrupt_controller::apic::new(

--- a/userland/Cargo.toml
+++ b/userland/Cargo.toml
@@ -75,7 +75,7 @@ path = "../applications/tests/test_dvfs"
 optional = true
 
 [features]
-default = ["test_dvfs"]
+default = []
 perf = ["awkernel_services/perf"]
 
 # Test applications


### PR DESCRIPTION
## Description

Use pvclock on KVM environments instead of HPET.
HPET is often disabled on KVM environments by default.
This PR uses pbclock if it is available.

## Related links

Close: #342 

## How was this PR tested?

Tested on a KVM virtual machine and an x86_64 physical machine.

## Notes for reviewers
