### PR TITLE
fix(igb): do not reset igb when updating multicast address

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igb.rs
+++ b/awkernel_drivers/src/pcie/intel/igb.rs
@@ -2184,25 +2184,21 @@ impl NetDevice for Igb {
     }
 
     fn remove_multicast_addr(&self, addr: &[u8; 6]) -> Result<(), NetDevError> {
-        let restart;
+        let mut inner = self.inner.write();
+        inner.multicast_addrs.remove_addr(addr);
 
-        {
-            let mut inner = self.inner.write();
-            inner.multicast_addrs.remove_addr(addr);
+        let restart = inner.flags.contains(NetFlags::UP);
 
-            restart = inner.flags.contains(NetFlags::UP);
-
-            if restart {
-                if matches!(
-                    inner.hw.get_mac_type(),
-                    MacType::Em82542Rev2_0 | MacType::Em82542Rev2_1
-                ) {
-                    drop(inner);
-                    self.down()?;
-                    self.up()?;
-                } else {
-                    inner.iff().or(Err(NetDevError::DeviceError))?;
-                }
+        if restart {
+            if matches!(
+                inner.hw.get_mac_type(),
+                MacType::Em82542Rev2_0 | MacType::Em82542Rev2_1
+            ) {
+                drop(inner);
+                self.down()?;
+                self.up()?;
+            } else {
+                inner.iff().or(Err(NetDevError::DeviceError))?;
             }
         }
 


### PR DESCRIPTION
## Description

Current Intel GbE device driver implementation always resets the device when updating multicast address.
However, as FreeBSD implementation, the reset is required for only e1000 82542 series.

This PR changes `igb`'s multicast join and leave methods to eliminate the device reset.

## Related links

- FreeBSD's `em_if_multi_set()`: https://github.com/freebsd/freebsd-src/blob/7121e9414f294d116caeadd07ebd969136d3a631/sys/dev/e1000/if_em.c#L2177-L2182

Reset the device if it is e1000 82542.

```c
	if (sc->hw.mac.type == e1000_82542 &&
	    sc->hw.revision_id == E1000_REVISION_2)
```

## How was this PR tested?

Multicast join and leave on `igb` are work on an x86_64 physical machine as follows..

![スクリーンショット 2025-04-18 18 41 27](https://github.com/user-attachments/assets/ecda4c6f-a990-4a09-b3a0-3bed1e27d7f7)

## Notes for reviewers
