### PR TITLE
feat(smoltcp): enable tests of smoltcp

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,7 @@ std = "build --package awkernel --no-default-features --features std"
 test_awkernel_lib = "test --package awkernel_lib --no-default-features --features std"
 test_awkernel_async_lib = "test --package awkernel_async_lib --no-default-features --features std"
 test_awkernel_drivers = "test --package awkernel_drivers --no-default-features --features std"
+test_smoltcp = "test --package smoltcp --no-default-features --features std --features awkernel"
 
 clippy_x86 = "clippy --package awkernel --no-default-features --features x86 --target targets/x86_64-kernel.json -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem"
 clippy_raspi = "clippy --package awkernel --no-default-features --features raspi --target targets/aarch64-kernel.json -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem"

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ test: FORCE
 	cargo test_awkernel_lib
 	cargo test_awkernel_async_lib -- --nocapture
 	cargo test_awkernel_drivers
+	cargo test_smoltcp
 
 # Format
 

--- a/awkernel_async_lib/Cargo.toml
+++ b/awkernel_async_lib/Cargo.toml
@@ -34,18 +34,7 @@ path = "../awkernel_futures_macro"
 [dependencies.smoltcp]
 path = "../smoltcp"
 default-features = false
-features = [
-    "alloc",
-    "async",
-    "log",
-    "socket-udp",
-    "socket-tcp",
-    "proto-ipv4",
-    "proto-ipv6",
-    "socket-icmp",
-    "medium-ethernet",
-    "proto-igmp",
-]
+features = ["awkernel"]
 
 [features]
 default = []

--- a/smoltcp/Cargo.toml
+++ b/smoltcp/Cargo.toml
@@ -157,6 +157,7 @@ required-features = [
 
 [dependencies.awkernel_sync]
 git = "https://github.com/tier4/awkernel_sync.git"
+default-features = false
 
 [dependencies.bitflags]
 version = "1.0"
@@ -404,5 +405,17 @@ socket-mdns = ["socket-dns"]
 socket-raw = ["socket"]
 socket-tcp = ["socket"]
 socket-udp = ["socket"]
-std = ["managed/std", "alloc"]
+std = ["managed/std", "alloc", "awkernel_sync/std"]
 verbose = []
+awkernel = [
+    "alloc",
+    "async",
+    "log",
+    "socket-udp",
+    "socket-tcp",
+    "proto-ipv4",
+    "proto-ipv6",
+    "socket-icmp",
+    "medium-ethernet",
+    "proto-igmp",
+]

--- a/smoltcp/examples/utils.rs
+++ b/smoltcp/examples/utils.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "phy-tuntap_interface")]
 use smoltcp::phy::TunTapInterface;
-use smoltcp::phy::{Device, FaultInjector, Medium, Tracer};
+use smoltcp::phy::{Device, FaultInjector, Tracer};
 use smoltcp::phy::{PcapMode, PcapWriter};
 use smoltcp::time::{Duration, Instant};
 
@@ -98,6 +98,8 @@ pub fn add_tuntap_options(opts: &mut Options, _free: &mut [&str]) {
 
 #[cfg(feature = "phy-tuntap_interface")]
 pub fn parse_tuntap_options(matches: &mut Matches) -> TunTapInterface {
+    use smoltcp::phy::Medium;
+
     let tun = matches.opt_str("tun");
     let tap = matches.opt_str("tap");
     match (tun, tap) {

--- a/smoltcp/src/iface/interface/tests/ipv4.rs
+++ b/smoltcp/src/iface/interface/tests/ipv4.rs
@@ -358,7 +358,7 @@ fn test_handle_ipv4_broadcast(#[case] medium: Medium) {
 #[case(Medium::Ethernet)]
 #[cfg(feature = "medium-ethernet")]
 fn test_handle_valid_arp_request(#[case] medium: Medium) {
-    let (mut iface, mut sockets, _device) = setup(medium);
+    let (mut iface, sockets, _device) = setup(medium);
 
     let mut eth_bytes = vec![0u8; 42];
 
@@ -385,7 +385,7 @@ fn test_handle_valid_arp_request(#[case] medium: Medium) {
     // Ensure an ARP Request for us triggers an ARP Reply
     assert_eq!(
         iface.inner.process_ethernet(
-            &mut sockets,
+            &sockets,
             PacketMeta::default(),
             frame.into_inner(),
             &mut iface.fragments
@@ -415,7 +415,7 @@ fn test_handle_valid_arp_request(#[case] medium: Medium) {
 #[case(Medium::Ethernet)]
 #[cfg(feature = "medium-ethernet")]
 fn test_handle_other_arp_request(#[case] medium: Medium) {
-    let (mut iface, mut sockets, _device) = setup(medium);
+    let (mut iface, sockets, _device) = setup(medium);
 
     let mut eth_bytes = vec![0u8; 42];
 
@@ -440,7 +440,7 @@ fn test_handle_other_arp_request(#[case] medium: Medium) {
     // Ensure an ARP Request for someone else does not trigger an ARP Reply
     assert_eq!(
         iface.inner.process_ethernet(
-            &mut sockets,
+            &sockets,
             PacketMeta::default(),
             frame.into_inner(),
             &mut iface.fragments

--- a/smoltcp/src/iface/interface/tests/mod.rs
+++ b/smoltcp/src/iface/interface/tests/mod.rs
@@ -14,10 +14,8 @@ use rstest::*;
 
 use super::*;
 
-use crate::iface::Interface;
 use crate::phy::ChecksumCapabilities;
 #[cfg(feature = "alloc")]
-use crate::phy::Loopback;
 use crate::time::Instant;
 
 #[allow(unused)]
@@ -27,6 +25,7 @@ fn fill_slice(s: &mut [u8], val: u8) {
     }
 }
 
+#[allow(unused)]
 #[cfg(feature = "proto-igmp")]
 fn recv_all(device: &mut crate::tests::TestingDevice, timestamp: Instant) -> Vec<Vec<u8>> {
     let mut pkts = Vec::new();
@@ -56,9 +55,9 @@ impl TxToken for MockTxToken {
 #[should_panic(expected = "The hardware address does not match the medium of the interface.")]
 #[cfg(all(feature = "medium-ip", feature = "medium-ethernet", feature = "alloc"))]
 fn test_new_panic() {
-    let mut device = Loopback::new(Medium::Ethernet);
+    let mut device = crate::phy::Loopback::new(Medium::Ethernet);
     let config = Config::new(HardwareAddress::Ip);
-    Interface::new(config, &mut device, Instant::ZERO);
+    crate::iface::Interface::new(config, &mut device, Instant::ZERO);
 }
 
 #[rstest]

--- a/smoltcp/src/iface/socket_set.rs
+++ b/smoltcp/src/iface/socket_set.rs
@@ -9,6 +9,7 @@ use crate::socket::{AnySocket, Socket};
 ///
 /// This is public so you can use it to allocate space for storing
 /// sockets when creating an Interface.
+#[derive(Default)]
 pub struct SocketStorage<'a> {
     inner: Option<Item<'a>>,
 }

--- a/smoltcp/src/storage/assembler.rs
+++ b/smoltcp/src/storage/assembler.rs
@@ -705,8 +705,8 @@ mod test {
                 let mut map = [false; MAX_INDEX];
 
                 for _ in 0..60 {
-                    let offset = rand::thread_rng().gen_range(0..MAX_INDEX - max_size - 1);
-                    let size = rand::thread_rng().gen_range(1..=max_size);
+                    let offset = rand::rng().random_range(0..MAX_INDEX - max_size - 1);
+                    let size = rand::rng().random_range(1..=max_size);
 
                     //println!("add {}..{} {}", offset, offset + size, size);
                     // Real impl

--- a/smoltcp/src/tests.rs
+++ b/smoltcp/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::iface::*;
 use crate::wire::*;
 
-pub(crate) fn setup<'a>(medium: Medium) -> (Interface, SocketSet<'a>, TestingDevice) {
+pub(crate) fn setup<'a>(medium: Medium) -> (Interface, RwLock<SocketSet<'a>>, TestingDevice) {
     let mut device = TestingDevice::new(medium);
 
     let config = Config::new(match medium {
@@ -46,9 +46,12 @@ pub(crate) fn setup<'a>(medium: Medium) -> (Interface, SocketSet<'a>, TestingDev
         });
     }
 
-    (iface, SocketSet::new(vec![]), device)
+    let sockets = RwLock::new(SocketSet::new(vec![]));
+
+    (iface, sockets, device)
 }
 
+use awkernel_sync::rwlock::RwLock;
 use heapless::Deque;
 use heapless::Vec;
 


### PR DESCRIPTION
## Description

Enable tests of smoltcp.
smoltcp can be tested as `cargo test_smoltcp`.

## Related links

## How was this PR tested?

```
$ cargo test_smoltcp
...
test result: ok. 242 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s

   Doc-tests smoltcp

running 7 tests
test smoltcp/src/socket/tcp.rs - socket::tcp::Socket<'a>::connect (line 787) - compile ... ok
test smoltcp/src/phy/mod.rs - phy::PacketMeta (line 152) ... ok
test smoltcp/src/phy/mod.rs - phy (line 18) ... ok
test smoltcp/src/socket/icmp.rs - socket::icmp::Socket<'a>::bind (line 244) ... ok
test smoltcp/src/socket/icmp.rs - socket::icmp::Socket<'a>::bind (line 223) ... ok
test smoltcp/src/wire/pretty_print.rs - wire::pretty_print (line 10) ... ok
test smoltcp/src/wire/mod.rs - wire (line 45) ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
```

## Notes for reviewers
