### PR TITLE
feat(x86_64): use monitor/mwait for mutual exclusions

### DIFF
--- a/awkernel_lib/Cargo.toml
+++ b/awkernel_lib/Cargo.toml
@@ -72,7 +72,13 @@ features = [
 
 [features]
 default = ["x86"]
-x86 = ["dep:x86_64", "dep:acpi", "dep:bootloader_api", "awkernel_sync/x86"]
+x86 = [
+    "dep:x86_64",
+    "dep:acpi",
+    "dep:bootloader_api",
+    "awkernel_sync/x86",
+    "awkernel_sync/x86_mwait",
+]
 aarch64 = ["dep:awkernel_aarch64", "awkernel_sync/aarch64"]
 rv32 = []
 rv64 = ["awkernel_sync/rv64"]


### PR DESCRIPTION
## Description

This PR uses `monitor` and `mwait` instructions for mutual exclusions.
`monitor` and `mwait` are used in https://github.com/tier4/awkernel_sync as follows.

https://github.com/tier4/awkernel_sync/blob/d9ea774eb55fc62a392981dd01945e92fec0f134/src/mwait.rs#L21-L33

```rust
    fn wait_while_false_mwait(val: &AtomicBool) {
        let addr = val.as_ptr();

        unsafe {
            while !val.load(Ordering::Relaxed) {
                asm!("monitor", in("rax") addr, in("rcx") 0, in("edx") 0);
                if val.load(Ordering::Relaxed) {
                    break;
                }
                asm!("mwait", in("rax") 0, in("rcx") 0);
            }
        }
    }
```

To use `monitor` and `mwait` this PR just enables `x86_mwait` feature of `awkernel_sync`.

## Related links

- MWAIT — Monitor Wait: https://www.felixcloutier.com/x86/mwait
- `awkernel_sync/src/mwait.rs`: https://github.com/tier4/awkernel_sync/blob/main/src/mwait.rs
- diff of `awkernel_sync`: https://github.com/tier4/awkernel_sync/compare/b35d1b7..main

## How was this PR tested?

It works on an x86_64 physical machine, the x86_64 qemu environment, and an x86_64 KVM virtual machine.

## Notes for reviewers
