### PR TITLE
feat(driver): implement NetDevice for VirtIO

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -63,8 +63,7 @@ pub fn attach(mut info: PCIeInfo) -> Result<Arc<dyn PCIeDevice + Sync + Send>, P
 
     let result = Arc::new(virtio_net);
 
-    // TODO: add interface
-    // awkernel_lib::net::add_interface(result.clone(), None);
+    awkernel_lib::net::add_interface(result.clone(), None);
 
     Ok(result)
 }


### PR DESCRIPTION
## Description

Implemented `NetDevice` for virtio-net.
Only `mac_address()` is properly implemented. Other methods are not implemented yet.

## Related links

## How was this PR tested?

In KVM, confirmed that virtio-net is initialized

During initialization:
```
[          976 INFO] Waking virtio-net up.
```

`ifconfig` command
```
> (ifconfig)
[0] virtio-net:
    IPv4 address: 
    IPv4 gateway: None
    MAC address: 12:34:56:11:22:34
    Link status: Down, Link speed: 10 Mbps
    Capabilities: 
    IRQs: []
    Poll mode: false
```

## Notes for reviewers
