### PR TITLE
feat(igc): implement `igc_init_hw_base()` and related functions

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc/i225.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/i225.rs
@@ -4,8 +4,8 @@ use crate::pcie::PCIeInfo;
 
 use super::{
     igc_base::{
-        igc_acquire_phy_base, igc_power_down_phy_copper_base, igc_release_phy_base,
-        IGC_RAR_ENTRIES_BASE,
+        igc_acquire_phy_base, igc_init_hw_base, igc_power_down_phy_copper_base,
+        igc_release_phy_base, IGC_RAR_ENTRIES_BASE,
     },
     igc_defines::*,
     igc_hw::{
@@ -59,6 +59,10 @@ impl IgcMacOperations for I225Flash {
 
     fn setup_link(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
         igc_setup_link_generic(self, info, hw)
+    }
+
+    fn init_hw(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
+        igc_init_hw_base(self, info, hw)
     }
 }
 
@@ -183,6 +187,10 @@ impl IgcMacOperations for I225NoFlash {
 
     fn setup_link(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
         igc_setup_link_generic(self, info, hw)
+    }
+
+    fn init_hw(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
+        igc_init_hw_base(self, info, hw)
     }
 }
 

--- a/awkernel_drivers/src/pcie/intel/igc/igc_base.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_base.rs
@@ -3,8 +3,10 @@ use crate::pcie::PCIeInfo;
 use super::{
     igc_defines::{IGC_SWFW_PHY0_SM, IGC_SWFW_PHY1_SM},
     igc_hw::{IgcHw, IgcOperations, IGC_FUNC_1},
+    igc_mac::igc_init_rx_addrs_generic,
     igc_phy::igc_power_down_phy_copper,
-    IgcDriverErr,
+    igc_regs::*,
+    read_reg, write_reg_array, IgcDriverErr,
 };
 
 pub(super) const IGC_RAR_ENTRIES_BASE: u16 = 16;
@@ -49,6 +51,82 @@ pub(super) fn igc_power_down_phy_copper_base(
     if ops.check_reset_block(info).is_ok() {
         igc_power_down_phy_copper(ops, info, hw)?;
     }
+
+    Ok(())
+}
+
+/// This inits the hardware readying it for operation.
+pub(super) fn igc_init_hw_base(
+    ops: &dyn IgcOperations,
+    info: &mut PCIeInfo,
+    hw: &mut IgcHw,
+) -> Result<(), IgcDriverErr> {
+    // Setup the receive address
+    igc_init_rx_addrs_generic(ops, info, hw, hw.mac.rar_entry_count)?;
+
+    // Zero out the Multicast HASH table
+    for i in 0..hw.mac.mta_reg_count {
+        write_reg_array(info, IGC_MTA, i as usize, 0)?;
+    }
+
+    // Zero out the Unicast HASH table
+    for i in 0..hw.mac.uta_reg_count {
+        write_reg_array(info, IGC_UTA, i as usize, 0)?;
+    }
+
+    // Setup link and flow control
+    ops.setup_link(info, hw)?;
+
+    // Clear all of the statistics registers (clear on read).  It is
+    // important that we do this after we have tried to establish link
+    // because the symbol error count will increment wildly if there
+    // is no link.
+    igc_clear_hw_cntrs_base_generic(info)?;
+
+    Ok(())
+}
+
+/// Clears the base hardware counters by reading the counter registers.
+fn igc_clear_hw_cntrs_base_generic(info: &mut PCIeInfo) -> Result<(), IgcDriverErr> {
+    read_reg(info, IGC_CRCERRS)?;
+    read_reg(info, IGC_MPC)?;
+    read_reg(info, IGC_SCC)?;
+    read_reg(info, IGC_ECOL)?;
+    read_reg(info, IGC_MCC)?;
+    read_reg(info, IGC_LATECOL)?;
+    read_reg(info, IGC_COLC)?;
+    read_reg(info, IGC_RERC)?;
+    read_reg(info, IGC_DC)?;
+    read_reg(info, IGC_RLEC)?;
+    read_reg(info, IGC_XONRXC)?;
+    read_reg(info, IGC_XONTXC)?;
+    read_reg(info, IGC_XOFFRXC)?;
+    read_reg(info, IGC_XOFFTXC)?;
+    read_reg(info, IGC_FCRUC)?;
+    read_reg(info, IGC_GPRC)?;
+    read_reg(info, IGC_BPRC)?;
+    read_reg(info, IGC_MPRC)?;
+    read_reg(info, IGC_GPTC)?;
+    read_reg(info, IGC_GORCL)?;
+    read_reg(info, IGC_GORCH)?;
+    read_reg(info, IGC_GOTCL)?;
+    read_reg(info, IGC_GOTCH)?;
+    read_reg(info, IGC_RNBC)?;
+    read_reg(info, IGC_RUC)?;
+    read_reg(info, IGC_RFC)?;
+    read_reg(info, IGC_ROC)?;
+    read_reg(info, IGC_RJC)?;
+    read_reg(info, IGC_TORL)?;
+    read_reg(info, IGC_TORH)?;
+    read_reg(info, IGC_TOTL)?;
+    read_reg(info, IGC_TOTH)?;
+    read_reg(info, IGC_TPR)?;
+    read_reg(info, IGC_TPT)?;
+    read_reg(info, IGC_MPTC)?;
+    read_reg(info, IGC_BPTC)?;
+    read_reg(info, IGC_TLPIC)?;
+    read_reg(info, IGC_RLPIC)?;
+    read_reg(info, IGC_RXDMTC)?;
 
     Ok(())
 }

--- a/awkernel_drivers/src/pcie/intel/igc/igc_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_hw.rs
@@ -80,7 +80,7 @@ pub(super) struct IgcMacInfo {
     ifs_ratio: u16,
     ifs_step_size: u16,
     pub(super) mta_reg_count: u16,
-    uta_reg_count: u16,
+    pub(super) uta_reg_count: u16,
 
     mta_shadow: MtaShadow,
     pub(super) rar_entry_count: u16,
@@ -279,9 +279,8 @@ pub(super) trait IgcMacOperations {
     fn reset_hw(&self, _info: &mut PCIeInfo, _hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
         todo!()
     }
-    fn init_hw(&self, _info: &mut PCIeInfo, _hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
-        todo!()
-    }
+
+    fn init_hw(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr>;
 
     fn setup_link(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr>;
 

--- a/awkernel_drivers/src/pcie/intel/igc/igc_mac.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_mac.rs
@@ -181,3 +181,26 @@ fn igc_set_fc_watermarks_generic(info: &mut PCIeInfo, hw: &IgcHw) -> Result<(), 
 
     Ok(())
 }
+
+/// Setup the receive address registers by setting the base receive address
+/// register to the devices MAC address and clearing all the other receive
+/// address registers to 0.
+pub(super) fn igc_init_rx_addrs_generic(
+    ops: &dyn IgcOperations,
+    info: &mut PCIeInfo,
+    hw: &mut IgcHw,
+    rar_count: u16,
+) -> Result<(), IgcDriverErr> {
+    // Setup the receive address
+
+    let mac_addr = hw.mac.addr;
+    ops.rar_set(info, hw, &mac_addr, 0)?;
+
+    // Zero out the other (rar_entry_count - 1) receive addresses
+    let mac_addr = [0; ETHER_ADDR_LEN];
+    for i in 1..rar_count {
+        ops.rar_set(info, hw, &mac_addr, i as usize)?;
+    }
+
+    Ok(())
+}

--- a/awkernel_drivers/src/pcie/intel/igc/igc_regs.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_regs.rs
@@ -292,3 +292,22 @@ pub(super) const IGC_SW_FW_SYNC: usize = 0x05B5C; // SW-FW Synchronization - RW
 pub(super) const IGC_FACTPS: usize = 0x05B30;
 pub(super) const IGC_SWSM: usize = 0x05B50; // SW Semaphore
 pub(super) const IGC_FWSM: usize = 0x05B54; // FW Semaphore
+
+// RSS registers
+pub(super) const IGC_MRQC: usize = 0x05818; // Multiple Receive Control - RW
+
+// Redirection Table - RW Array
+pub(super) const IGC_RETA: fn(usize) -> usize = |i| 0x05C00 + (i * 4);
+
+// RSS Random Key - RW Array
+pub(super) const IGC_RSSRK: fn(usize) -> usize = |i| 0x05C80 + (i * 4);
+pub(super) const IGC_UTA: usize = 0x0A000; // Unicast Table Array - RW
+
+// Energy Efficient Ethernet "EEE" registers
+pub(super) const IGC_IPCNFG: usize = 0x0E38; // Internal PHY Configuration
+pub(super) const IGC_LTRC: usize = 0x01A0; // Latency Tolerance Reporting Control
+pub(super) const IGC_EEER: usize = 0x0E30; // Energy Efficient Ethernet "EEE"
+pub(super) const IGC_EEE_SU: usize = 0x0E34; // EEE Setup
+pub(super) const IGC_EEE_SU_2P5: usize = 0x0E3C; // EEE 2.5G Setup
+pub(super) const IGC_TLPIC: usize = 0x4148; // EEE Tx LPI Count - TLPIC
+pub(super) const IGC_RLPIC: usize = 0x414C; // EEE Rx LPI Count - RLPIC


### PR DESCRIPTION
## Description

Implement `igc_init_hw_base()` and related functions.

## Related links

- OpenBSD's `igc_init_hw_base()`: https://github.com/openbsd/src/blob/c9362caa18fd5813dcfe5d1675eb64b65c1d0a28/sys/dev/pci/igc_base.c#L58
- OpenBSD's `igc_clear_hw_cntrs_base_generic()`: https://github.com/openbsd/src/blob/c9362caa18fd5813dcfe5d1675eb64b65c1d0a28/sys/dev/pci/igc_mac.c#L308
- OpenBSD's `igc_init_rx_addrs_generic()`: https://github.com/openbsd/src/blob/c9362caa18fd5813dcfe5d1675eb64b65c1d0a28/sys/dev/pci/igc_mac.c#L67
- OpenBSD's `igc_init_hw_i225()`: https://github.com/openbsd/src/blob/c9362caa18fd5813dcfe5d1675eb64b65c1d0a28/sys/dev/pci/igc_i225.c#L1090C1-L1090C17
- OpenBSD's `igc_init_mac_params_i225()`: https://github.com/openbsd/src/blob/c9362caa18fd5813dcfe5d1675eb64b65c1d0a28/sys/dev/pci/igc_i225.c#L101
- issue #335 

## How was this PR tested?

## Notes for reviewers
