### PR TITLE
fix(logger): initialize the logger in `register_console()`

### DIFF
--- a/awkernel_lib/src/console.rs
+++ b/awkernel_lib/src/console.rs
@@ -151,7 +151,14 @@ pub fn register_console(console: Box<dyn Console>) {
     let mut node = MCSNode::new();
     let mut c = CONSOLE.console.lock(&mut node);
 
+    if c.is_some() {
+        return;
+    }
+
     *c = Some(console);
+
+    // Initialize the logger.
+    unsafe { crate::logger::init() };
 
     crate::logger::set_raw_console(&CONSOLE);
     log::set_max_level(log::LevelFilter::Debug);

--- a/kernel/src/arch/aarch64/kernel_main.rs
+++ b/kernel/src/arch/aarch64/kernel_main.rs
@@ -55,10 +55,8 @@ pub unsafe extern "C" fn kernel_main(device_tree_base: usize) -> ! {
 /// 5. Enable heap allocator.
 /// 6. Board specific initialization (Interrupt controller, etc).
 unsafe fn primary_cpu(device_tree_base: usize) {
-    unsafe {
-        awkernel_lib::logger::init();
-        crate::config::init();
-    }
+    unsafe { crate::config::init() };
+
     let device_tree = load_device_tree(device_tree_base);
     let mut initializer = super::bsp::SoCInitializer::new(device_tree, device_tree_base);
 

--- a/kernel/src/arch/std_common/kernel_main.rs
+++ b/kernel/src/arch/std_common/kernel_main.rs
@@ -8,10 +8,7 @@ use libc::c_void;
 #[no_mangle]
 pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     // Initialize.
-    unsafe {
-        crate::config::init();
-        awkernel_lib::logger::init();
-    }
+    unsafe { crate::config::init() };
     awkernel_lib::arch::std_common::init();
     awkernel_lib::arch::std_common::init_per_thread(0);
     console::init();

--- a/kernel/src/arch/x86_64/kernel_main.rs
+++ b/kernel/src/arch/x86_64/kernel_main.rs
@@ -141,7 +141,6 @@ fn kernel_main2(
     backup_next_frame: Option<PhysFrame>,
 ) {
     // 5. Enable logger.
-    unsafe { awkernel_lib::logger::init() };
     super::console::register_console();
 
     log::info!(


### PR DESCRIPTION
## Description

In AArch64 environments, `crate::logger::init()` is called before initializing virtual memory regions.
To guarantee that `crate::logger::init()` is called after the initialization, this PR calls `crate::logger::init()` in `register_console()`.

## Related links

## How was this PR tested?

It works on my Raspberry Pi 4.
(It did not work on Raspberry Pi 4.)

## Notes for reviewers
