### PR TITLE
feat(dvfs): add methods to set min and max performance

### DIFF
--- a/awkernel_lib/src/arch/x86_64/dvfs/hwpstate_intel.rs
+++ b/awkernel_lib/src/arch/x86_64/dvfs/hwpstate_intel.rs
@@ -269,11 +269,6 @@ impl HwPstateIntel {
         assert!(self.high >= self.low);
         let range = self.high - self.low;
 
-        // avoid zero division
-        if range == 0 {
-            return self.low;
-        }
-
         // To avoid overflow, the raw value is calculated by casting the values to u32.
         let val = (percent as u32 * range as u32) / 100 + self.low as u32;
         if val > self.high as u32 {


### PR DESCRIPTION
## Description

`maximum_performance_select()` and `minimum_performance_select()` are implemented to `HwPstateIntel`.
These methods set the minimum and the maximum performance values, respectively.

Additionally, a logging message are printed when attaching, and `HWPSTATE_PKG_CTRL_ENABLE` is defined as FreeBSD does.

## Related links

- issue #332 

## How was this PR tested?

## Notes for reviewers
