### PR TITLE
feat(qemu): enable modern VirtIO in qemu-x86_64-net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ QEMU_X86_NET_ARGS+= -netdev user,id=net0,hostfwd=udp::4445-:2000
 QEMU_X86_NET_ARGS+= -device e1000e,netdev=net0,mac=12:34:56:11:22:33
 QEMU_X86_NET_ARGS+= -object filter-dump,id=net0,netdev=net0,file=packets_net0.pcap
 QEMU_X86_NET_ARGS+= -netdev user,id=net1,hostfwd=udp::4446-:2001
-QEMU_X86_NET_ARGS+= -device virtio-net-pci,netdev=net1,mac=12:34:56:11:22:34
+QEMU_X86_NET_ARGS+= -device virtio-net-pci,netdev=net1,mac=12:34:56:11:22:34,disable-legacy=on,disable-modern=off
 QEMU_X86_NET_ARGS+= -object filter-dump,id=net1,netdev=net1,file=packets_net1.pcap
 
 tcp-dump:


### PR DESCRIPTION
## Description

Enabled modern VirtIO in `QEMU_X86_NET`

## Related links

## How was this PR tested?

Confirmed that VirtIO PCIe is recognized at initialization.

## Notes for reviewers
