### PR TITLE
feat(driver): add `VIRTIO_F_VERSION_1` bit to VirtIO

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -109,7 +109,7 @@ impl VirtioNet {
             common_cfg.virtio_set_device_status(VIRTIO_CONFIG_DEVICE_STATUS_FAILED)?;
             return Err(PCIeDeviceErr::InitFailure);
         }
-        if negotiated_features & VIRTIO_F_VERSION_1 != 0 {
+        if negotiated_features & VIRTIO_F_VERSION_1 == 0 {
             common_cfg.virtio_set_device_status(VIRTIO_CONFIG_DEVICE_STATUS_FAILED)?;
             return Err(PCIeDeviceErr::InitFailure);
         }


### PR DESCRIPTION
## Description

Added `VIRTIO_F_VERSION_1` bit

## Related links

VirtIO spec

https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1220001:~:text=VIRTIO_F_VERSION_1(32),devices%20or%20drivers.
> VIRTIO_F_VERSION_1(32)
This indicates compliance with this specification, giving a simple way to detect legacy devices or drivers.

https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1220001:~:text=A%20driver%20MUST%20accept%20VIRTIO_F_VERSION_1%20if%20it%20is%20offered.%20A%20driver%20MAY%20fail%20to%20operate%20further%20if%20VIRTIO_F_VERSION_1%20is%20not%20offered.
> A driver MUST accept VIRTIO_F_VERSION_1 if it is offered. A driver MAY fail to operate further if VIRTIO_F_VERSION_1 is not offered.
A device MUST offer VIRTIO_F_VERSION_1. A device MAY fail to operate further if VIRTIO_F_VERSION_1 is not accepted.

https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1220001:~:text=Transitional%20Drivers%20MUST%20detect%20Legacy%20Devices%20by%20detecting%20that%20the%20feature%20bit%20VIRTIO_F_VERSION_1%20is%20not%20offered.%20Transitional%20devices%20MUST%20detect%20Legacy%20drivers%20by%20detecting%20that%20VIRTIO_F_VERSION_1%20has%20not%20been%20acknowledged%20by%20the%20driver.
> Transitional Drivers MUST detect Legacy Devices by detecting that the feature bit VIRTIO_F_VERSION_1 is not offered. Transitional devices MUST detect Legacy drivers by detecting that VIRTIO_F_VERSION_1 has not been acknowledged by the driver.


OpenBSD

https://github.com/openbsd/src/blob/73df8e5b9b658928ec5b34188870de3ada00d9f1/sys/dev/pv/virtioreg.h#L92
```
#define  VIRTIO_F_VERSION_1			(1ULL<<32)
```

https://github.com/openbsd/src/blob/73df8e5b9b658928ec5b34188870de3ada00d9f1/sys/dev/pci/virtio_pci.c#L851
```
vsc->sc_driver_features |= VIRTIO_F_VERSION_1;
```

https://github.com/openbsd/src/blob/73df8e5b9b658928ec5b34188870de3ada00d9f1/sys/dev/pci/virtio_pci.c#L889C2-L895C3
```
        if ((negotiated & VIRTIO_F_VERSION_1) == 0) {
#if VIRTIO_DEBUG
		printf("%s: Host rejected Version_1\n", __func__);
#endif
		CWRITE(sc, device_status, VIRTIO_CONFIG_DEVICE_STATUS_FAILED);
		return EINVAL;
	}
```

## How was this PR tested?

## Notes for reviewers
