### PR TITLE
feat(virtio): implement down()

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -238,14 +238,14 @@ impl VirtioNetInner {
         Ok(())
     }
 
-    // To reset the device to a known state, do following:
-    //	 virtio_reset();              // this will stop the device activity
-    //	 <dequeue finished requests>; // virtio_dequeue() still can be called
-    //	 <revoke pending requests in the vqs if any>;
-    //	 virtio_reinit_start();       // dequeue prohibited
-    //	 <some other initialization>;
-    //	 virtio_reinit_end();         // device activated; enqueue allowed
-    // Once attached, features are assumed to not change again.
+    /// To reset the device to a known state, do following:
+    ///  virtio_reset();              // this will stop the device activity
+    ///  <dequeue finished requests>; // virtio_dequeue() still can be called
+    ///  <revoke pending requests in the vqs if any>;
+    ///  virtio_reinit_start();       // dequeue prohibited
+    ///  <some other initialization>;
+    ///  virtio_reinit_end();         // device activated; enqueue allowed
+    /// Once attached, features are assumed to not change again.
     fn virtio_reset(&mut self) -> Result<(), VirtioDriverErr> {
         self.common_cfg
             .virtio_set_device_status(VIRTIO_CONFIG_DEVICE_STATUS_RESET)?;


### PR DESCRIPTION
## Description

Implemented `down()` method for VirtIO net.

## Related links

OpenBSD functions
[vio_stop()](https://github.com/openbsd/src/blob/b108d39a11662389e517f1f530d8bc03d7231ea2/sys/dev/pv/if_vio.c#L1010)
[virtio_reset()](https://github.com/openbsd/src/blob/b108d39a11662389e517f1f530d8bc03d7231ea2/sys/dev/pv/virtio.c#L151)
[virtio_reinit_start()](https://github.com/openbsd/src/blob/b108d39a11662389e517f1f530d8bc03d7231ea2/sys/dev/pv/virtio.c#L179)
[virtio_reinit_end()](https://github.com/openbsd/src/blob/b108d39a11662389e517f1f530d8bc03d7231ea2/sys/dev/pv/virtio.c#L203C1-L203C18)

## How was this PR tested?

## Notes for reviewers
