### PR TITLE
fix: make test warning

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,7 +9,7 @@ test_awkernel_lib = "test --package awkernel_lib --no-default-features --feature
 test_awkernel_async_lib = "test --package awkernel_async_lib --no-default-features --features std"
 test_awkernel_drivers = "test --package awkernel_drivers --no-default-features --features std"
 test_smoltcp = "test --package smoltcp --no-default-features --features std --features awkernel"
-test_rd_gen_to_dags = "test --package rd_gen_to_dags --no-default-features --features std"
+test_rd_gen_to_dags = "test --package rd_gen_to_dags --no-default-features --features std --features milliseconds"
 
 clippy_x86 = "clippy --package awkernel --no-default-features --features x86 --target targets/x86_64-kernel.json -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem"
 clippy_raspi = "clippy --package awkernel --no-default-features --features raspi --target targets/aarch64-kernel.json -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem"


### PR DESCRIPTION
## Description
Fixed warnings during make test.
Added “milliseconds” to features.
```
warning: unused import: `awkernel_lib::delay::wait_millisec`
 --> applications/rd_gen_to_dags/src/time_unit.rs:four:5
  |
4 | use awkernel_lib::delay::wait_millisec;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `rd_gen_to_dags` (lib) generated 1 warning (run `cargo fix --lib -p rd_gen_to_dags` to apply 1 suggestion)
warning: `rd_gen_to_dags` (lib test) generated 1 warning (1 duplicate)
```

## Related links
https://star4.slack.com/archives/C054R6DL5KL/p1747129564335309
## How was this PR tested?

```
$ make test

cargo test_rd_gen_to_dags
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/rd_gen_to_dags-ef2b7bed82af3376)

running 1 test
test parse_yaml::tests::test_parse_dag ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests rd_gen_to_dags

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Notes for reviewers
