### PR TITLE
feat(igc): implement generic methods of `IgcMacOperations`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc/igc_defines.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_defines.rs
@@ -418,8 +418,8 @@ pub(super) const IGC_VLAN_FILTER_TBL_SIZE: u32 = 128; // VLAN Filter Table (4096
 // manageability enabled, allowing us room for 15 multicast addresses.
 pub(super) const IGC_RAR_ENTRIES: u32 = 15;
 pub(super) const IGC_RAH_AV: u32 = 0x80000000; // Receive descriptor valid
-pub(super) const IGC_RAL_MAC_ADDR_LEN: u32 = 4;
-pub(super) const IGC_RAH_MAC_ADDR_LEN: u32 = 2;
+pub(super) const IGC_RAL_MAC_ADDR_LEN: usize = 4;
+pub(super) const IGC_RAH_MAC_ADDR_LEN: usize = 2;
 
 // Loop limit on how long we wait for auto-negotiation to complete
 pub(super) const COPPER_LINK_UP_LIMIT: u32 = 10;

--- a/awkernel_drivers/src/pcie/intel/igc/igc_regs.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_regs.rs
@@ -68,3 +68,210 @@ pub(super) const IGC_RDFTS: usize = 0x02428; // Rx Data FIFO Tail Saved - RW
 pub(super) const IGC_RDFPC: usize = 0x02430; // Rx Data FIFO Packet Count - RW
 pub(super) const IGC_PBRTH: usize = 0x02458; // PB Rx Arbitration Threshold - RW
 pub(super) const IGC_FCRTV: usize = 0x02460; // Flow Control Refresh Timer Value - RW
+
+// Convenience macros
+//
+// Example usage:
+// IGC_RDBAL_REG(current_rx_queue)
+pub(super) const IGC_RDBAL: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x02800 + (n * 0x100)
+    } else {
+        0x0C000 + (n * 0x40)
+    }
+};
+pub(super) const IGC_RDBAH: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x02804 + (n * 0x100)
+    } else {
+        0x0C004 + (n * 0x40)
+    }
+};
+pub(super) const IGC_RDLEN: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x02808 + (n * 0x100)
+    } else {
+        0x0C008 + (n * 0x40)
+    }
+};
+pub(super) const IGC_SRRCTL: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x0280C + (n * 0x100)
+    } else {
+        0x0C00C + (n * 0x40)
+    }
+};
+pub(super) const IGC_RDH: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x02810 + (n * 0x100)
+    } else {
+        0x0C010 + (n * 0x40)
+    }
+};
+pub(super) const IGC_RDT: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x02818 + (n * 0x100)
+    } else {
+        0x0C018 + (n * 0x40)
+    }
+};
+pub(super) const IGC_RXDCTL: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x02828 + (n * 0x100)
+    } else {
+        0x0C028 + (n * 0x40)
+    }
+};
+pub(super) const IGC_RQDPC: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x02830 + (n * 0x100)
+    } else {
+        0x0C030 + (n * 0x40)
+    }
+};
+pub(super) const IGC_TDBAL: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x03800 + (n * 0x100)
+    } else {
+        0x0E000 + (n * 0x40)
+    }
+};
+pub(super) const IGC_TDBAH: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x03804 + (n * 0x100)
+    } else {
+        0x0E004 + (n * 0x40)
+    }
+};
+pub(super) const IGC_TDLEN: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x03808 + (n * 0x100)
+    } else {
+        0x0E008 + (n * 0x40)
+    }
+};
+pub(super) const IGC_TDH: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x03810 + (n * 0x100)
+    } else {
+        0x0E010 + (n * 0x40)
+    }
+};
+pub(super) const IGC_TDT: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x03818 + (n * 0x100)
+    } else {
+        0x0E018 + (n * 0x40)
+    }
+};
+pub(super) const IGC_TXDCTL: fn(usize) -> usize = |n| {
+    if n < 4 {
+        0x03828 + (n * 0x100)
+    } else {
+        0x0E028 + (n * 0x40)
+    }
+};
+pub(super) const IGC_TARC: fn(usize) -> usize = |n| 0x03840 + (n * 0x100);
+pub(super) const IGC_RSRPD: usize = 0x02C00; // Rx Small Packet Detect - RW
+pub(super) const IGC_RAID: usize = 0x02C08; // Receive Ack Interrupt Delay - RW
+pub(super) const IGC_KABGTXD: usize = 0x03004; // AFE Band Gap Transmit Ref Data
+pub(super) const IGC_PSRTYPE: fn(usize) -> usize = |i| 0x05480 + (i * 4);
+pub(super) const IGC_RAL: fn(usize) -> usize = |i| {
+    if i <= 15 {
+        0x05400 + (i * 8)
+    } else {
+        0x054E0 + ((i - 16) * 8)
+    }
+};
+pub(super) const IGC_RAH: fn(usize) -> usize = |i| {
+    if i <= 15 {
+        0x05404 + (i * 8)
+    } else {
+        0x054E4 + ((i - 16) * 8)
+    }
+};
+
+// Statistics Register Descriptions
+pub(super) const IGC_CRCERRS: usize = 0x04000; // CRC Error Count - R/clr
+pub(super) const IGC_ALGNERRC: usize = 0x04004; // Alignment Error Count - R/clr
+pub(super) const IGC_MPC: usize = 0x04010; // Missed Packet Count - R/clr
+pub(super) const IGC_SCC: usize = 0x04014; // Single Collision Count - R/clr
+pub(super) const IGC_ECOL: usize = 0x04018; // Excessive Collision Count - R/clr
+pub(super) const IGC_MCC: usize = 0x0401C; // Multiple Collision Count - R/clr
+pub(super) const IGC_LATECOL: usize = 0x04020; // Late Collision Count - R/clr
+pub(super) const IGC_COLC: usize = 0x04028; // Collision Count - R/clr
+pub(super) const IGC_RERC: usize = 0x0402C; // Receive Error Count - R/clr
+pub(super) const IGC_DC: usize = 0x04030; // Defer Count - R/clr
+pub(super) const IGC_TNCRS: usize = 0x04034; // Tx-No CRS - R/clr
+pub(super) const IGC_HTDPMC: usize = 0x0403C; // Host Transmit Discarded by MAC - R/clr
+pub(super) const IGC_RLEC: usize = 0x04040; // Receive Length Error Count - R/clr
+pub(super) const IGC_XONRXC: usize = 0x04048; // XON Rx Count - R/clr
+pub(super) const IGC_XONTXC: usize = 0x0404C; // XON Tx Count - R/clr
+pub(super) const IGC_XOFFRXC: usize = 0x04050; // XOFF Rx Count - R/clr
+pub(super) const IGC_XOFFTXC: usize = 0x04054; // XOFF Tx Count - R/clr
+pub(super) const IGC_FCRUC: usize = 0x04058; // Flow Control Rx Unsupported Count- R/clr
+pub(super) const IGC_PRC64: usize = 0x0405C; // Packets Rx (64 bytes) - R/clr
+pub(super) const IGC_PRC127: usize = 0x04060; // Packets Rx (65-127 bytes) - R/clr
+pub(super) const IGC_PRC255: usize = 0x04064; // Packets Rx (128-255 bytes) - R/clr
+pub(super) const IGC_PRC511: usize = 0x04068; // Packets Rx (255-511 bytes) - R/clr
+pub(super) const IGC_PRC1023: usize = 0x0406C; // Packets Rx (512-1023 bytes) - R/clr
+pub(super) const IGC_PRC1522: usize = 0x04070; // Packets Rx (1024-1522 bytes) - R/clr
+pub(super) const IGC_GPRC: usize = 0x04074; // Good Packets Rx Count - R/clr
+pub(super) const IGC_BPRC: usize = 0x04078; // Broadcast Packets Rx Count - R/clr
+pub(super) const IGC_MPRC: usize = 0x0407C; // Multicast Packets Rx Count - R/clr
+pub(super) const IGC_GPTC: usize = 0x04080; // Good Packets Tx Count - R/clr
+pub(super) const IGC_GORCL: usize = 0x04088; // Good Octets Rx Count Low - R/clr
+pub(super) const IGC_GORCH: usize = 0x0408C; // Good Octets Rx Count High - R/clr
+pub(super) const IGC_GOTCL: usize = 0x04090; // Good Octets Tx Count Low - R/clr
+pub(super) const IGC_GOTCH: usize = 0x04094; // Good Octets Tx Count High - R/clr
+pub(super) const IGC_RNBC: usize = 0x040A0; // Rx No Buffers Count - R/clr
+pub(super) const IGC_RUC: usize = 0x040A4; // Rx Undersize Count - R/clr
+pub(super) const IGC_RFC: usize = 0x040A8; // Rx Fragment Count - R/clr
+pub(super) const IGC_ROC: usize = 0x040AC; // Rx Oversize Count - R/clr
+pub(super) const IGC_RJC: usize = 0x040B0; // Rx Jabber Count - R/clr
+pub(super) const IGC_MGTPRC: usize = 0x040B4; // Management Packets Rx Count - R/clr
+pub(super) const IGC_MGTPDC: usize = 0x040B8; // Management Packets Dropped Count - R/clr
+pub(super) const IGC_MGTPTC: usize = 0x040BC; // Management Packets Tx Count - R/clr
+pub(super) const IGC_TORL: usize = 0x040C0; // Total Octets Rx Low - R/clr
+pub(super) const IGC_TORH: usize = 0x040C4; // Total Octets Rx High - R/clr
+pub(super) const IGC_TOTL: usize = 0x040C8; // Total Octets Tx Low - R/clr
+pub(super) const IGC_TOTH: usize = 0x040CC; // Total Octets Tx High - R/clr
+pub(super) const IGC_TPR: usize = 0x040D0; // Total Packets Rx - R/clr
+pub(super) const IGC_TPT: usize = 0x040D4; // Total Packets Tx - R/clr
+pub(super) const IGC_PTC64: usize = 0x040D8; // Packets Tx (64 bytes) - R/clr
+pub(super) const IGC_PTC127: usize = 0x040DC; // Packets Tx (65-127 bytes) - R/clr
+pub(super) const IGC_PTC255: usize = 0x040E0; // Packets Tx (128-255 bytes) - R/clr
+pub(super) const IGC_PTC511: usize = 0x040E4; // Packets Tx (256-511 bytes) - R/clr
+pub(super) const IGC_PTC1023: usize = 0x040E8; // Packets Tx (512-1023 bytes) - R/clr
+pub(super) const IGC_PTC1522: usize = 0x040EC; // Packets Tx (1024-1522 Bytes) - R/clr
+pub(super) const IGC_MPTC: usize = 0x040F0; // Multicast Packets Tx Count - R/clr
+pub(super) const IGC_BPTC: usize = 0x040F4; // Broadcast Packets Tx Count - R/clr
+pub(super) const IGC_TSCTC: usize = 0x040F8; // TCP Segmentation Context Tx - R/clr
+pub(super) const IGC_IAC: usize = 0x04100; // Interrupt Assertion Count
+pub(super) const IGC_RXDMTC: usize = 0x04120; // Rx Descriptor Minimum Threshold Count
+
+pub(super) const IGC_VFGPRC: usize = 0x00F10;
+pub(super) const IGC_VFGORC: usize = 0x00F18;
+pub(super) const IGC_VFMPRC: usize = 0x00F3C;
+pub(super) const IGC_VFGPTC: usize = 0x00F14;
+pub(super) const IGC_VFGOTC: usize = 0x00F34;
+pub(super) const IGC_VFGOTLBC: usize = 0x00F50;
+pub(super) const IGC_VFGPTLBC: usize = 0x00F44;
+pub(super) const IGC_VFGORLBC: usize = 0x00F48;
+pub(super) const IGC_VFGPRLBC: usize = 0x00F40;
+pub(super) const IGC_HGORCL: usize = 0x04128; // Host Good Octets Received Count Low
+pub(super) const IGC_HGORCH: usize = 0x0412C; // Host Good Octets Received Count High
+pub(super) const IGC_HGOTCL: usize = 0x04130; // Host Good Octets Transmit Count Low
+pub(super) const IGC_HGOTCH: usize = 0x04134; // Host Good Octets Transmit Count High
+pub(super) const IGC_LENERRS: usize = 0x04138; // Length Errors Count
+pub(super) const IGC_PCS_ANADV: usize = 0x04218; // AN advertisement - RW
+pub(super) const IGC_PCS_LPAB: usize = 0x0421C; // Link Partner Ability - RW
+pub(super) const IGC_RXCSUM: usize = 0x05000; // Rx Checksum Control - RW
+pub(super) const IGC_RLPML: usize = 0x05004; // Rx Long Packet Max Length
+pub(super) const IGC_RFCTL: usize = 0x05008; // Receive Filter Control
+pub(super) const IGC_MTA: usize = 0x05200; // Multicast Table Array - RW Array
+pub(super) const IGC_RA: usize = 0x05400; // Receive Address - RW Array
+pub(super) const IGC_VFTA: usize = 0x05600; // VLAN Filter Table Array - RW Array
+pub(super) const IGC_WUC: usize = 0x05800; // Wakeup Control - RW
+pub(super) const IGC_WUFC: usize = 0x05808; // Wakeup Filter Control - RW
+pub(super) const IGC_WUS: usize = 0x05810; // Wakeup Status - RO


### PR DESCRIPTION
## Description

### 1. Implement generic methods of `IgcMacOperations` as follows.

- `init_params()`
- `write_vfta()`
- `config_collision_dist()`
- `rar_set()`
- `read_mac_addr()`

### 2. Remove unused methods of `IgcMacOperations`.

Following methods are unused by igc.

- `clear_hw_cntrs()`
- `clear_vfta()`
- `get_bus_info()`
- `set_lan_id()`
- `validate_mdi_setting()`

### 3. Define some constant values.

Define registers such as `IGC_CRCERRS`.

## Related links

- `igc_null_ops_generic` for `init_params()`
  - https://github.com/openbsd/src/blob/f0cb83d2ff07487b2d4d917b13c4f56261d7ee6d/sys/dev/pci/igc_mac.c#L23
  - https://github.com/openbsd/src/blob/f0cb83d2ff07487b2d4d917b13c4f56261d7ee6d/sys/dev/pci/igc_mac.c#L33
- `igc_write_vfta_generic()`: https://github.com/openbsd/src/blob/f0cb83d2ff07487b2d4d917b13c4f56261d7ee6d/sys/dev/pci/igc_mac.c#L49
- `igc_config_collision_dist_generic()`: https://github.com/openbsd/src/blob/f0cb83d2ff07487b2d4d917b13c4f56261d7ee6d/sys/dev/pci/igc_mac.c#L418
- `igc_rar_set_generic()`: https://github.com/openbsd/src/blob/f0cb83d2ff07487b2d4d917b13c4f56261d7ee6d/sys/dev/pci/igc_mac.c#L162
- `igc_read_mac_addr_generic()`: https://github.com/openbsd/src/blob/f0cb83d2ff07487b2d4d917b13c4f56261d7ee6d/sys/dev/pci/igc_nvm.c#L181
- registers: https://github.com/openbsd/src/blob/f0cb83d2ff07487b2d4d917b13c4f56261d7ee6d/sys/dev/pci/igc_regs.h#L114-L251

issue #335

## How was this PR tested?

## Notes for reviewers
