### PR TITLE
feat(igc): implement `igc_get_hw_semaphore_i225()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -19,6 +19,7 @@ pub enum IgcDriverErr {
     MacInit,
     MasterRequestsPending,
     Reset,
+    NVM,
 }
 
 /// Check if the device is an Intel I225/I226.

--- a/awkernel_drivers/src/pcie/intel/igc/igc_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_hw.rs
@@ -153,10 +153,10 @@ enum IgcNvmType {
 }
 
 #[derive(Debug)]
-struct IgcNvmInfo {
+pub(super) struct IgcNvmInfo {
     nvm_type: IgcNvmType,
 
-    word_size: u16,
+    pub(super) word_size: u16,
     delay_usec: u16,
     address_bits: u16,
     opcode_bits: u16,
@@ -208,9 +208,9 @@ pub(super) struct IgcBusInfo {
 }
 
 #[derive(Debug)]
-struct IgcDevSpecI225 {
+pub(super) struct IgcDevSpecI225 {
     eee_disable: bool,
-    clear_semaphore_once: bool,
+    pub(super) clear_semaphore_once: bool,
     mtu: u32,
 }
 
@@ -219,10 +219,10 @@ pub(super) struct IgcHw {
     pub(super) mac: IgcMacInfo,
     fc: IgcFcInfo,
     phy: IgcPhyInfo,
-    nvm: IgcNvmInfo,
+    pub(super) nvm: IgcNvmInfo,
     pub(super) bus: IgcBusInfo,
 
-    dev_spec: IgcDevSpecI225,
+    pub(super) dev_spec: IgcDevSpecI225,
 
     pub(super) device_id: u16,
     subsystem_vendor_id: u16,

--- a/awkernel_drivers/src/pcie/intel/igc/igc_mac.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_mac.rs
@@ -104,3 +104,11 @@ pub(super) fn igc_get_auto_rd_done_generic(info: &mut PCIeInfo) -> Result<(), Ig
     log::debug!("Auto read by HW from NVM has not completed.");
     Err(IgcDriverErr::Reset)
 }
+
+/// Release hardware semaphore used to access the PHY or NVM
+pub(super) fn igc_put_hw_semaphore_generic(info: &mut PCIeInfo) -> Result<(), IgcDriverErr> {
+    let mut swsm = read_reg(info, IGC_SWSM)?;
+    swsm &= !(IGC_SWSM_SMBI | IGC_SWSM_SWESMBI);
+
+    write_reg(info, IGC_SWSM, swsm)
+}

--- a/awkernel_drivers/src/pcie/intel/igc/igc_regs.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_regs.rs
@@ -275,3 +275,11 @@ pub(super) const IGC_VFTA: usize = 0x05600; // VLAN Filter Table Array - RW Arra
 pub(super) const IGC_WUC: usize = 0x05800; // Wakeup Control - RW
 pub(super) const IGC_WUFC: usize = 0x05808; // Wakeup Filter Control - RW
 pub(super) const IGC_WUS: usize = 0x05810; // Wakeup Status - RO
+
+// Semaphore registers
+pub(super) const IGC_SW_FW_SYNC: usize = 0x05B5C; // SW-FW Synchronization - RW
+
+// Function Active and Power State to MNG
+pub(super) const IGC_FACTPS: usize = 0x05B30;
+pub(super) const IGC_SWSM: usize = 0x05B50; // SW Semaphore
+pub(super) const IGC_FWSM: usize = 0x05B54; // FW Semaphore


### PR DESCRIPTION
## Description

Implement `igc_get_hw_semaphore_i225()` for igc.

## Related links

- issue: #335 
- OpenBSD `igc_get_hw_semaphore_i225()`  https://github.com/openbsd/src/blob/351a734b4a2d91c37d337a6a09a23fe640c9538d/sys/dev/pci/igc_i225.c#L373

## How was this PR tested?

## Notes for reviewers
