### PR TITLE
feat(igc): implement `igc_config_fc_after_link_up_generic` and related

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc/i225.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/i225.rs
@@ -14,7 +14,8 @@ use super::{
     },
     igc_mac::{
         igc_check_alt_mac_addr_generic, igc_disable_pcie_master_generic,
-        igc_get_auto_rd_done_generic, igc_put_hw_semaphore_generic, igc_setup_link_generic,
+        igc_get_auto_rd_done_generic, igc_get_speed_and_duplex_copper_generic,
+        igc_put_hw_semaphore_generic, igc_setup_link_generic,
     },
     igc_nvm::{acquire_nvm, igc_read_nvm_eerd, igc_validate_nvm_checksum_generic},
     igc_phy::{
@@ -33,6 +34,14 @@ impl IgcMacOperations for I225Flash {
     fn init_params(&self, _info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
         igc_init_mac_params_i225(hw);
         Ok(())
+    }
+
+    fn get_link_up_info(
+        &self,
+        info: &mut PCIeInfo,
+        hw: &mut IgcHw,
+    ) -> Result<(IgcSpeed, IgcDuplex), IgcDriverErr> {
+        igc_get_speed_and_duplex_copper_generic(info, hw)
     }
 
     fn reset_hw(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
@@ -161,6 +170,14 @@ impl IgcMacOperations for I225NoFlash {
     fn init_params(&self, _info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
         igc_init_mac_params_i225(hw);
         Ok(())
+    }
+
+    fn get_link_up_info(
+        &self,
+        info: &mut PCIeInfo,
+        hw: &mut IgcHw,
+    ) -> Result<(IgcSpeed, IgcDuplex), IgcDriverErr> {
+        igc_get_speed_and_duplex_copper_generic(info, hw)
     }
 
     fn reset_hw(&self, info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {

--- a/awkernel_drivers/src/pcie/intel/igc/igc_defines.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_defines.rs
@@ -176,12 +176,19 @@ pub(super) const IGC_STATUS_2P5_SKU: u32 = 0x00001000; // Val of 2.5GBE SKU stra
 pub(super) const IGC_STATUS_2P5_SKU_OVER: u32 = 0x00002000; // Val of 2.5GBE SKU Over
 pub(super) const IGC_STATUS_PCIM_STATE: u32 = 0x40000000; // PCIm function state
 
-pub(super) const SPEED_10: u32 = 10;
-pub(super) const SPEED_100: u32 = 100;
-pub(super) const SPEED_1000: u32 = 1000;
-pub(super) const SPEED_2500: u32 = 2500;
-pub(super) const HALF_DUPLEX: u32 = 1;
-pub(super) const FULL_DUPLEX: u32 = 2;
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum IgcSpeed {
+    Speed10 = 10,
+    Speed100 = 100,
+    Speed1000 = 1000,
+    Speed2500 = 2500,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum IgcDuplex {
+    Half = 1,
+    Full = 2,
+}
 
 pub(super) const ADVERTISE_10_HALF: u16 = 0x0001;
 pub(super) const ADVERTISE_10_FULL: u16 = 0x0002;
@@ -499,46 +506,46 @@ pub(super) const MII_CR_SPEED_100: u16 = 0x2000;
 pub(super) const MII_CR_SPEED_10: u16 = 0x0000;
 
 // PHY Status Register
-pub(super) const MII_SR_EXTENDED_CAPS: u32 = 0x0001; // Extended register capabilities
-pub(super) const MII_SR_JABBER_DETECT: u32 = 0x0002; // Jabber Detected
-pub(super) const MII_SR_LINK_STATUS: u32 = 0x0004; // Link Status 1 = link
-pub(super) const MII_SR_AUTONEG_CAPS: u32 = 0x0008; // Auto Neg Capable
-pub(super) const MII_SR_REMOTE_FAULT: u32 = 0x0010; // Remote Fault Detect
-pub(super) const MII_SR_AUTONEG_COMPLETE: u32 = 0x0020; // Auto Neg Complete
-pub(super) const MII_SR_PREAMBLE_SUPPRESS: u32 = 0x0040; // Preamble may be suppressed
-pub(super) const MII_SR_EXTENDED_STATUS: u32 = 0x0100; // Ext. status info in Reg 0x0F
-pub(super) const MII_SR_100T2_HD_CAPS: u32 = 0x0200; // 100T2 Half Duplex Capable
-pub(super) const MII_SR_100T2_FD_CAPS: u32 = 0x0400; // 100T2 Full Duplex Capable
-pub(super) const MII_SR_10T_HD_CAPS: u32 = 0x0800; // 10T   Half Duplex Capable
-pub(super) const MII_SR_10T_FD_CAPS: u32 = 0x1000; // 10T   Full Duplex Capable
-pub(super) const MII_SR_100X_HD_CAPS: u32 = 0x2000; // 100X  Half Duplex Capable
-pub(super) const MII_SR_100X_FD_CAPS: u32 = 0x4000; // 100X  Full Duplex Capable
-pub(super) const MII_SR_100T4_CAPS: u32 = 0x8000; // 100T4 Capable
+pub(super) const MII_SR_EXTENDED_CAPS: u16 = 0x0001; // Extended register capabilities
+pub(super) const MII_SR_JABBER_DETECT: u16 = 0x0002; // Jabber Detected
+pub(super) const MII_SR_LINK_STATUS: u16 = 0x0004; // Link Status 1 = link
+pub(super) const MII_SR_AUTONEG_CAPS: u16 = 0x0008; // Auto Neg Capable
+pub(super) const MII_SR_REMOTE_FAULT: u16 = 0x0010; // Remote Fault Detect
+pub(super) const MII_SR_AUTONEG_COMPLETE: u16 = 0x0020; // Auto Neg Complete
+pub(super) const MII_SR_PREAMBLE_SUPPRESS: u16 = 0x0040; // Preamble may be suppressed
+pub(super) const MII_SR_EXTENDED_STATUS: u16 = 0x0100; // Ext. status info in Reg 0x0F
+pub(super) const MII_SR_100T2_HD_CAPS: u16 = 0x0200; // 100T2 Half Duplex Capable
+pub(super) const MII_SR_100T2_FD_CAPS: u16 = 0x0400; // 100T2 Full Duplex Capable
+pub(super) const MII_SR_10T_HD_CAPS: u16 = 0x0800; // 10T   Half Duplex Capable
+pub(super) const MII_SR_10T_FD_CAPS: u16 = 0x1000; // 10T   Full Duplex Capable
+pub(super) const MII_SR_100X_HD_CAPS: u16 = 0x2000; // 100X  Half Duplex Capable
+pub(super) const MII_SR_100X_FD_CAPS: u16 = 0x4000; // 100X  Full Duplex Capable
+pub(super) const MII_SR_100T4_CAPS: u16 = 0x8000; // 100T4 Capable
 
 // Autoneg Advertisement Register
-pub(super) const NWAY_AR_SELECTOR_FIELD: u32 = 0x0001; // indicates IEEE 802.3 CSMA/CD
-pub(super) const NWAY_AR_10T_HD_CAPS: u32 = 0x0020; // 10T   Half Duplex Capable
-pub(super) const NWAY_AR_10T_FD_CAPS: u32 = 0x0040; // 10T   Full Duplex Capable
-pub(super) const NWAY_AR_100TX_HD_CAPS: u32 = 0x0080; // 100TX Half Duplex Capable
-pub(super) const NWAY_AR_100TX_FD_CAPS: u32 = 0x0100; // 100TX Full Duplex Capable
-pub(super) const NWAY_AR_100T4_CAPS: u32 = 0x0200; // 100T4 Capable
-pub(super) const NWAY_AR_PAUSE: u32 = 0x0400; // Pause operation desired
-pub(super) const NWAY_AR_ASM_DIR: u32 = 0x0800; // Asymmetric Pause Direction bit
-pub(super) const NWAY_AR_REMOTE_FAULT: u32 = 0x2000; // Remote Fault detected
-pub(super) const NWAY_AR_NEXT_PAGE: u32 = 0x8000; // Next Page ability supported
+pub(super) const NWAY_AR_SELECTOR_FIELD: u16 = 0x0001; // indicates IEEE 802.3 CSMA/CD
+pub(super) const NWAY_AR_10T_HD_CAPS: u16 = 0x0020; // 10T   Half Duplex Capable
+pub(super) const NWAY_AR_10T_FD_CAPS: u16 = 0x0040; // 10T   Full Duplex Capable
+pub(super) const NWAY_AR_100TX_HD_CAPS: u16 = 0x0080; // 100TX Half Duplex Capable
+pub(super) const NWAY_AR_100TX_FD_CAPS: u16 = 0x0100; // 100TX Full Duplex Capable
+pub(super) const NWAY_AR_100T4_CAPS: u16 = 0x0200; // 100T4 Capable
+pub(super) const NWAY_AR_PAUSE: u16 = 0x0400; // Pause operation desired
+pub(super) const NWAY_AR_ASM_DIR: u16 = 0x0800; // Asymmetric Pause Direction bit
+pub(super) const NWAY_AR_REMOTE_FAULT: u16 = 0x2000; // Remote Fault detected
+pub(super) const NWAY_AR_NEXT_PAGE: u16 = 0x8000; // Next Page ability supported
 
 // Link Partner Ability Register (Base Page)
-pub(super) const NWAY_LPAR_SELECTOR_FIELD: u32 = 0x0000; // LP protocol selector field
-pub(super) const NWAY_LPAR_10T_HD_CAPS: u32 = 0x0020; // LP 10T Half Dplx Capable
-pub(super) const NWAY_LPAR_10T_FD_CAPS: u32 = 0x0040; // LP 10T Full Dplx Capable
-pub(super) const NWAY_LPAR_100TX_HD_CAPS: u32 = 0x0080; // LP 100TX Half Dplx Capable
-pub(super) const NWAY_LPAR_100TX_FD_CAPS: u32 = 0x0100; // LP 100TX Full Dplx Capable
-pub(super) const NWAY_LPAR_100T4_CAPS: u32 = 0x0200; // LP is 100T4 Capable
-pub(super) const NWAY_LPAR_PAUSE: u32 = 0x0400; // LP Pause operation desired
-pub(super) const NWAY_LPAR_ASM_DIR: u32 = 0x0800; // LP Asym Pause Direction bit
-pub(super) const NWAY_LPAR_REMOTE_FAULT: u32 = 0x2000; // LP detected Remote Fault
-pub(super) const NWAY_LPAR_ACKNOWLEDGE: u32 = 0x4000; // LP rx'd link code word
-pub(super) const NWAY_LPAR_NEXT_PAGE: u32 = 0x8000; // Next Page ability supported
+pub(super) const NWAY_LPAR_SELECTOR_FIELD: u16 = 0x0000; // LP protocol selector field
+pub(super) const NWAY_LPAR_10T_HD_CAPS: u16 = 0x0020; // LP 10T Half Dplx Capable
+pub(super) const NWAY_LPAR_10T_FD_CAPS: u16 = 0x0040; // LP 10T Full Dplx Capable
+pub(super) const NWAY_LPAR_100TX_HD_CAPS: u16 = 0x0080; // LP 100TX Half Dplx Capable
+pub(super) const NWAY_LPAR_100TX_FD_CAPS: u16 = 0x0100; // LP 100TX Full Dplx Capable
+pub(super) const NWAY_LPAR_100T4_CAPS: u16 = 0x0200; // LP is 100T4 Capable
+pub(super) const NWAY_LPAR_PAUSE: u16 = 0x0400; // LP Pause operation desired
+pub(super) const NWAY_LPAR_ASM_DIR: u16 = 0x0800; // LP Asym Pause Direction bit
+pub(super) const NWAY_LPAR_REMOTE_FAULT: u16 = 0x2000; // LP detected Remote Fault
+pub(super) const NWAY_LPAR_ACKNOWLEDGE: u16 = 0x4000; // LP rx'd link code word
+pub(super) const NWAY_LPAR_NEXT_PAGE: u16 = 0x8000; // Next Page ability supported
 
 // Autoneg Expansion Register
 pub(super) const NWAY_ER_LP_NWAY_CAPS: u32 = 0x0001; // LP has Auto Neg Capability

--- a/awkernel_drivers/src/pcie/intel/igc/igc_hw.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_hw.rs
@@ -266,9 +266,13 @@ pub(super) trait IgcMacOperations {
     fn check_for_link(&self, _info: &mut PCIeInfo, _hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
         todo!()
     }
-    fn get_link_up_info(&self, _info: &mut PCIeInfo, _hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
-        todo!()
-    }
+
+    fn get_link_up_info(
+        &self,
+        info: &mut PCIeInfo,
+        hw: &mut IgcHw,
+    ) -> Result<(IgcSpeed, IgcDuplex), IgcDriverErr>;
+
     fn update_mc_addr_list(
         &self,
         _info: &mut PCIeInfo,


### PR DESCRIPTION
## Description

Implement following functions.

- `igc_config_fc_after_link_up_generic()`
- `igc_force_mac_fc_generic()`
- `igc_get_speed_and_duplex_copper_generic()`

## Related links

- OpenBSD's `igc_config_fc_after_link_up_generic()`: https://github.com/openbsd/src/blob/f84e98ba7169fc5f1e7ebd5fdc41347d7be55f4a/sys/dev/pci/igc_mac.c#L545
-  OpenBSD's `igc_force_mac_fc_generic()`: https://github.com/openbsd/src/blob/f84e98ba7169fc5f1e7ebd5fdc41347d7be55f4a/sys/dev/pci/igc_mac.c#L482
-  OpenBSD's `igc_get_speed_and_duplex_copper_generic()`: https://github.com/openbsd/src/blob/f84e98ba7169fc5f1e7ebd5fdc41347d7be55f4a/sys/dev/pci/igc_mac.c#L709
- OpenBSD's `igc_init_mac_params_i225()`: https://github.com/openbsd/src/blob/f84e98ba7169fc5f1e7ebd5fdc41347d7be55f4a/sys/dev/pci/igc_i225.c#L107
- issue #335 

## How was this PR tested?

## Notes for reviewers
