### PR TITLE
fix(net): use pass-by-reference instead of pass-by-value for `IpAddr` and `TcpConfig`

### DIFF
--- a/applications/tests/test_network/src/lib.rs
+++ b/applications/tests/test_network/src/lib.rs
@@ -69,7 +69,7 @@ async fn ipv4_multicast_send_test() {
     // Create a UDP socket on interface 0.
     let mut socket = awkernel_async_lib::net::udp::UdpSocket::bind_on_interface(
         INTERFACE_ID,
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 
@@ -98,7 +98,7 @@ async fn ipv4_multicast_recv_test() {
     };
 
     let mut socket =
-        awkernel_async_lib::net::udp::UdpSocket::bind_on_interface(INTERFACE_ID, config).unwrap();
+        awkernel_async_lib::net::udp::UdpSocket::bind_on_interface(INTERFACE_ID, &config).unwrap();
 
     loop {
         // Join the multicast group.
@@ -186,7 +186,7 @@ async fn tcp_listen_test() {
     };
 
     let Ok(mut tcp_listener) =
-        awkernel_async_lib::net::tcp::TcpListener::bind_on_interface(INTERFACE_ID, config)
+        awkernel_async_lib::net::tcp::TcpListener::bind_on_interface(INTERFACE_ID, &config)
     else {
         return;
     };
@@ -228,7 +228,7 @@ async fn udp_test() {
     // Create a UDP socket on interface 0.
     let mut socket = awkernel_async_lib::net::udp::UdpSocket::bind_on_interface(
         INTERFACE_ID,
-        Default::default(),
+        &Default::default(),
     )
     .unwrap();
 

--- a/awkernel_async_lib/src/net/tcp.rs
+++ b/awkernel_async_lib/src/net/tcp.rs
@@ -67,7 +67,7 @@ impl TcpListener {
     /// The listener is bound to the specified address and port.
     pub fn bind_on_interface(
         interface_id: u64,
-        config: TcpConfig,
+        config: &TcpConfig,
     ) -> Result<TcpListener, NetManagerError> {
         let listener = awkernel_lib::net::tcp_listener::TcpListener::bind_on_interface(
             interface_id,

--- a/awkernel_async_lib/src/net/udp.rs
+++ b/awkernel_async_lib/src/net/udp.rs
@@ -38,11 +38,11 @@ pub struct UdpSocket {
 impl UdpSocket {
     pub fn bind_on_interface(
         interface_id: u64,
-        config: UdpConfig,
+        config: &UdpConfig,
     ) -> Result<UdpSocket, UdpSocketError> {
         let socket_handle = awkernel_lib::net::udp_socket::UdpSocket::bind_on_interface(
             interface_id,
-            config.addr,
+            &config.addr,
             config.port,
             config.rx_buffer_size,
             config.tx_buffer_size,

--- a/awkernel_lib/src/net/udp_socket.rs
+++ b/awkernel_lib/src/net/udp_socket.rs
@@ -34,7 +34,7 @@ where
     ///     let buf_size = 64 * 1024;
     ///     let handler = UdpSocket::bind_on_interface(
     ///         0,
-    ///         IpAddr::new_v4(Ipv4Addr::new(192, 168, 0, 1)),
+    ///         &IpAddr::new_v4(Ipv4Addr::new(192, 168, 0, 1)),
     ///         Some(10000),
     ///         buf_size,
     ///         buf_size).unwrap();
@@ -42,7 +42,7 @@ where
     /// ```
     fn bind_on_interface(
         interface_id: u64,
-        addr: IpAddr,
+        addr: &IpAddr,
         port: Option<u16>,
         rx_buffer_size: usize,
         tx_buffer_size: usize,

--- a/awkernel_lib/src/net/udp_socket/udp_socket_no_std.rs
+++ b/awkernel_lib/src/net/udp_socket/udp_socket_no_std.rs
@@ -15,7 +15,7 @@ pub struct UdpSocket {
 impl super::SockUdp for UdpSocket {
     fn bind_on_interface(
         interface_id: u64,
-        addr: IpAddr,
+        addr: &IpAddr,
         port: Option<u16>,
         rx_buffer_size: usize,
         tx_buffer_size: usize,

--- a/awkernel_lib/src/net/udp_socket/udp_socket_std.rs
+++ b/awkernel_lib/src/net/udp_socket/udp_socket_std.rs
@@ -15,7 +15,7 @@ pub struct UdpSocket {
 impl super::SockUdp for UdpSocket {
     fn bind_on_interface(
         _interface_id: u64,
-        addr: IpAddr,
+        addr: &IpAddr,
         port: Option<u16>,
         _rx_buffer_size: usize,
         _tx_buffer_size: usize,


### PR DESCRIPTION
## Description

Some networking APIs use pass-by-value for IpAddr and configuration arguments, while others use pass-by-reference.
This PR changes the `IpAddr` and `TcpConfig` arguments in networking APIs from pass-by-value to pass-by-reference.

## Related links

## How was this PR tested?

## Notes for reviewers
