### PR TITLE
refactor: narrowing the scope

### DIFF
--- a/applications/tests/test_dag/src/lib.rs
+++ b/applications/tests/test_dag/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloc::{borrow::Cow, vec};
 use awkernel_async_lib::dag::{create_dag, finish_create_dags};
 use awkernel_async_lib::scheduler::SchedulerType;
-use awkernel_lib::{delay::wait_microsec, sync::mutex::MCSNode};
+use awkernel_lib::delay::wait_microsec;
 use core::time::Duration;
 
 pub async fn run() {
@@ -74,9 +74,6 @@ pub async fn run() {
 
     let _ = finish_create_dags(&[dag.clone()]).await;
 
-    let mut node = MCSNode::new();
-    let graph = dag.graph.lock(&mut node);
-
-    assert_eq!(graph.node_count(), 5);
-    assert_eq!(graph.edge_count(), 5);
+    assert_eq!(dag.node_count(), 5);
+    assert_eq!(dag.edge_count(), 5);
 }

--- a/awkernel_async_lib/src/dag.rs
+++ b/awkernel_async_lib/src/dag.rs
@@ -47,7 +47,7 @@ impl PendingTask {
     }
 }
 
-pub struct NodeInfo {
+struct NodeInfo {
     task_id: u32,
     subscribe_topics: Vec<Cow<'static, str>>,
     publish_topics: Vec<Cow<'static, str>>,
@@ -55,11 +55,23 @@ pub struct NodeInfo {
 }
 
 pub struct Dag {
-    pub id: u32,
-    pub graph: Mutex<graph::Graph<NodeInfo, u32>>, //TODO: Change to edge attribute
+    id: u32,
+    graph: Mutex<graph::Graph<NodeInfo, u32>>, //TODO: Change to edge attribute
 }
 
 impl Dag {
+    pub fn node_count(&self) -> usize {
+        let mut node = MCSNode::new();
+        let graph = self.graph.lock(&mut node);
+        graph.node_count()
+    }
+
+    pub fn edge_count(&self) -> usize {
+        let mut node = MCSNode::new();
+        let graph = self.graph.lock(&mut node);
+        graph.edge_count()
+    }
+
     fn add_node_with_topic_edges(
         &self,
         subscribe_topic_names: &[Cow<'static, str>],


### PR DESCRIPTION
## Description
Change in scope.
・Remove `pub` for `id` and `graph` of Dag.
・Remove pub for `NodeInfo`.

## Related links
[Separation of this PR](https://github.com/tier4/awkernel/pull/383/files)

## How was this PR tested?
Verify that it works with `test_dag`.

## Notes for reviewers
- For `node_count`, and `edge_count`, it may be possible to make them `pub(crete)`, but since they are used for testing, they are made `pub`.
- `pub` functions are assumed to be used by users.