### PR TITLE
feat(driver): add VirtIO capability

### DIFF
--- a/awkernel_drivers/src/pcie/capability/virtio.rs
+++ b/awkernel_drivers/src/pcie/capability/virtio.rs
@@ -1,12 +1,52 @@
 use crate::pcie::PCIeInfo;
 
+// Virtio Structure PCI Capabilities
+// struct virtio_pci_cap {
+//     cap_vndr: u8,     // Generic PCI field: PCI_CAP_ID_VNDR
+//     cap_next: u8,     // Generic PCI field: next ptr.
+//     cap_len: u8,      // Generic PCI field: capability length
+//     cfg_type: u8,     // Identifies the structure.
+//     bar: u8,          // Where to find it.
+//     id: u8,           // Multiple capabilities of the same type
+//     padding: [u8; 2], // Pad to full dword.
+//     offset: u32,      // Offset within bar.
+//     length: u32,      // Length of the structure, in bytes.
+// }
+
+const VIRTIO_PCI_CAP_CFG_TYPE: usize = 0x03;
+const VIRTIO_PCI_CAP_BAR: usize = 0x04;
+const VIRTIO_PCI_CAP_OFFSET: usize = 0x08;
+
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct VirtioCap {
-    _cap_ptr: usize,
+    cfg_type: u8,
+    bar: u8,
+    offset: u32,
 }
 
 impl VirtioCap {
-    pub fn new(_info: &PCIeInfo, cap_ptr: usize) -> Self {
-        Self { _cap_ptr: cap_ptr }
+    pub fn new(info: &PCIeInfo, cap_ptr: usize) -> Self {
+        let cfg_type = info.config_space.read_u8(cap_ptr + VIRTIO_PCI_CAP_CFG_TYPE);
+        let bar = info.config_space.read_u8(cap_ptr + VIRTIO_PCI_CAP_BAR);
+        let offset = info.config_space.read_u32(cap_ptr + VIRTIO_PCI_CAP_OFFSET);
+
+        Self {
+            cfg_type,
+            bar,
+            offset,
+        }
+    }
+
+    pub fn _get_cfg_type(&self) -> u8 {
+        self.cfg_type
+    }
+
+    pub fn _get_bar(&self) -> u8 {
+        self.bar
+    }
+
+    pub fn _get_offset(&self) -> u32 {
+        self.offset
     }
 }

--- a/awkernel_drivers/src/pcie/config_space.rs
+++ b/awkernel_drivers/src/pcie/config_space.rs
@@ -32,7 +32,7 @@ impl ConfigSpace {
         Some(*base + offset)
     }
 
-    pub fn _read_u8(&self, offset: usize) -> u8 {
+    pub fn read_u8(&self, offset: usize) -> u8 {
         match self {
             #[allow(unused_variables)]
             Self::IO(base) => {


### PR DESCRIPTION
## Description

Added VirtIO capability.
This is necessary for virtio initialization.

## Related links

VirtIO Spec : https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html
- 4.1.4 Virtio Structure PCI Capabilities

OpenBSD implementation : https://github.com/openbsd/src/blob/d8bca26c1181d3985e71ff51149249b81dec1b9c/sys/dev/pci/virtio_pcireg.h#L42

## How was this PR tested?

Tested in [this branch](https://github.com/tier4/awkernel/pull/397)

## Notes for reviewers
