### PR TITLE
fix(epoll): reenable eventfd and stdin

### DIFF
--- a/awkernel_lib/src/select/epoll.rs
+++ b/awkernel_lib/src/select/epoll.rs
@@ -174,14 +174,18 @@ pub(super) fn wait(timeout: Duration) {
         // Update epoll.
         let mut events = EventFlag::empty();
         {
-            let mut node = MCSNode::new();
-            let map = super::FD_TO_WAKER.lock(&mut node);
-            if map.contains_key(&(raw_fd, EventType::Read)) {
+            if raw_fd == evfd || raw_fd == libc::STDIN_FILENO {
                 events.insert(EventFlag::READ);
-            }
+            } else {
+                let mut node = MCSNode::new();
+                let map = super::FD_TO_WAKER.lock(&mut node);
+                if map.contains_key(&(raw_fd, EventType::Read)) {
+                    events.insert(EventFlag::READ);
+                }
 
-            if map.contains_key(&(raw_fd, EventType::Write)) {
-                events.insert(EventFlag::WRITE);
+                if map.contains_key(&(raw_fd, EventType::Write)) {
+                    events.insert(EventFlag::WRITE);
+                }
             }
         }
 


### PR DESCRIPTION
## Description

`eventfd` and `stdin` will be enabled again after `epoll` detects the events.

## Related links

## How was this PR tested?

It works on a Linux environment as follows.

```
$ make std
cargo +nightly-2025-02-27 std --features debug
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
$ make run-std
cargo +nightly-2025-02-27 run --package awkernel --no-default-features --features std --features debug
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/awkernel`
[            0 WARN] kernel/src/arch/std_common/kernel_main.rs:22: Failed to SCHED_FIFO.
[            0 INFO] CPU#1 is starting.
[            0 INFO] CPU#3 is starting.
[            0 INFO] CPU#2 is starting.
[            0 INFO] CPU#4 is starting.
[            0 INFO] CPU#7 is starting.
[            0 INFO] CPU#5 is starting.
[            0 INFO] CPU#8 is starting.
[            0 INFO] CPU#6 is starting.
[            0 INFO] CPU#9 is starting.
[            0 INFO] CPU#10 is starting.
[            0 INFO] CPU#12 is starting.
[            1 INFO] CPU#11 is starting.
[            1 INFO] CPU#13 is starting.
[            1 INFO] CPU#14 is starting.
[            1 INFO] CPU#0 is starting.
[            1 INFO] CPU#15 is starting.
[            1 WARN] awkernel_lib/src/interrupt.rs:467: interrupt::INTERRUPT_CONTROLLER is not yet initialized.
[            1 WARN] awkernel_lib/src/interrupt.rs:473: interrupt::PREEMPT_FN is not yet initialized.
[            1 INFO] timer::TIMER is not yet initialized.
[            1 INFO] Starting [Awkernel] network service.
[         1001 WARN] /home/ytakano/program/rust/awkernel/awkernel_lib/src/interrupt.rs:175: Interrupt controller is not yet enabled.
[         1001 WARN] applications/awkernel_shell/src/lib.rs:33: Failed to initialize UART's interrupt handler.
[         1001 INFO] Start [Awkernel] shell.

Welcome to Awkernel!

You can use BLisp language as follows.
https://ytakano.github.io/blisp/

> (factorial 20)
2432902008176640000
> (+ 10 20)
30

Enjoy!

>

> (help)
Awkernel v202306
BLisp grammer: https://ytakano.github.io/blisp/

BLisp functions:
(help)      ; print this message
(task)      ; print tasks
(interrupt) ; print interrupt information
(ifconfig)  ; print network interfaces
(perf)      ; print performance information
[]
>
```

## Notes for reviewers
