### PR TITLE
feat: time related functions

### DIFF
--- a/applications/rd_gen_to_dags/Cargo.toml
+++ b/applications/rd_gen_to_dags/Cargo.toml
@@ -12,12 +12,19 @@ serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 path = "../../awkernel_lib"
 default-features = false
 
-[features]
-default = []
-x86 = ["awkernel_lib/x86"]
-aarch64 = ["awkernel_lib/aarch64"]
-rv32 = ["awkernel_lib/rv32"]
-rv64 = ["awkernel_lib/rv64"]
-std = ["awkernel_lib/std"]
+[dependencies.awkernel_async_lib]
+path = "../../awkernel_async_lib"
+default-features = false
 
+[features]
+default = ["milliseconds"]
+
+# Time Unit 
+seconds = []
+milliseconds = []
+microseconds = []
+nanoseconds = []
+
+# For test
+std = ["awkernel_lib/std", "awkernel_async_lib/std"]
 

--- a/applications/rd_gen_to_dags/src/lib.rs
+++ b/applications/rd_gen_to_dags/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate alloc;
 
 mod parse_yaml;
+mod time_unit;
 
 use awkernel_lib::delay::wait_millisec;
 

--- a/applications/rd_gen_to_dags/src/time_unit.rs
+++ b/applications/rd_gen_to_dags/src/time_unit.rs
@@ -1,0 +1,67 @@
+// TODO: Remove allow(dead_code).
+#![allow(dead_code)]
+
+use awkernel_lib::delay::wait_millisec;
+use core::time::Duration;
+
+#[cfg(feature = "seconds")]
+pub(super) fn convert_duration(duration: u64) -> Duration {
+    Duration::from_secs(duration)
+}
+
+#[cfg(feature = "milliseconds")]
+pub(super) fn convert_duration(duration: u64) -> Duration {
+    Duration::from_millis(duration)
+}
+
+#[cfg(feature = "microseconds")]
+pub(super) fn convert_duration(duration: u64) -> Duration {
+    Duration::from_micros(duration)
+}
+
+#[cfg(feature = "nanoseconds")]
+pub(super) fn convert_duration(duration: u64) -> Duration {
+    Duration::from_nanos(duration)
+}
+
+// default
+#[cfg(not(any(
+    feature = "seconds",
+    feature = "milliseconds",
+    feature = "microseconds",
+    feature = "nanoseconds"
+)))]
+pub(super) fn convert_duration(duration: u64) -> Duration {
+    Duration::from_millis(duration)
+}
+
+#[cfg(feature = "seconds")]
+pub(super) fn simulated_execution_time(duration: u64) {
+    wait_millisec(duration * 1000);
+}
+
+#[cfg(feature = "milliseconds")]
+pub(super) fn simulated_execution_time(duration: u64) {
+    wait_millisec(duration);
+}
+
+#[cfg(feature = "microseconds")]
+pub(super) fn simulated_execution_time(duration: u64) {
+    wait_millisec(duration / 1000);
+}
+
+#[cfg(feature = "nanoseconds")]
+pub(super) fn simulated_execution_time(duration: u64) {
+    wait_millisec(duration / 1000000);
+}
+
+// default
+#[cfg(not(any(
+    feature = "seconds",
+    feature = "milliseconds",
+    feature = "microseconds",
+    feature = "nanoseconds"
+)))]
+pub(super) fn simulated_execution_time(duration: u64) -> u64 {
+    duration
+}


### PR DESCRIPTION
## Description
Implement conversion and provisional runtime functions.
To provide optimal processing according to the granularity of time (seconds, milliseconds, microseconds, nanoseconds), versions for each unit of time are conditionally compiled using the feature flags.
The default is `milliseconds`, which can be changed in `applications/rd_gen_to_dags/Cargo.toml` features. 

## Related links
[Ticket](https://tier4.atlassian.net/browse/RT2-2335)
[#427](https://github.com/tier4/awkernel/pull/427)

## How was this PR tested?
None.

## Notes for reviewers

- In #427, the method was to specify by static variables in the same file. However, this PR implementation has been changed in terms of code optimization and centralized management of settings.
- `#! [allow(dead_code)]` is temporary.