### PR TITLE
Update rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,4 +71,4 @@ jobs:
         run: make udeps
 
       - name: test
-        run: make test
+        run: RUSTFLAGS="-D warnings" make test


### PR DESCRIPTION
## Description

To detect warnings during GitHub Actions, run `RUSTFLAGS="-D warnings" make test` instead of `make test`.

## Related links

## How was this PR tested?

## Notes for reviewers
