### PR TITLE
feat(driver): add u8 read operations

### DIFF
--- a/awkernel_drivers/src/pcie/base_address.rs
+++ b/awkernel_drivers/src/pcie/base_address.rs
@@ -76,6 +76,35 @@ impl BaseAddress {
         }
     }
 
+    pub fn read8(&self, offset: usize) -> Option<u8> {
+        match self {
+            #[cfg(feature = "x86")]
+            BaseAddress::IO { addr, size, .. } => {
+                if offset >= *size {
+                    return None;
+                }
+
+                let mut port1 = x86_64::instructions::port::PortWriteOnly::new(0xCF8);
+                let mut port2 = x86_64::instructions::port::PortReadOnly::new(0xCFC);
+
+                let addr = *addr | ((offset as u32) & 0xfc);
+                let val = unsafe {
+                    port1.write(addr);
+                    let tmp: u32 = port2.read();
+                    (tmp >> ((offset as u32 & 3) * 8)) as u8
+                };
+
+                Some(val)
+            }
+            BaseAddress::Mmio { addr, size, .. } => {
+                let dst = *addr + offset;
+                assert!(dst + 1 < *addr + *size);
+                unsafe { Some(read_volatile(dst as *const u8)) }
+            }
+            _ => None,
+        }
+    }
+
     pub fn read16(&self, offset: usize) -> Option<u16> {
         assert_eq!(offset & 1, 0);
         match self {

--- a/awkernel_drivers/src/pcie/config_space.rs
+++ b/awkernel_drivers/src/pcie/config_space.rs
@@ -32,6 +32,35 @@ impl ConfigSpace {
         Some(*base + offset)
     }
 
+    pub fn _read_u8(&self, offset: usize) -> u8 {
+        match self {
+            #[allow(unused_variables)]
+            Self::IO(base) => {
+                #[cfg(feature = "x86")]
+                {
+                    let mut port1 = x86_64::instructions::port::PortWriteOnly::new(0xCF8);
+                    let mut port2 = x86_64::instructions::port::PortReadOnly::new(0xCFC);
+
+                    let addr = *base | ((offset as u32) & 0xfc);
+                    unsafe {
+                        port1.write(addr);
+                        let tmp: u32 = port2.read();
+                        (tmp >> ((offset as u32 & 3) * 8)) as u8
+                    }
+                }
+
+                #[cfg(not(feature = "x86"))]
+                {
+                    unreachable!()
+                }
+            }
+            Self::Mmio(base) => {
+                let addr = *base + offset;
+                unsafe { read_volatile(addr.as_ptr()) }
+            }
+        }
+    }
+
     pub fn read_u16(&self, offset: usize) -> u16 {
         match self {
             #[allow(unused_variables)]


### PR DESCRIPTION
## Description

- add `read8` operation to `BaseAfddress`
- add `_read_u8` operation to `ConfigSpace`
  - to avoid clippy warning, `_` is prefixed

## Related links

## How was this PR tested?

Used in [VirtIO branch](https://github.com/tier4/awkernel/pull/397)

## Notes for reviewers
