### PR TITLE
feat(igc): implement `igc_update_link_status()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -488,6 +488,10 @@ impl IgcInner {
         info: &mut PCIeInfo,
         hw: &mut IgcHw,
     ) -> Result<(), IgcDriverErr> {
+        if hw.mac.get_link_status {
+            ops.check_for_link(info, hw)?;
+        }
+
         self.link_status = if read_reg(info, igc_regs::IGC_STATUS)? & IGC_STATUS_LU != 0 {
             if !self.link_active {
                 let (speed, duplex) = ops.get_link_up_info(info, hw)?;


### PR DESCRIPTION
## Description

Implement `igc_update_link_status()` and introduce `IgcInner` for mutual exclusion.

## Related links

- OpenBSD's `igc_update_link_status()`: https://github.com/openbsd/src/blob/ec3f709602567a1e5cec4356a9d819cf2eacef49/sys/dev/pci/if_igc.c#L1623
- issue #335 

## How was this PR tested?

## Notes for reviewers
