### PR TITLE
feat(filesystem): Add fatfs from existing crate

### DIFF
--- a/fatfs/.editorconfig
+++ b/fatfs/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*.rs]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+max_line_length = 120

--- a/fatfs/CHANGELOG.md
+++ b/fatfs/CHANGELOG.md
@@ -1,0 +1,103 @@
+Changelog
+=========
+
+0.4.0 (not released yet)
+------------------------
+New features:
+* Add `fatfs::Read`, `fatfs::Write` and `fatfs::Seek` traits and use them to replace usages of `Read`, `Write`, `Seek`
+  traits from `std::io` (BREAKING CHANGE). New traits are subtraits of `fatfs::IoBase` and use `IoBase::Error`
+  associated type for errors.
+* Add `Error` enum and use it to replace all usages of `std::io::Error` struct (BREAKING CHANGE). The new enum items
+  allow better differentiation of errors than `std::io::ErrorKind`.
+* Implement `From<Error<std::io::Error>>` trait for `std::io::Error` to simplify errors conversion.
+* Implement `Read`, `Write`, `Seek` traits from `std::io` for `fatfs::File` struct.
+* Add `StdIoWrapper` struct that implements newly added `Read`, `Write`, `Seek` traits and wraps types that implement
+  corresponding traits from `std::io` module.
+* Add `IntoStorage` trait and implement it for types that implement `Read`, `Write`, `Seek` traits from `std::io` and
+  types that implement newly added `Read`, `Write`, `Seek` traits from this crate. Make `FileSystem::new` accept types
+  that implement `IntoStorage`.
+* Remove `core_io` dependency. There are no Rust compiler restrictions for `no_std` builds anymore.
+* Add type parameters for `TimeProvider` and `OemCpConverter` in `FileSystem`, `File`, `Dir`, `DirEntry`, `FsOptions`
+  public structs and require an owned time provider and oem CP converter instead of a reference with a static lifetime in
+  `FsOptions` (BREAKING CHANGE). This change allows `FileSystem` usage in multi-threaded environment (e.g. wrapped in a
+  `Mutex`).
+* Add non-public field to `Date`, `Time`, `DateTime` structures to disallow direct instantiation (BREAKING CHANGE).
+* Add `Date::new`, `Time::new`, `DateTime::new` functions that instiantiate corresponding structures after ensuring
+  that arguments are in the supported range. They panic if this is not the case.
+* Fix time encoding during a leap second if using `chrono`.
+* Create directory entry with `VOLUME_ID` attribute when formatting if volume label was set in `FormatVolumeOptions`.
+* Fix creating directory entries when `lfn` feature is enabled and `alloc` feature is disabled
+* Fix `format_volume` function panicking in debug build for FAT12 volumes with size below 1 MB
+* Fix index out of range panic when reading 248+ characters long file names with `alloc` feature disabled
+* Remove `byteorder` dependency.
+* Bump up minimal Rust compiler version to 1.65.0.
+* Build the crate using the 2021 edition.
+* Add support for compile-time configuration of logging levels via Cargo features. By default, all logging levels are
+  enabled, including "trace" and up.
+* Disable chrono default features except `clock`
+* Use chrono naive types instead of deprecated `chrono::Date` (BREAKING CHANGE)
+* Add defaults for `FileSystem` generic parameters: `TP = DefaultTimeProvider`, `OCC = LossyOemCpConverter`
+* Structures `FsOptions`, `ChronoTimeProvider`, `NullTimeProvider` and `LossyOemCpConverter` now implement `Default` trait
+* Undeprecate `set_created`, `set_accessed`, `set_modified` methods on `File` - there are scenarios where those methods are needed
+* Relax BPB validation by allowing non-zero values in both `total_sectors_32` and `total_sectors_16`
+* Add `strict` field in `FsOptions`, which allows disabling validation of boot signature to improve compatibility with old FAT images
+
+Bug fixes:
+* Fix formatting volumes with size in range 4096-4199 KB
+* Always respect `fat_type` from `FormatVolumeOptions`
+* Fill FAT32 root directory clusters with zeros after allocation to avoid interpreting old data as directory entries
+* Put '.' and '..' in the first two directory entries. (fixes "Expected a valid '.' entry in this slot." fsck error)
+* Set the cluster number to 0 in the ".." directory entry if it points to the root dir
+
+0.3.4 (2020-07-20)
+------------------
+Bug fixes:
+* Fix time encoding and decoding in a directory entry.
+
+0.3.3 (2019-11-10)
+------------------
+Bug fixes:
+* Add missing characters to the whitelist for long file name (`^`, `#`, `&`)
+* Fix invalid short file names for `.` and `..` entries when creating a new directory
+* Fix `no_std` build
+
+Misc changes:
+* Fix compiler warnings
+* Improve documentation
+
+0.3.2 (2018-12-29)
+------------------
+New features:
+* Add `format_volume` function for initializing a FAT filesystem on a partition
+* Add more checks of filesystem correctness when mounting
+
+Bug fixes:
+* Clear directory returned from `create_dir` method - upgrade ASAP if this method is used
+* Fix handling of FSInfo sector on FAT32 volumes with sector size different than 512 - upgrade ASAP if such sector size is used
+* Use `write_all` in `serialize` method for FSInfo sector - previously it could have been improperly updated
+
+0.3.1 (2018-10-20)
+------------------
+New features:
+* Increased file creation time resolution from 2s to 1/100s
+* Added oem_cp_converter filesystem option allowing to provide custom short name decoder
+* Added time_provider filesystem option allowing to provide time used when modifying directory entries
+* Added marking volume as dirty on first write and not-dirty on unmount
+* Added support for reading volume label from root directory
+
+Bug fixes:
+* Fixed handling of short names with spaces in the middle - all characters after first space in 8.3 components were
+  stripped before
+* Fixed decoding 0xE5 character in first byte of short name - if first character of short name is equal to 0xE5,
+  it was read as 0x05
+* Preserve 4 most significant bits in FAT32 entries - it is required by FAT specification, but previous behavior
+  should not cause any compatibility problem because all known implementations ignore those bits
+* Fixed warnings for file entries without LFN entries - they were handled properly, but caused warnings in run-time
+
+Misc changes:
+* Deprecated set_created. set_accessed, set_modified methods on File - those fields are updated automatically using
+  information provided by TimeProvider
+* Fixed size formatting in ls.rs example
+* Added more filesystem checks causing errors or warnings when incompatibility is detected
+* Removed unnecessary clone() calls
+* Code formatting and docs fixes

--- a/fatfs/Cargo.toml
+++ b/fatfs/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "fatfs"
+version = "0.4.0"
+authors = ["Rafał Harabień <rafalh92@outlook.com>"]
+edition = "2021"
+rust-version = "1.65"
+repository = "https://github.com/rafalh/rust-fatfs"
+readme = "README.md"
+keywords = ["fat", "filesystem", "no_std"]
+categories = ["filesystem"]
+license = "MIT"
+description = """
+FAT filesystem library.
+"""
+exclude = [
+    "resources/*",
+]
+
+[features]
+# Use Rust std library
+std = []
+# LFN (Long File Name) support
+lfn = []
+# Use dynamic allocation. When used without std please enable core_io/collections
+alloc = []
+# Full Unicode support. Disabling it reduces code size by avoiding Unicode-aware character case conversion
+unicode = []
+# Enable only error-level logging
+log_level_error = []
+# Enable logging levels warn and up
+log_level_warn  = ["log_level_error"]
+# Enable logging levels info and up
+log_level_info  = ["log_level_warn"]
+# Enable logging levels debug and up
+log_level_debug = ["log_level_info"]
+# Enable all logging levels: trace and up
+log_level_trace = ["log_level_debug"]
+
+# Default features
+default = ["chrono", "std", "alloc", "lfn", "unicode", "log_level_trace"]
+
+[dependencies]
+bitflags = { version = "2", default-features = false }
+log = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+
+[dev-dependencies]
+env_logger = "0.9"
+fscommon = "0.1"

--- a/fatfs/LICENSE.txt
+++ b/fatfs/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright 2017 Rafał Harabień
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/fatfs/README.md
+++ b/fatfs/README.md
@@ -1,0 +1,75 @@
+Rust FAT FS
+===========
+
+[![CI Status](https://github.com/rafalh/rust-fatfs/actions/workflows/ci.yml/badge.svg)](https://github.com/rafalh/rust-fatfs/actions/workflows/ci.yml)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.txt)
+[![crates.io](https://img.shields.io/crates/v/fatfs)](https://crates.io/crates/fatfs)
+[![Documentation](https://docs.rs/fatfs/badge.svg)](https://docs.rs/fatfs)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.65+-yellow.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
+
+A FAT filesystem library implemented in Rust.
+
+Features:
+* read/write file using standard Read/Write traits
+* read directory contents
+* create/remove file or directory
+* rename/move file or directory
+* read/write file timestamps (updated automatically if `chrono` feature is enabled)
+* format volume
+* FAT12, FAT16, FAT32 compatibility
+* LFN (Long File Names) extension is supported
+* Basic no_std environment support
+* logging configurable at compile time using cargo features
+
+Usage
+-----
+
+Add this to your `Cargo.toml`:
+
+    [dependencies]
+    fatfs = "0.4"
+
+You can start using the `fatfs` library now:
+
+    let img_file = File::open("fat.img")?;
+    let fs = fatfs::FileSystem::new(img_file, fatfs::FsOptions::new())?;
+    let root_dir = fs.root_dir();
+    let mut file = root_dir.create_file("hello.txt")?;
+    file.write_all(b"Hello World!")?;
+
+Note: it is recommended to wrap the underlying file struct in a buffering/caching object like `BufStream` from
+`fscommon` crate. For example:
+
+    let buf_stream = BufStream::new(img_file);
+    let fs = fatfs::FileSystem::new(buf_stream, fatfs::FsOptions::new())?;
+
+See more examples in the `examples` subdirectory.
+
+no_std usage
+------------
+
+Add this to your `Cargo.toml`:
+
+    [dependencies]
+    fatfs = { version = "0.4", default-features = false }
+
+Additional features:
+
+* `lfn` - LFN (long file name) support
+* `alloc` - use `alloc` crate for dynamic allocation. Needed for API which uses `String` type. You may have to provide
+a memory allocator implementation.
+* `unicode` - use Unicode-compatible case conversion in file names - you may want to have it disabled for lower memory
+footprint
+* `log_level_*` - enable specific logging levels at compile time.
+The options are as follows:
+  * `log_level_error` - enable only error-level logging.
+  * `log_level_warn` - enable warn-level logging and higher.
+  * `log_level_info` - enable info-level logging and higher.
+  * `log_level_debug` - enable debug-level logging and higher.
+  * `log_level_trace` - (default) enable all logging levels, trace and higher.
+
+Note: above features are enabled by default and were designed primarily for `no_std` usage.
+
+License
+-------
+The MIT license. See `LICENSE.txt`.

--- a/fatfs/build-nostd.sh
+++ b/fatfs/build-nostd.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+cargo build --no-default-features
+cargo build --no-default-features --features alloc
+cargo build --no-default-features --features lfn,alloc

--- a/fatfs/examples/cat.rs
+++ b/fatfs/examples/cat.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::fs::File;
+use std::io::{self, prelude::*};
+
+use fatfs::{FileSystem, FsOptions};
+use fscommon::BufStream;
+
+fn main() -> io::Result<()> {
+    let file = File::open("resources/fat32.img")?;
+    let buf_rdr = BufStream::new(file);
+    let fs = FileSystem::new(buf_rdr, FsOptions::new())?;
+    let root_dir = fs.root_dir();
+    let mut file = root_dir.open_file(&env::args().nth(1).expect("filename expected"))?;
+    let mut buf = vec![];
+    file.read_to_end(&mut buf)?;
+    print!("{}", String::from_utf8_lossy(&buf));
+    Ok(())
+}

--- a/fatfs/examples/ls.rs
+++ b/fatfs/examples/ls.rs
@@ -1,0 +1,42 @@
+use std::env;
+use std::fs::File;
+use std::io;
+
+use chrono::NaiveDateTime;
+use fatfs::{FileSystem, FsOptions};
+use fscommon::BufStream;
+
+fn format_file_size(size: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+    if size < KB {
+        format!("{}B", size)
+    } else if size < MB {
+        format!("{}KB", size / KB)
+    } else if size < GB {
+        format!("{}MB", size / MB)
+    } else {
+        format!("{}GB", size / GB)
+    }
+}
+
+fn main() -> io::Result<()> {
+    let file = File::open("resources/fat32.img")?;
+    let buf_rdr = BufStream::new(file);
+    let fs = FileSystem::new(buf_rdr, FsOptions::new())?;
+    let root_dir = fs.root_dir();
+    let dir = match env::args().nth(1) {
+        None => root_dir,
+        Some(ref path) if path == "." => root_dir,
+        Some(ref path) => root_dir.open_dir(path)?,
+    };
+    for r in dir.iter() {
+        let e = r?;
+        let modified = NaiveDateTime::from(e.modified())
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        println!("{:4}  {}  {}", format_file_size(e.len()), modified, e.file_name());
+    }
+    Ok(())
+}

--- a/fatfs/examples/mkfatfs.rs
+++ b/fatfs/examples/mkfatfs.rs
@@ -1,0 +1,14 @@
+use std::env;
+use std::fs;
+use std::io;
+
+use fatfs::{format_volume, FormatVolumeOptions, StdIoWrapper};
+use fscommon::BufStream;
+
+fn main() -> io::Result<()> {
+    let filename = env::args().nth(1).expect("image path expected");
+    let file = fs::OpenOptions::new().read(true).write(true).open(filename)?;
+    let buf_file = BufStream::new(file);
+    format_volume(&mut StdIoWrapper::from(buf_file), FormatVolumeOptions::new())?;
+    Ok(())
+}

--- a/fatfs/examples/partition.rs
+++ b/fatfs/examples/partition.rs
@@ -1,0 +1,22 @@
+use std::{fs, io};
+
+use fatfs::{FileSystem, FsOptions};
+use fscommon::{BufStream, StreamSlice};
+
+fn main() -> io::Result<()> {
+    // Open disk image
+    let file = fs::File::open("resources/fat32.img")?;
+    // Provide sample partition localization. In real application it should be read from MBR/GPT.
+    let first_lba = 0;
+    let last_lba = 10000;
+    // Create partition using provided start address and size in bytes
+    let partition = StreamSlice::new(file, first_lba, last_lba + 1)?;
+    // Create buffered stream to optimize file access
+    let buf_rdr = BufStream::new(partition);
+    // Finally initialize filesystem struct using provided partition
+    let fs = FileSystem::new(buf_rdr, FsOptions::new())?;
+    // Read and display volume label
+    println!("Volume Label: {}", fs.volume_label());
+    // other operations...
+    Ok(())
+}

--- a/fatfs/examples/write.rs
+++ b/fatfs/examples/write.rs
@@ -1,0 +1,21 @@
+use std::fs::OpenOptions;
+use std::io::{self, prelude::*};
+
+use fatfs::{FileSystem, FsOptions};
+use fscommon::BufStream;
+
+fn main() -> io::Result<()> {
+    let img_file = match OpenOptions::new().read(true).write(true).open("fat.img") {
+        Ok(file) => file,
+        Err(err) => {
+            println!("Failed to open image!");
+            return Err(err);
+        }
+    };
+    let buf_stream = BufStream::new(img_file);
+    let options = FsOptions::new().update_accessed_date(true);
+    let fs = FileSystem::new(buf_stream, options)?;
+    let mut file = fs.root_dir().create_file("hello.txt")?;
+    file.write_all(b"Hello World!")?;
+    Ok(())
+}

--- a/fatfs/rustfmt.toml
+++ b/fatfs/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 120
+use_field_init_shorthand = true

--- a/fatfs/scripts/create-test-img.sh
+++ b/fatfs/scripts/create-test-img.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+OUT_DIR=../resources
+set -e
+
+create_test_img() {
+	local name=$1
+	local blkcount=$2
+	local fatSize=$3
+	dd if=/dev/zero of="$name" bs=1024 count=$blkcount
+	mkfs.vfat -s 1 -F $fatSize -n "Test!" -i 12345678 "$name"
+	mkdir -p mnt
+	sudo mount -o loop "$name" mnt -o rw,uid=$USER,gid=$USER
+	for i in $(seq 1 1000); do
+	  echo "Rust is cool!" >>"mnt/long.txt"
+	done
+	echo "Rust is cool!" >>"mnt/short.txt"
+	mkdir -p "mnt/very/long/path"
+	echo "Rust is cool!" >>"mnt/very/long/path/test.txt"
+	mkdir -p "mnt/very-long-dir-name"
+	echo "Rust is cool!" >>"mnt/very-long-dir-name/very-long-file-name.txt"
+
+	sudo umount mnt
+}
+
+create_test_img "$OUT_DIR/fat12.img" 1000 12
+create_test_img "$OUT_DIR/fat16.img" 2500 16
+create_test_img "$OUT_DIR/fat32.img" 34000 32

--- a/fatfs/src/boot_sector.rs
+++ b/fatfs/src/boot_sector.rs
@@ -1,0 +1,1041 @@
+use core::slice;
+
+use crate::dir_entry::DIR_ENTRY_SIZE;
+use crate::error::{Error, IoError};
+use crate::fs::{FatType, FormatVolumeOptions, FsStatusFlags};
+use crate::io::{Read, ReadLeExt, Write, WriteLeExt};
+use crate::table::RESERVED_FAT_ENTRIES;
+
+const BITS_PER_BYTE: u32 = 8;
+const KB_32: u32 = 1024;
+const KB_64: u64 = 1024;
+const MB_64: u64 = KB_64 * 1024;
+const GB_64: u64 = MB_64 * 1024;
+
+#[derive(Default, Debug, Clone)]
+pub(crate) struct BiosParameterBlock {
+    pub(crate) bytes_per_sector: u16,
+    pub(crate) sectors_per_cluster: u8,
+    pub(crate) reserved_sectors: u16,
+    pub(crate) fats: u8,
+    pub(crate) root_entries: u16,
+    pub(crate) total_sectors_16: u16,
+    pub(crate) media: u8,
+    pub(crate) sectors_per_fat_16: u16,
+    pub(crate) sectors_per_track: u16,
+    pub(crate) heads: u16,
+    pub(crate) hidden_sectors: u32,
+    pub(crate) total_sectors_32: u32,
+
+    // Extended BIOS Parameter Block
+    pub(crate) sectors_per_fat_32: u32,
+    pub(crate) extended_flags: u16,
+    pub(crate) fs_version: u16,
+    pub(crate) root_dir_first_cluster: u32,
+    pub(crate) fs_info_sector: u16,
+    pub(crate) backup_boot_sector: u16,
+    pub(crate) reserved_0: [u8; 12],
+    pub(crate) drive_num: u8,
+    pub(crate) reserved_1: u8,
+    pub(crate) ext_sig: u8,
+    pub(crate) volume_id: u32,
+    pub(crate) volume_label: [u8; 11],
+    pub(crate) fs_type_label: [u8; 8],
+}
+
+impl BiosParameterBlock {
+    fn deserialize<R: Read>(rdr: &mut R) -> Result<Self, R::Error> {
+        let mut bpb = Self {
+            bytes_per_sector: rdr.read_u16_le()?,
+            sectors_per_cluster: rdr.read_u8()?,
+            reserved_sectors: rdr.read_u16_le()?,
+            fats: rdr.read_u8()?,
+            root_entries: rdr.read_u16_le()?,
+            total_sectors_16: rdr.read_u16_le()?,
+            media: rdr.read_u8()?,
+            sectors_per_fat_16: rdr.read_u16_le()?,
+            sectors_per_track: rdr.read_u16_le()?,
+            heads: rdr.read_u16_le()?,
+            hidden_sectors: rdr.read_u32_le()?,
+            total_sectors_32: rdr.read_u32_le()?,
+            ..Self::default()
+        };
+
+        if bpb.is_fat32() {
+            bpb.sectors_per_fat_32 = rdr.read_u32_le()?;
+            bpb.extended_flags = rdr.read_u16_le()?;
+            bpb.fs_version = rdr.read_u16_le()?;
+            bpb.root_dir_first_cluster = rdr.read_u32_le()?;
+            bpb.fs_info_sector = rdr.read_u16_le()?;
+            bpb.backup_boot_sector = rdr.read_u16_le()?;
+            rdr.read_exact(&mut bpb.reserved_0)?;
+        }
+
+        bpb.drive_num = rdr.read_u8()?;
+        bpb.reserved_1 = rdr.read_u8()?;
+        bpb.ext_sig = rdr.read_u8()?; // 0x29
+        bpb.volume_id = rdr.read_u32_le()?;
+        rdr.read_exact(&mut bpb.volume_label)?;
+        rdr.read_exact(&mut bpb.fs_type_label)?;
+
+        // when the extended boot signature is anything other than 0x29, the fields are invalid
+        if bpb.ext_sig != 0x29 {
+            // fields after ext_sig are not used - clean them
+            bpb.volume_id = 0;
+            bpb.volume_label = [0; 11];
+            bpb.fs_type_label = [0; 8];
+        }
+
+        Ok(bpb)
+    }
+
+    fn serialize<W: Write>(&self, wrt: &mut W) -> Result<(), W::Error> {
+        wrt.write_u16_le(self.bytes_per_sector)?;
+        wrt.write_u8(self.sectors_per_cluster)?;
+        wrt.write_u16_le(self.reserved_sectors)?;
+        wrt.write_u8(self.fats)?;
+        wrt.write_u16_le(self.root_entries)?;
+        wrt.write_u16_le(self.total_sectors_16)?;
+        wrt.write_u8(self.media)?;
+        wrt.write_u16_le(self.sectors_per_fat_16)?;
+        wrt.write_u16_le(self.sectors_per_track)?;
+        wrt.write_u16_le(self.heads)?;
+        wrt.write_u32_le(self.hidden_sectors)?;
+        wrt.write_u32_le(self.total_sectors_32)?;
+
+        if self.is_fat32() {
+            wrt.write_u32_le(self.sectors_per_fat_32)?;
+            wrt.write_u16_le(self.extended_flags)?;
+            wrt.write_u16_le(self.fs_version)?;
+            wrt.write_u32_le(self.root_dir_first_cluster)?;
+            wrt.write_u16_le(self.fs_info_sector)?;
+            wrt.write_u16_le(self.backup_boot_sector)?;
+            wrt.write_all(&self.reserved_0)?;
+        }
+
+        wrt.write_u8(self.drive_num)?;
+        wrt.write_u8(self.reserved_1)?;
+        wrt.write_u8(self.ext_sig)?; // 0x29
+        wrt.write_u32_le(self.volume_id)?;
+        wrt.write_all(&self.volume_label)?;
+        wrt.write_all(&self.fs_type_label)?;
+        Ok(())
+    }
+
+    fn validate_bytes_per_sector<E: IoError>(&self) -> Result<(), Error<E>> {
+        if !self.bytes_per_sector.is_power_of_two() {
+            error!(
+                "invalid bytes_per_sector value in BPB: expected a power of two but got {}",
+                self.bytes_per_sector
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        if self.bytes_per_sector < 512 || self.bytes_per_sector > 4096 {
+            error!(
+                "invalid bytes_per_sector value in BPB: expected value in range [512, 4096] but got {}",
+                self.bytes_per_sector
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        Ok(())
+    }
+
+    fn validate_sectors_per_cluster<E: IoError>(&self) -> Result<(), Error<E>> {
+        if !self.sectors_per_cluster.is_power_of_two() {
+            error!(
+                "invalid sectors_per_cluster value in BPB: expected a power of two but got {}",
+                self.sectors_per_cluster
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+
+        // bytes per sector is u16, sectors per cluster is u8, so guaranteed no overflow in multiplication
+        let bytes_per_cluster = u32::from(self.bytes_per_sector) * u32::from(self.sectors_per_cluster);
+        let maximum_compatibility_bytes_per_cluster: u32 = 32 * 1024;
+
+        if bytes_per_cluster > maximum_compatibility_bytes_per_cluster {
+            // 32k is the largest value to maintain greatest compatibility
+            // Many implementations appear to support 64k per cluster, and some may support 128k or larger
+            // However, >32k is not as thoroughly tested...
+            warn!("fs compatibility: bytes_per_cluster value '{}' in BPB exceeds '{}', and thus may be incompatible with some implementations",
+                bytes_per_cluster, maximum_compatibility_bytes_per_cluster);
+        }
+        Ok(())
+    }
+
+    fn validate_reserved_sectors<E: IoError>(&self) -> Result<(), Error<E>> {
+        let is_fat32 = self.is_fat32();
+        if self.reserved_sectors < 1 {
+            error!("invalid reserved_sectors value in BPB: {}", self.reserved_sectors);
+            return Err(Error::CorruptedFileSystem);
+        }
+        if !is_fat32 && self.reserved_sectors != 1 {
+            // Microsoft document indicates fat12 and fat16 code exists that presume this value is 1
+            warn!(
+                "fs compatibility: reserved_sectors value '{}' in BPB is not '1', and thus is incompatible with some implementations",
+                self.reserved_sectors
+            );
+        }
+        if is_fat32 && self.backup_boot_sector >= self.reserved_sectors {
+            error!(
+                "Invalid BPB: expected backup boot-sector to be in the reserved region (sector < {}) but got sector {}",
+                self.reserved_sectors, self.backup_boot_sector
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        if is_fat32 && self.fs_info_sector >= self.reserved_sectors {
+            error!(
+                "Invalid BPB: expected FSInfo sector to be in the reserved region (sector < {}) but got sector {}",
+                self.reserved_sectors, self.fs_info_sector
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        Ok(())
+    }
+
+    fn validate_fats<E: IoError>(&self) -> Result<(), Error<E>> {
+        if self.fats == 0 {
+            error!("invalid fats value in BPB: {}", self.fats);
+            return Err(Error::CorruptedFileSystem);
+        }
+        if self.fats > 2 {
+            // Microsoft document indicates that few implementations support any values other than 1 or 2
+            warn!(
+                "fs compatibility: numbers of FATs '{}' in BPB is greater than '2', and thus is incompatible with some implementations",
+                self.fats
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_root_entries<E: IoError>(&self) -> Result<(), Error<E>> {
+        let is_fat32 = self.is_fat32();
+        if is_fat32 && self.root_entries != 0 {
+            error!(
+                "Invalid root_entries value in FAT32 BPB: expected 0 but got {}",
+                self.root_entries
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        if !is_fat32 && self.root_entries == 0 {
+            error!(
+                "Invalid root_entries value in FAT12/FAT16 BPB: expected non-zero value but got {}",
+                self.root_entries
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        if (u32::from(self.root_entries) * DIR_ENTRY_SIZE) % u32::from(self.bytes_per_sector) != 0 {
+            warn!("Root entries should fill sectors fully");
+        }
+        Ok(())
+    }
+
+    fn validate_total_sectors<E: IoError>(&self) -> Result<(), Error<E>> {
+        let is_fat32 = self.is_fat32();
+        if is_fat32 && self.total_sectors_16 != 0 {
+            error!(
+                "Invalid total_sectors_16 value in FAT32 BPB: expected 0 but got {}",
+                self.total_sectors_16
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        if self.total_sectors_16 == 0 && self.total_sectors_32 == 0 {
+            error!("Invalid BPB: total_sectors_16 or total_sectors_32 should be non-zero");
+            return Err(Error::CorruptedFileSystem);
+        }
+        if self.total_sectors_16 != 0
+            && self.total_sectors_32 != 0
+            && self.total_sectors_16 as u32 != self.total_sectors_32
+        {
+            error!("Invalid BPB: total_sectors_16 and total_sectors_32 are non-zero and have conflicting values");
+            return Err(Error::CorruptedFileSystem);
+        }
+        let total_sectors = self.total_sectors();
+        let first_data_sector = self.first_data_sector();
+        if total_sectors <= first_data_sector {
+            error!(
+                "Invalid total_sectors value in BPB: expected value > {} but got {}",
+                first_data_sector, total_sectors
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        Ok(())
+    }
+
+    fn validate_sectors_per_fat<E: IoError>(&self) -> Result<(), Error<E>> {
+        let is_fat32 = self.is_fat32();
+        if is_fat32 && self.sectors_per_fat_32 == 0 {
+            error!(
+                "Invalid sectors_per_fat_32 value in FAT32 BPB: expected non-zero value but got {}",
+                self.sectors_per_fat_32
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        Ok(())
+    }
+
+    fn validate_total_clusters<E: IoError>(&self) -> Result<(), Error<E>> {
+        let is_fat32 = self.is_fat32();
+        let total_clusters = self.total_clusters();
+        let fat_type = FatType::from_clusters(total_clusters);
+        if is_fat32 != (fat_type == FatType::Fat32) {
+            error!("Invalid BPB: result of FAT32 determination from total number of clusters and sectors_per_fat_16 field differs");
+            return Err(Error::CorruptedFileSystem);
+        }
+        if fat_type == FatType::Fat32 && total_clusters > 0x0FFF_FFFF {
+            error!("Invalid BPB: too many clusters {}", total_clusters);
+            return Err(Error::CorruptedFileSystem);
+        }
+
+        let bits_per_fat_entry = fat_type.bits_per_fat_entry();
+        let total_fat_entries = self.sectors_per_fat() * u32::from(self.bytes_per_sector) * 8 / bits_per_fat_entry;
+        let usable_fat_entries = total_fat_entries - RESERVED_FAT_ENTRIES;
+        if usable_fat_entries < total_clusters {
+            warn!(
+                "FAT is too small (allows allocation of {} clusters) compared to the total number of clusters ({})",
+                usable_fat_entries, total_clusters
+            );
+        }
+        Ok(())
+    }
+
+    fn validate<E: IoError>(&self) -> Result<(), Error<E>> {
+        if self.fs_version != 0 {
+            error!("Unsupported filesystem version: expected 0 but got {}", self.fs_version);
+            return Err(Error::CorruptedFileSystem);
+        }
+        self.validate_bytes_per_sector()?;
+        self.validate_sectors_per_cluster()?;
+        self.validate_reserved_sectors()?;
+        self.validate_fats()?;
+        self.validate_root_entries()?;
+        self.validate_total_sectors()?;
+        self.validate_sectors_per_fat()?;
+        self.validate_total_clusters()?;
+        Ok(())
+    }
+
+    pub(crate) fn mirroring_enabled(&self) -> bool {
+        self.extended_flags & 0x80 == 0
+    }
+
+    pub(crate) fn active_fat(&self) -> u16 {
+        // The zero-based number of the active FAT is only valid if mirroring is disabled.
+        if self.mirroring_enabled() {
+            0
+        } else {
+            self.extended_flags & 0x0F
+        }
+    }
+
+    pub(crate) fn status_flags(&self) -> FsStatusFlags {
+        FsStatusFlags::decode(self.reserved_1)
+    }
+
+    pub(crate) fn is_fat32(&self) -> bool {
+        // because this field must be zero on FAT32, and
+        // because it must be non-zero on FAT12/FAT16,
+        // this provides a simple way to detect FAT32
+        self.sectors_per_fat_16 == 0
+    }
+
+    pub(crate) fn sectors_per_fat(&self) -> u32 {
+        if self.is_fat32() {
+            self.sectors_per_fat_32
+        } else {
+            u32::from(self.sectors_per_fat_16)
+        }
+    }
+
+    pub(crate) fn total_sectors(&self) -> u32 {
+        if self.total_sectors_16 == 0 {
+            self.total_sectors_32
+        } else {
+            u32::from(self.total_sectors_16)
+        }
+    }
+
+    pub(crate) fn reserved_sectors(&self) -> u32 {
+        u32::from(self.reserved_sectors)
+    }
+
+    pub(crate) fn root_dir_sectors(&self) -> u32 {
+        let root_dir_bytes = u32::from(self.root_entries) * DIR_ENTRY_SIZE;
+        (root_dir_bytes + u32::from(self.bytes_per_sector) - 1) / u32::from(self.bytes_per_sector)
+    }
+
+    pub(crate) fn sectors_per_all_fats(&self) -> u32 {
+        u32::from(self.fats) * self.sectors_per_fat()
+    }
+
+    pub(crate) fn first_data_sector(&self) -> u32 {
+        let root_dir_sectors = self.root_dir_sectors();
+        let fat_sectors = self.sectors_per_all_fats();
+        self.reserved_sectors() + fat_sectors + root_dir_sectors
+    }
+
+    pub(crate) fn total_clusters(&self) -> u32 {
+        let total_sectors = self.total_sectors();
+        let first_data_sector = self.first_data_sector();
+        let data_sectors = total_sectors - first_data_sector;
+        data_sectors / u32::from(self.sectors_per_cluster)
+    }
+
+    pub(crate) fn bytes_from_sectors(&self, sectors: u32) -> u64 {
+        // Note: total number of sectors is a 32 bit number so offsets have to be 64 bit
+        u64::from(sectors) * u64::from(self.bytes_per_sector)
+    }
+
+    pub(crate) fn sectors_from_clusters(&self, clusters: u32) -> u32 {
+        // Note: total number of sectors is a 32 bit number so it should not overflow
+        clusters * u32::from(self.sectors_per_cluster)
+    }
+
+    pub(crate) fn cluster_size(&self) -> u32 {
+        u32::from(self.sectors_per_cluster) * u32::from(self.bytes_per_sector)
+    }
+
+    pub(crate) fn clusters_from_bytes(&self, bytes: u64) -> u32 {
+        let cluster_size = u64::from(self.cluster_size());
+        ((bytes + cluster_size - 1) / cluster_size) as u32
+    }
+
+    pub(crate) fn fs_info_sector(&self) -> u32 {
+        u32::from(self.fs_info_sector)
+    }
+
+    pub(crate) fn backup_boot_sector(&self) -> u32 {
+        u32::from(self.backup_boot_sector)
+    }
+}
+
+pub(crate) struct BootSector {
+    bootjmp: [u8; 3],
+    oem_name: [u8; 8],
+    pub(crate) bpb: BiosParameterBlock,
+    boot_code: [u8; 448],
+    boot_sig: [u8; 2],
+}
+
+impl BootSector {
+    pub(crate) fn deserialize<R: Read>(rdr: &mut R) -> Result<Self, R::Error> {
+        let mut boot = Self::default();
+        rdr.read_exact(&mut boot.bootjmp)?;
+        rdr.read_exact(&mut boot.oem_name)?;
+        boot.bpb = BiosParameterBlock::deserialize(rdr)?;
+
+        if boot.bpb.is_fat32() {
+            rdr.read_exact(&mut boot.boot_code[0..420])?;
+        } else {
+            rdr.read_exact(&mut boot.boot_code[0..448])?;
+        }
+        rdr.read_exact(&mut boot.boot_sig)?;
+        Ok(boot)
+    }
+
+    pub(crate) fn serialize<W: Write>(&self, wrt: &mut W) -> Result<(), W::Error> {
+        wrt.write_all(&self.bootjmp)?;
+        wrt.write_all(&self.oem_name)?;
+        self.bpb.serialize(&mut *wrt)?;
+
+        if self.bpb.is_fat32() {
+            wrt.write_all(&self.boot_code[0..420])?;
+        } else {
+            wrt.write_all(&self.boot_code[0..448])?;
+        }
+        wrt.write_all(&self.boot_sig)?;
+        Ok(())
+    }
+
+    pub(crate) fn validate<E: IoError>(&self, strict: bool) -> Result<(), Error<E>> {
+        if strict && self.boot_sig != [0x55, 0xAA] {
+            error!(
+                "Invalid boot sector signature: expected [0x55, 0xAA] but got {:?}",
+                self.boot_sig
+            );
+            return Err(Error::CorruptedFileSystem);
+        }
+        if strict && self.bootjmp[0] != 0xEB && self.bootjmp[0] != 0xE9 {
+            warn!("Unknown opcode {:x} in bootjmp boot sector field", self.bootjmp[0]);
+        }
+        self.bpb.validate()?;
+        Ok(())
+    }
+}
+
+impl Default for BootSector {
+    fn default() -> Self {
+        Self {
+            bootjmp: Default::default(),
+            oem_name: Default::default(),
+            bpb: BiosParameterBlock::default(),
+            boot_code: [0; 448],
+            boot_sig: Default::default(),
+        }
+    }
+}
+
+pub(crate) fn estimate_fat_type(total_bytes: u64) -> FatType {
+    // Used only to select cluster size if FAT type has not been overriden in options
+    if total_bytes < 4200 * KB_64 {
+        FatType::Fat12
+    } else if total_bytes < 512 * MB_64 {
+        FatType::Fat16
+    } else {
+        FatType::Fat32
+    }
+}
+
+fn determine_bytes_per_cluster(total_bytes: u64, bytes_per_sector: u16, fat_type: Option<FatType>) -> u32 {
+    const MAX_CLUSTER_SIZE: u32 = 32 * KB_32;
+
+    let fat_type = fat_type.unwrap_or_else(|| estimate_fat_type(total_bytes));
+    let bytes_per_cluster = match fat_type {
+        FatType::Fat12 => {
+            // approximate cluster count: (1024, 2048]
+            (total_bytes.next_power_of_two() / MB_64 * 512) as u32
+        }
+        FatType::Fat16 => {
+            if total_bytes <= 16 * MB_64 {
+                // cluster size: 1 KB
+                // approximate cluster count: (4096, 16384]
+                KB_32
+            } else if total_bytes <= 128 * MB_64 {
+                // cluster size: 2 KB
+                // approximate cluster count: (8192, 65536]
+                2 * KB_32
+            } else {
+                // cluster size: 4 KB or more
+                // approximate cluster count: (32768, 65536]
+                ((total_bytes.next_power_of_two() / (64 * MB_64)) as u32) * KB_32
+            }
+        }
+        FatType::Fat32 => {
+            if total_bytes <= 260 * MB_64 {
+                // cluster size: 512 B
+                // approximate cluster count: (65_536, 532_480]
+                512
+            } else if total_bytes <= 8 * GB_64 {
+                // cluster size: 4 KB
+                // approximate cluster count: (66_560, 2_097_152]
+                // Note: for minimal volume size (260 MB + 1 sector) it always results in enough cluster for this FAT type
+                // unless there is more than ~7000 reserved sectors
+                4 * KB_32
+            } else {
+                // cluster size: 8 KB or more
+                // approximate cluster count: (1_048_576, 2_097_152]
+                // at 32 GB it already uses maximal cluster size and then cluster count goes out of the above range
+                ((total_bytes.next_power_of_two() / (2 * GB_64)) as u32) * KB_32
+            }
+        }
+    };
+    let bytes_per_cluster_clamped = bytes_per_cluster.clamp(bytes_per_sector.into(), MAX_CLUSTER_SIZE);
+    debug_assert!(bytes_per_cluster_clamped.is_power_of_two());
+    bytes_per_cluster_clamped
+}
+
+fn determine_sectors_per_fat(
+    total_sectors: u32,
+    bytes_per_sector: u16,
+    sectors_per_cluster: u8,
+    fat_type: FatType,
+    reserved_sectors: u16,
+    root_dir_sectors: u32,
+    fats: u8,
+) -> u32 {
+    //
+    // FAT size formula transformations:
+    //
+    // Initial basic formula:
+    // size of FAT in bits >= (total number of clusters + 2) * bits per FAT entry
+    //
+    // Note: when computing number of clusters from number of sectors rounding down is used because partial clusters
+    // are not allowed
+    // Note: in those transformations '/' is a floating-point division (not a rounding towards zero division)
+    //
+    // data_sectors = total_sectors - reserved_sectors - fats * sectors_per_fat - root_dir_sectors
+    // total_clusters = floor(data_sectors / sectors_per_cluster)
+    // bits_per_sector = bytes_per_sector * 8
+    // sectors_per_fat * bits_per_sector >= (total_clusters + 2) * bits_per_fat_entry
+    // sectors_per_fat * bits_per_sector >= (floor(data_sectors / sectors_per_cluster) + 2) * bits_per_fat_entry
+    //
+    // Note: omitting the floor function can cause the FAT to be bigger by 1 entry - negligible
+    //
+    // sectors_per_fat * bits_per_sector >= (data_sectors / sectors_per_cluster + 2) * bits_per_fat_entry
+    // t0 = total_sectors - reserved_sectors - root_dir_sectors
+    // sectors_per_fat * bits_per_sector >= ((t0 - fats * sectors_per_fat) / sectors_per_cluster + 2) * bits_per_fat_entry
+    // sectors_per_fat * bits_per_sector / bits_per_fat_entry >= (t0 - fats * sectors_per_fat) / sectors_per_cluster + 2
+    // sectors_per_fat * bits_per_sector / bits_per_fat_entry >= t0 / sectors_per_cluster + 2 - fats * sectors_per_fat / sectors_per_cluster
+    // sectors_per_fat * bits_per_sector / bits_per_fat_entry + fats * sectors_per_fat / sectors_per_cluster >= t0 / sectors_per_cluster + 2
+    // sectors_per_fat * (bits_per_sector / bits_per_fat_entry + fats / sectors_per_cluster) >= t0 / sectors_per_cluster + 2
+    // sectors_per_fat >= (t0 / sectors_per_cluster + 2) / (bits_per_sector / bits_per_fat_entry + fats / sectors_per_cluster)
+    //
+    // Note: MS specification omits the constant 2 in calculations. This library is taking a better approach...
+    //
+    // sectors_per_fat >= ((t0 + 2 * sectors_per_cluster) / sectors_per_cluster) / (bits_per_sector / bits_per_fat_entry + fats / sectors_per_cluster)
+    // sectors_per_fat >= (t0 + 2 * sectors_per_cluster) / (sectors_per_cluster * bits_per_sector / bits_per_fat_entry + fats)
+    //
+    // Note: compared to MS formula this one can suffer from an overflow problem if u32 type is used
+    //
+    // When converting formula to integer types round towards a bigger FAT:
+    // * first division towards infinity
+    // * second division towards zero (it is in a denominator of the first division)
+
+    let t0: u32 = total_sectors - u32::from(reserved_sectors) - root_dir_sectors;
+    let t1: u64 = u64::from(t0) + u64::from(2 * u32::from(sectors_per_cluster));
+    let bits_per_cluster = u32::from(sectors_per_cluster) * u32::from(bytes_per_sector) * BITS_PER_BYTE;
+    let t2 = u64::from(bits_per_cluster / fat_type.bits_per_fat_entry() + u32::from(fats));
+    let sectors_per_fat = (t1 + t2 - 1) / t2;
+    // Note: casting is safe here because number of sectors per FAT cannot be bigger than total sectors number
+    sectors_per_fat as u32
+}
+
+fn try_fs_layout(
+    total_sectors: u32,
+    bytes_per_sector: u16,
+    sectors_per_cluster: u8,
+    fat_type: FatType,
+    root_dir_sectors: u32,
+    fats: u8,
+) -> Result<(u16, u32), Error<()>> {
+    // Note: most of implementations use 32 reserved sectors for FAT32 but it's wasting of space
+    // This implementation uses only 8. This is enough to fit in two boot sectors (main and backup) with additional
+    // bootstrap code and one FSInfo sector. It also makes FAT alligned to 4096 which is a nice number.
+    let reserved_sectors: u16 = if fat_type == FatType::Fat32 { 8 } else { 1 };
+
+    // Check if volume has enough space to accomodate reserved sectors, FAT, root directory and some data space
+    // Having less than 8 sectors for FAT and data would make a little sense
+    if total_sectors <= u32::from(reserved_sectors) + root_dir_sectors + 8 {
+        error!("Volume is too small");
+        return Err(Error::InvalidInput);
+    }
+
+    // calculate File Allocation Table size
+    let sectors_per_fat = determine_sectors_per_fat(
+        total_sectors,
+        bytes_per_sector,
+        sectors_per_cluster,
+        fat_type,
+        reserved_sectors,
+        root_dir_sectors,
+        fats,
+    );
+
+    let data_sectors =
+        total_sectors - u32::from(reserved_sectors) - root_dir_sectors - sectors_per_fat * u32::from(fats);
+    let total_clusters = data_sectors / u32::from(sectors_per_cluster);
+    if fat_type != FatType::from_clusters(total_clusters) {
+        error!(
+            "Invalid FAT type (expect {:?} due to {} clusters",
+            FatType::from_clusters(total_clusters),
+            total_clusters
+        );
+        return Err(Error::InvalidInput);
+    }
+    debug_assert!(total_clusters >= fat_type.min_clusters());
+    if total_clusters > fat_type.max_clusters() {
+        // Note: it can happen for FAT32
+        error!("Too many clusters");
+        return Err(Error::InvalidInput);
+    }
+
+    Ok((reserved_sectors, sectors_per_fat))
+}
+
+fn determine_root_dir_sectors(root_dir_entries: u16, bytes_per_sector: u16, fat_type: FatType) -> u32 {
+    if fat_type == FatType::Fat32 {
+        0
+    } else {
+        let root_dir_bytes = u32::from(root_dir_entries) * DIR_ENTRY_SIZE;
+        (root_dir_bytes + u32::from(bytes_per_sector) - 1) / u32::from(bytes_per_sector)
+    }
+}
+
+struct FsLayout {
+    fat_type: FatType,
+    reserved_sectors: u16,
+    sectors_per_fat: u32,
+    sectors_per_cluster: u8,
+}
+
+fn determine_fs_layout<E: IoError>(options: &FormatVolumeOptions, total_sectors: u32) -> Result<FsLayout, Error<E>> {
+    let bytes_per_cluster = options.bytes_per_cluster.unwrap_or_else(|| {
+        let total_bytes = u64::from(total_sectors) * u64::from(options.bytes_per_sector);
+        determine_bytes_per_cluster(total_bytes, options.bytes_per_sector, options.fat_type)
+    });
+
+    let sectors_per_cluster_32 = bytes_per_cluster / u32::from(options.bytes_per_sector);
+    let Ok(sectors_per_cluster) = sectors_per_cluster_32.try_into() else {
+        error!("Too many sectors per cluster, please try a different volume size");
+        return Err(Error::InvalidInput);
+    };
+
+    let allowed_fat_types: &[FatType] = options
+        .fat_type
+        .as_ref()
+        .map_or(&[FatType::Fat32, FatType::Fat16, FatType::Fat12], slice::from_ref);
+
+    // Note: this loop is needed because in case of user-provided cluster size it is hard to reliably determine
+    // a proper FAT type. In case of automatic cluster size actual FAT type is determined in `estimate_fat_type`
+    for &fat_type in allowed_fat_types {
+        let root_dir_sectors =
+            determine_root_dir_sectors(options.max_root_dir_entries, options.bytes_per_sector, fat_type);
+        let result = try_fs_layout(
+            total_sectors,
+            options.bytes_per_sector,
+            sectors_per_cluster,
+            fat_type,
+            root_dir_sectors,
+            options.fats,
+        );
+        if let Ok((reserved_sectors, sectors_per_fat)) = result {
+            return Ok(FsLayout {
+                fat_type,
+                reserved_sectors,
+                sectors_per_fat,
+                sectors_per_cluster,
+            });
+        }
+    }
+
+    error!("Cannot select FAT type - unfortunate storage size");
+    Err(Error::InvalidInput)
+}
+
+fn format_bpb<E: IoError>(
+    options: &FormatVolumeOptions,
+    total_sectors: u32,
+) -> Result<(BiosParameterBlock, FatType), Error<E>> {
+    let layout = determine_fs_layout(options, total_sectors)?;
+
+    // drive_num should be 0 for floppy disks and 0x80 for hard disks - determine it using FAT type
+    let drive_num = options
+        .drive_num
+        .unwrap_or_else(|| if layout.fat_type == FatType::Fat12 { 0 } else { 0x80 });
+
+    // setup volume label
+    let volume_label = options.volume_label.unwrap_or(*b"NO NAME    ");
+
+    // setup fs_type_label field
+    let fs_type_label = *match layout.fat_type {
+        FatType::Fat12 => b"FAT12   ",
+        FatType::Fat16 => b"FAT16   ",
+        FatType::Fat32 => b"FAT32   ",
+    };
+
+    // create Bios Parameter Block struct
+    let is_fat32 = layout.fat_type == FatType::Fat32;
+    let sectors_per_fat_16 = if is_fat32 {
+        0
+    } else {
+        let Ok(sectors_per_fat_16) = layout.sectors_per_fat.try_into() else {
+            error!("FAT is too big, please try a different volume size");
+            return Err(Error::InvalidInput);
+        };
+        sectors_per_fat_16
+    };
+    let sectors_per_fat_32 = if is_fat32 { layout.sectors_per_fat } else { 0 };
+
+    let root_entries = if is_fat32 { 0 } else { options.max_root_dir_entries };
+
+    let total_sectors_16 = if is_fat32 {
+        0
+    } else {
+        total_sectors.try_into().unwrap_or(0)
+    };
+    let total_sectors_32 = if total_sectors_16 == 0 { total_sectors } else { 0 };
+
+    let bpb = BiosParameterBlock {
+        bytes_per_sector: options.bytes_per_sector,
+        sectors_per_cluster: layout.sectors_per_cluster,
+        reserved_sectors: layout.reserved_sectors,
+        fats: options.fats,
+        root_entries,
+        total_sectors_16,
+        media: options.media,
+        sectors_per_fat_16,
+        sectors_per_track: options.sectors_per_track,
+        heads: options.heads,
+        hidden_sectors: 0,
+        total_sectors_32,
+        // FAT32 fields start
+        sectors_per_fat_32,
+        extended_flags: 0, // mirroring enabled
+        fs_version: 0,
+        root_dir_first_cluster: if is_fat32 { 2 } else { 0 },
+        fs_info_sector: if is_fat32 { 1 } else { 0 },
+        backup_boot_sector: if is_fat32 { 6 } else { 0 },
+        reserved_0: [0_u8; 12],
+        // FAT32 fields end
+        drive_num,
+        reserved_1: 0,
+        ext_sig: 0x29,
+        volume_id: options.volume_id,
+        volume_label,
+        fs_type_label,
+    };
+
+    // Check if number of clusters is proper for used FAT type
+    if FatType::from_clusters(bpb.total_clusters()) != layout.fat_type {
+        error!("Total number of clusters and FAT type does not match, please try a different volume size");
+        return Err(Error::InvalidInput);
+    }
+
+    Ok((bpb, layout.fat_type))
+}
+
+pub(crate) fn format_boot_sector<E: IoError>(
+    options: &FormatVolumeOptions,
+    total_sectors: u32,
+) -> Result<(BootSector, FatType), Error<E>> {
+    let mut boot = BootSector::default();
+    let (bpb, fat_type) = format_bpb(options, total_sectors)?;
+    boot.bpb = bpb;
+    boot.oem_name.copy_from_slice(b"MSWIN4.1");
+    // Boot code copied from FAT32 boot sector initialized by mkfs.fat
+    boot.bootjmp = [0xEB, 0x58, 0x90];
+    let boot_code: [u8; 129] = [
+        0x0E, 0x1F, 0xBE, 0x77, 0x7C, 0xAC, 0x22, 0xC0, 0x74, 0x0B, 0x56, 0xB4, 0x0E, 0xBB, 0x07, 0x00, 0xCD, 0x10,
+        0x5E, 0xEB, 0xF0, 0x32, 0xE4, 0xCD, 0x16, 0xCD, 0x19, 0xEB, 0xFE, 0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73,
+        0x20, 0x6E, 0x6F, 0x74, 0x20, 0x61, 0x20, 0x62, 0x6F, 0x6F, 0x74, 0x61, 0x62, 0x6C, 0x65, 0x20, 0x64, 0x69,
+        0x73, 0x6B, 0x2E, 0x20, 0x20, 0x50, 0x6C, 0x65, 0x61, 0x73, 0x65, 0x20, 0x69, 0x6E, 0x73, 0x65, 0x72, 0x74,
+        0x20, 0x61, 0x20, 0x62, 0x6F, 0x6F, 0x74, 0x61, 0x62, 0x6C, 0x65, 0x20, 0x66, 0x6C, 0x6F, 0x70, 0x70, 0x79,
+        0x20, 0x61, 0x6E, 0x64, 0x0D, 0x0A, 0x70, 0x72, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6E, 0x79, 0x20, 0x6B, 0x65,
+        0x79, 0x20, 0x74, 0x6F, 0x20, 0x74, 0x72, 0x79, 0x20, 0x61, 0x67, 0x61, 0x69, 0x6E, 0x20, 0x2E, 0x2E, 0x2E,
+        0x20, 0x0D, 0x0A,
+    ];
+    boot.boot_code[..boot_code.len()].copy_from_slice(&boot_code);
+    boot.boot_sig = [0x55, 0xAA];
+
+    // fix offsets in bootjmp and boot code for non-FAT32 filesystems (bootcode is on a different offset)
+    if fat_type != FatType::Fat32 {
+        // offset of boot code
+        const BOOT_CODE_OFFSET: u8 = 0x36 + 8;
+        // offset of message
+        const MESSAGE_OFFSET: u16 = 29;
+        boot.bootjmp[1] = BOOT_CODE_OFFSET - 2;
+        let message_offset_in_sector = u16::from(BOOT_CODE_OFFSET) + MESSAGE_OFFSET + 0x7c00;
+        boot.boot_code[3] = (message_offset_in_sector & 0xff) as u8;
+        boot.boot_code[4] = (message_offset_in_sector >> 8) as u8;
+    }
+
+    Ok((boot, fat_type))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
+    #[test]
+    fn test_estimate_fat_type() {
+        assert_eq!(estimate_fat_type(4 * MB_64), FatType::Fat12);
+        assert_eq!(estimate_fat_type(5 * MB_64), FatType::Fat16);
+        assert_eq!(estimate_fat_type(511 * MB_64), FatType::Fat16);
+        assert_eq!(estimate_fat_type(512 * MB_64), FatType::Fat32);
+    }
+
+    #[test]
+    fn test_determine_bytes_per_cluster_fat12() {
+        assert_eq!(determine_bytes_per_cluster(128 * KB_64, 512, Some(FatType::Fat12)), 512);
+        assert_eq!(determine_bytes_per_cluster(MB_64, 512, Some(FatType::Fat12)), 512);
+        assert_eq!(determine_bytes_per_cluster(MB_64 + 1, 512, Some(FatType::Fat12)), 1024);
+        assert_eq!(determine_bytes_per_cluster(MB_64, 4096, Some(FatType::Fat12)), 4096);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_determine_bytes_per_cluster_fat16() {
+        assert_eq!(determine_bytes_per_cluster(MB_64,            512, Some(FatType::Fat16)), KB_32);
+        assert_eq!(determine_bytes_per_cluster(MB_64,            4096, Some(FatType::Fat16)), 4 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(16 * MB_64,       512, Some(FatType::Fat16)), KB_32);
+        assert_eq!(determine_bytes_per_cluster(16 * MB_64 + 1,   512, Some(FatType::Fat16)), 2 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(128 * MB_64,      512, Some(FatType::Fat16)), 2 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(128 * MB_64 + 1,  512, Some(FatType::Fat16)), 4 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(256 * MB_64,      512, Some(FatType::Fat16)), 4 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(256 * MB_64 + 1,  512, Some(FatType::Fat16)), 8 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(512 * MB_64,      512, Some(FatType::Fat16)), 8 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(512 * MB_64 + 1,  512, Some(FatType::Fat16)), 16 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(1024 * MB_64,     512, Some(FatType::Fat16)), 16 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(1024 * MB_64 + 1, 512, Some(FatType::Fat16)), 32 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(99999 * MB_64,    512, Some(FatType::Fat16)), 32 * KB_32);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_determine_bytes_per_cluster_fat32() {
+        assert_eq!(determine_bytes_per_cluster(260 * MB_64,     512, Some(FatType::Fat32)), 512);
+        assert_eq!(determine_bytes_per_cluster(260 * MB_64,     4096, Some(FatType::Fat32)), 4 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(260 * MB_64 + 1, 512, Some(FatType::Fat32)), 4 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(8   * GB_64,     512, Some(FatType::Fat32)), 4 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(8   * GB_64 + 1, 512, Some(FatType::Fat32)), 8 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(16  * GB_64,     512, Some(FatType::Fat32)), 8 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(16  * GB_64 + 1, 512, Some(FatType::Fat32)), 16 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(32  * GB_64,     512, Some(FatType::Fat32)), 16 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(32  * GB_64 + 1, 512, Some(FatType::Fat32)), 32 * KB_32);
+        assert_eq!(determine_bytes_per_cluster(999 * GB_64,     512, Some(FatType::Fat32)), 32 * KB_32);
+    }
+
+    fn test_determine_sectors_per_fat_single(
+        total_bytes: u64,
+        bytes_per_sector: u16,
+        bytes_per_cluster: u32,
+        fat_type: FatType,
+        reserved_sectors: u16,
+        fats: u8,
+        root_dir_entries: u32,
+    ) {
+        let total_sectors = total_bytes / u64::from(bytes_per_sector);
+        debug_assert!(total_sectors <= u64::from(u32::MAX), "{:x}", total_sectors);
+        let total_sectors = total_sectors as u32;
+
+        let sectors_per_cluster = (bytes_per_cluster / u32::from(bytes_per_sector)) as u8;
+        let root_dir_size = root_dir_entries * DIR_ENTRY_SIZE;
+        let root_dir_sectors = (root_dir_size + u32::from(bytes_per_sector) - 1) / u32::from(bytes_per_sector);
+        let sectors_per_fat = determine_sectors_per_fat(
+            total_sectors,
+            bytes_per_sector,
+            sectors_per_cluster,
+            fat_type,
+            reserved_sectors,
+            root_dir_sectors,
+            fats,
+        );
+
+        let sectors_per_all_fats = u32::from(fats) * sectors_per_fat;
+        let total_data_sectors = total_sectors - u32::from(reserved_sectors) - sectors_per_all_fats - root_dir_sectors;
+        let total_clusters = total_data_sectors / u32::from(sectors_per_cluster);
+        if FatType::from_clusters(total_clusters) != fat_type {
+            // Skip impossible FAT configurations
+            return;
+        }
+        let bits_per_sector = u32::from(bytes_per_sector) * BITS_PER_BYTE;
+        let bits_per_fat = u64::from(sectors_per_fat) * u64::from(bits_per_sector);
+        let total_fat_entries = (bits_per_fat / u64::from(fat_type.bits_per_fat_entry())) as u32;
+        let fat_clusters = total_fat_entries - RESERVED_FAT_ENTRIES;
+        // Note: fat_entries_per_sector is rounded down for FAT12
+        let fat_entries_per_sector = bits_per_sector / fat_type.bits_per_fat_entry();
+        let desc = format!("total_clusters {}, fat_clusters {}, total_sectors {}, bytes/sector {}, sectors/cluster {}, fat_type {:?}, reserved_sectors {}, root_dir_sectors {}, sectors_per_fat {}",
+            total_clusters, fat_clusters, total_sectors, bytes_per_sector, sectors_per_cluster, fat_type, reserved_sectors, root_dir_sectors, sectors_per_fat);
+        assert!(fat_clusters >= total_clusters, "Too small FAT: {}", desc);
+        let expected_max_fat_clusters = total_clusters + 2 * fat_entries_per_sector;
+        assert!(fat_clusters <= expected_max_fat_clusters, "Too big FAT: {}", desc);
+    }
+
+    fn test_determine_sectors_per_fat_for_multiple_sizes(
+        bytes_per_sector: u16,
+        fat_type: FatType,
+        reserved_sectors: u16,
+        fats: u8,
+        root_dir_entries: u32,
+    ) {
+        let mut bytes_per_cluster = u32::from(bytes_per_sector);
+        while bytes_per_cluster <= 64 * KB_32 {
+            let mut size: u64 = MB_64;
+            while size < 2048 * GB_64 {
+                test_determine_sectors_per_fat_single(
+                    size,
+                    bytes_per_sector,
+                    bytes_per_cluster,
+                    fat_type,
+                    reserved_sectors,
+                    fats,
+                    root_dir_entries,
+                );
+                size = size + size / 7;
+            }
+            size = 2048 * GB_64 - 1;
+            test_determine_sectors_per_fat_single(
+                size,
+                bytes_per_sector,
+                bytes_per_cluster,
+                fat_type,
+                reserved_sectors,
+                fats,
+                root_dir_entries,
+            );
+            bytes_per_cluster *= 2;
+        }
+    }
+
+    #[test]
+    fn test_determine_sectors_per_fat() {
+        init();
+
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat12, 1, 2, 512);
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat12, 1, 1, 512);
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat12, 1, 2, 8192);
+        test_determine_sectors_per_fat_for_multiple_sizes(4096, FatType::Fat12, 1, 2, 512);
+
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat16, 1, 2, 512);
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat16, 1, 1, 512);
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat16, 1, 2, 8192);
+        test_determine_sectors_per_fat_for_multiple_sizes(4096, FatType::Fat16, 1, 2, 512);
+
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat32, 32, 2, 0);
+        test_determine_sectors_per_fat_for_multiple_sizes(512, FatType::Fat32, 32, 1, 0);
+        test_determine_sectors_per_fat_for_multiple_sizes(4096, FatType::Fat32, 32, 2, 0);
+    }
+
+    #[test]
+    fn test_format_boot_sector() {
+        init();
+
+        let bytes_per_sector = 512_u16;
+        // test all partition sizes from 1MB to 2TB (u32::MAX sectors is 2TB - 1 for 512 byte sectors)
+        let mut total_sectors_vec = Vec::new();
+        let mut size = MB_64;
+        while size < 2048 * GB_64 {
+            total_sectors_vec.push((size / u64::from(bytes_per_sector)) as u32);
+            size = size + size / 7;
+        }
+        total_sectors_vec.push(u32::MAX);
+        total_sectors_vec.push(8227);
+        for total_sectors in total_sectors_vec {
+            let (boot, _) = format_boot_sector::<()>(&FormatVolumeOptions::new(), total_sectors)
+                .unwrap_or_else(|_| panic!("format_boot_sector total_sectors: {}", total_sectors));
+            boot.validate::<()>(true).expect("validate");
+        }
+    }
+
+    fn test_determine_fs_layout(fat_type: FatType, min_size: u64, max_size: u64) {
+        init();
+
+        let bytes_per_sector = 512_u16;
+        // test all partition sizes from 24 KB to 127 MB
+        let mut total_sectors_vec = Vec::new();
+        let mut size = min_size;
+        while size < max_size {
+            total_sectors_vec.push((size / u64::from(bytes_per_sector)).try_into().unwrap());
+            size += size / 7;
+        }
+        total_sectors_vec.push((max_size / u64::from(bytes_per_sector)).try_into().unwrap());
+        for total_sectors in total_sectors_vec {
+            let options = FormatVolumeOptions::new().fat_type(fat_type);
+            let layout = determine_fs_layout::<()>(&options, total_sectors)
+                .unwrap_or_else(|e| panic!("determine_fs_layout(total_sectors={}): {:?}", total_sectors, e));
+            assert_eq!(layout.fat_type, fat_type);
+        }
+    }
+
+    #[test]
+    fn test_determine_fs_layout_fat12() {
+        // approximately: 21 KB - 127 MB
+        test_determine_fs_layout(FatType::Fat12, 21 * KB_64, 127 * MB_64);
+    }
+
+    #[test]
+    fn test_determine_fs_layout_fat16() {
+        // approximately: 4.1 MB - 1.9 GB
+        test_determine_fs_layout(FatType::Fat16, 4120 * KB_64, 2047 * MB_64);
+    }
+
+    #[test]
+    fn test_determine_fs_layout_fat32() {
+        // approximately: 33 MB - 1.9 TB
+        test_determine_fs_layout(FatType::Fat32, 33 * MB_64, 2048 * GB_64 - 1);
+    }
+}

--- a/fatfs/src/dir.rs
+++ b/fatfs/src/dir.rs
@@ -1,0 +1,1365 @@
+#[cfg(all(not(feature = "std"), feature = "alloc", feature = "lfn"))]
+use alloc::vec::Vec;
+use core::num;
+use core::str;
+#[cfg(feature = "lfn")]
+use core::{iter, slice};
+
+use crate::dir_entry::{
+    DirEntry, DirEntryData, DirFileEntryData, DirLfnEntryData, FileAttributes, ShortName, DIR_ENTRY_SIZE,
+};
+#[cfg(feature = "lfn")]
+use crate::dir_entry::{LFN_ENTRY_LAST_FLAG, LFN_PART_LEN};
+use crate::dir_entry::{SFN_PADDING, SFN_SIZE};
+use crate::error::{Error, IoError};
+use crate::file::File;
+use crate::fs::{DiskSlice, FileSystem, FsIoAdapter, OemCpConverter, ReadWriteSeek};
+use crate::io::{self, IoBase, Read, Seek, SeekFrom, Write};
+use crate::time::TimeProvider;
+
+const LFN_PADDING: u16 = 0xFFFF;
+
+pub(crate) enum DirRawStream<'a, IO: ReadWriteSeek, TP, OCC> {
+    File(File<'a, IO, TP, OCC>),
+    Root(DiskSlice<FsIoAdapter<'a, IO, TP, OCC>, FsIoAdapter<'a, IO, TP, OCC>>),
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> DirRawStream<'_, IO, TP, OCC> {
+    fn abs_pos(&self) -> Option<u64> {
+        match self {
+            DirRawStream::File(file) => file.abs_pos(),
+            DirRawStream::Root(slice) => Some(slice.abs_pos()),
+        }
+    }
+
+    fn first_cluster(&self) -> Option<u32> {
+        match self {
+            DirRawStream::File(file) => file.first_cluster(),
+            DirRawStream::Root(_) => None,
+        }
+    }
+
+    pub(crate) fn is_root_dir(&self) -> bool {
+        match self {
+            DirRawStream::File(file) => file.is_root_dir(),
+            DirRawStream::Root(_) => true,
+        }
+    }
+}
+
+// Note: derive cannot be used because of invalid bounds. See: https://github.com/rust-lang/rust/issues/26925
+impl<IO: ReadWriteSeek, TP, OCC> Clone for DirRawStream<'_, IO, TP, OCC> {
+    fn clone(&self) -> Self {
+        match self {
+            DirRawStream::File(file) => DirRawStream::File(file.clone()),
+            DirRawStream::Root(raw) => DirRawStream::Root(raw.clone()),
+        }
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> IoBase for DirRawStream<'_, IO, TP, OCC> {
+    type Error = Error<IO::Error>;
+}
+
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> Read for DirRawStream<'_, IO, TP, OCC> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        match self {
+            DirRawStream::File(file) => file.read(buf),
+            DirRawStream::Root(raw) => raw.read(buf),
+        }
+    }
+}
+
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> Write for DirRawStream<'_, IO, TP, OCC> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        match self {
+            DirRawStream::File(file) => file.write(buf),
+            DirRawStream::Root(raw) => raw.write(buf),
+        }
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        match self {
+            DirRawStream::File(file) => file.flush(),
+            DirRawStream::Root(raw) => raw.flush(),
+        }
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> Seek for DirRawStream<'_, IO, TP, OCC> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        match self {
+            DirRawStream::File(file) => file.seek(pos),
+            DirRawStream::Root(raw) => raw.seek(pos),
+        }
+    }
+}
+
+fn split_path(path: &str) -> (&str, Option<&str>) {
+    let trimmed_path = path.trim_matches('/');
+    trimmed_path.find('/').map_or((trimmed_path, None), |n| {
+        (&trimmed_path[..n], Some(&trimmed_path[n + 1..]))
+    })
+}
+
+enum DirEntryOrShortName<'a, IO: ReadWriteSeek, TP, OCC> {
+    DirEntry(DirEntry<'a, IO, TP, OCC>),
+    ShortName([u8; SFN_SIZE]),
+}
+
+/// A FAT filesystem directory.
+///
+/// This struct is created by the `open_dir` or `create_dir` methods on `Dir`.
+/// The root directory is returned by the `root_dir` method on `FileSystem`.
+pub struct Dir<'a, IO: ReadWriteSeek, TP, OCC> {
+    stream: DirRawStream<'a, IO, TP, OCC>,
+    fs: &'a FileSystem<IO, TP, OCC>,
+}
+
+impl<'a, IO: ReadWriteSeek, TP, OCC> Dir<'a, IO, TP, OCC> {
+    pub(crate) fn new(stream: DirRawStream<'a, IO, TP, OCC>, fs: &'a FileSystem<IO, TP, OCC>) -> Self {
+        Dir { stream, fs }
+    }
+
+    /// Creates directory entries iterator.
+    #[must_use]
+    #[allow(clippy::iter_not_returning_iterator)]
+    pub fn iter(&self) -> DirIter<'a, IO, TP, OCC> {
+        DirIter::new(self.stream.clone(), self.fs, true)
+    }
+}
+
+impl<'a, IO: ReadWriteSeek, TP: TimeProvider, OCC: OemCpConverter> Dir<'a, IO, TP, OCC> {
+    fn find_entry(
+        &self,
+        name: &str,
+        is_dir: Option<bool>,
+        mut short_name_gen: Option<&mut ShortNameGenerator>,
+    ) -> Result<DirEntry<'a, IO, TP, OCC>, Error<IO::Error>> {
+        for r in self.iter() {
+            let e = r?;
+            // compare name ignoring case
+            if e.eq_name(name) {
+                // check if file or directory is expected
+                if is_dir.is_some() && Some(e.is_dir()) != is_dir {
+                    if e.is_dir() {
+                        error!("Is a directory");
+                    } else {
+                        error!("Not a directory");
+                    }
+                    return Err(Error::InvalidInput);
+                }
+                return Ok(e);
+            }
+            // update short name generator state
+            if let Some(ref mut gen) = short_name_gen {
+                gen.add_existing(e.raw_short_name());
+            }
+        }
+        Err(Error::NotFound) //("No such file or directory"))
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn find_volume_entry(&self) -> Result<Option<DirEntry<'a, IO, TP, OCC>>, Error<IO::Error>> {
+        for r in DirIter::new(self.stream.clone(), self.fs, false) {
+            let e = r?;
+            if e.data.is_volume() {
+                return Ok(Some(e));
+            }
+        }
+        Ok(None)
+    }
+
+    fn check_for_existence(
+        &self,
+        name: &str,
+        is_dir: Option<bool>,
+    ) -> Result<DirEntryOrShortName<'a, IO, TP, OCC>, Error<IO::Error>> {
+        let mut short_name_gen = ShortNameGenerator::new(name);
+        loop {
+            // find matching entry
+            let r = self.find_entry(name, is_dir, Some(&mut short_name_gen));
+            match r {
+                // file not found - continue with short name generation
+                Err(Error::NotFound) => {}
+                // unexpected error - return it
+                Err(err) => return Err(err),
+                // directory already exists - return it
+                Ok(e) => return Ok(DirEntryOrShortName::DirEntry(e)),
+            };
+            // try to generate short name
+            if let Ok(name) = short_name_gen.generate() {
+                return Ok(DirEntryOrShortName::ShortName(name));
+            }
+            // there were too many collisions in short name generation
+            // try different checksum in the next iteration
+            short_name_gen.next_iteration();
+        }
+    }
+
+    /// Opens existing subdirectory.
+    ///
+    /// `path` is a '/' separated directory path relative to self directory.
+    ///
+    /// # Errors
+    ///
+    /// Errors that can be returned:
+    ///
+    /// * `Error::NotFound` will be returned if `path` does not point to any existing directory entry.
+    /// * `Error::InvalidInput` will be returned if `path` points to a file that is not a directory.
+    /// * `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn open_dir(&self, path: &str) -> Result<Self, Error<IO::Error>> {
+        trace!("Dir::open_dir {}", path);
+        let (name, rest_opt) = split_path(path);
+        let e = self.find_entry(name, Some(true), None)?;
+        match rest_opt {
+            Some(rest) => e.to_dir().open_dir(rest),
+            None => Ok(e.to_dir()),
+        }
+    }
+
+    /// Opens existing file.
+    ///
+    /// `path` is a '/' separated file path relative to self directory.
+    ///
+    /// # Errors
+    ///
+    /// Errors that can be returned:
+    ///
+    /// * `Error::NotFound` will be returned if `path` points to a non-existing directory entry.
+    /// * `Error::InvalidInput` will be returned if `path` points to a file that is a directory.
+    /// * `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn open_file(&self, path: &str) -> Result<File<'a, IO, TP, OCC>, Error<IO::Error>> {
+        trace!("Dir::open_file {}", path);
+        // traverse path
+        let (name, rest_opt) = split_path(path);
+        if let Some(rest) = rest_opt {
+            let e = self.find_entry(name, Some(true), None)?;
+            return e.to_dir().open_file(rest);
+        }
+        // convert entry to a file
+        let e = self.find_entry(name, Some(false), None)?;
+        Ok(e.to_file())
+    }
+
+    /// Creates new or opens existing file=.
+    ///
+    /// `path` is a '/' separated file path relative to `self` directory.
+    /// File is never truncated when opening. It can be achieved by calling `File::truncate` method after opening.
+    ///
+    /// # Errors
+    ///
+    /// Errors that can be returned:
+    ///
+    /// * `Error::InvalidInput` will be returned if `path` points to an existing file that is a directory.
+    /// * `Error::InvalidFileNameLength` will be returned if the file name is empty or if it is too long.
+    /// * `Error::UnsupportedFileNameCharacter` will be returned if the file name contains an invalid character.
+    /// * `Error::NotEnoughSpace` will be returned if there is not enough free space to create a new file.
+    /// * `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn create_file(&self, path: &str) -> Result<File<'a, IO, TP, OCC>, Error<IO::Error>> {
+        trace!("Dir::create_file {}", path);
+        // traverse path
+        let (name, rest_opt) = split_path(path);
+        if let Some(rest) = rest_opt {
+            return self.find_entry(name, Some(true), None)?.to_dir().create_file(rest);
+        }
+        // this is final filename in the path
+        let r = self.check_for_existence(name, Some(false))?;
+        match r {
+            // file does not exist - create it
+            DirEntryOrShortName::ShortName(short_name) => {
+                let sfn_entry = self.create_sfn_entry(short_name, FileAttributes::from_bits_truncate(0), None);
+                Ok(self.write_entry(name, sfn_entry)?.to_file())
+            }
+            // file already exists - return it
+            DirEntryOrShortName::DirEntry(e) => Ok(e.to_file()),
+        }
+    }
+
+    /// Creates new directory or opens existing.
+    ///
+    /// `path` is a '/' separated path relative to self directory.
+    ///
+    /// # Errors
+    ///
+    /// Errors that can be returned:
+    ///
+    /// * `Error::InvalidInput` will be returned if `path` points to an existing file that is not a directory.
+    /// * `Error::InvalidFileNameLength` will be returned if the file name is empty or if it is too long.
+    /// * `Error::UnsupportedFileNameCharacter` will be returned if the file name contains an invalid character.
+    /// * `Error::NotEnoughSpace` will be returned if there is not enough free space to create a new directory.
+    /// * `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn create_dir(&self, path: &str) -> Result<Self, Error<IO::Error>> {
+        trace!("Dir::create_dir {}", path);
+        // traverse path
+        let (name, rest_opt) = split_path(path);
+        if let Some(rest) = rest_opt {
+            return self.find_entry(name, Some(true), None)?.to_dir().create_dir(rest);
+        }
+        // this is final filename in the path
+        let r = self.check_for_existence(name, Some(true))?;
+        match r {
+            // directory does not exist - create it
+            DirEntryOrShortName::ShortName(short_name) => {
+                // alloc cluster for directory data
+                let cluster = self.fs.alloc_cluster(None, true)?;
+                // create entry in parent directory
+                let sfn_entry = self.create_sfn_entry(short_name, FileAttributes::DIRECTORY, Some(cluster));
+                let entry = self.write_entry(name, sfn_entry)?;
+                let dir = entry.to_dir();
+                // create special entries "." and ".."
+                let dot_sfn = ShortNameGenerator::generate_dot();
+                let sfn_entry = self.create_sfn_entry(dot_sfn, FileAttributes::DIRECTORY, entry.first_cluster());
+                dir.write_entry(".", sfn_entry)?;
+                let dotdot_sfn = ShortNameGenerator::generate_dotdot();
+                // cluster of the root dir shall be set to 0 in directory entries.
+                let dotdot_cluster = if self.stream.is_root_dir() {
+                    None
+                } else {
+                    self.stream.first_cluster()
+                };
+                let sfn_entry = self.create_sfn_entry(dotdot_sfn, FileAttributes::DIRECTORY, dotdot_cluster);
+                dir.write_entry("..", sfn_entry)?;
+                Ok(dir)
+            }
+            // directory already exists - return it
+            DirEntryOrShortName::DirEntry(e) => Ok(e.to_dir()),
+        }
+    }
+
+    fn is_empty(&self) -> Result<bool, Error<IO::Error>> {
+        trace!("Dir::is_empty");
+        // check if directory contains no files
+        for r in self.iter() {
+            let e = r?;
+            let name = e.short_file_name_as_bytes();
+            // ignore special entries "." and ".."
+            if name != b"." && name != b".." {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    /// Removes existing file or directory.
+    ///
+    /// `path` is a '/' separated file path relative to self directory.
+    /// Make sure there is no reference to this file (no File instance) or filesystem corruption
+    /// can happen.
+    ///
+    /// # Errors
+    ///
+    /// Errors that can be returned:
+    ///
+    /// * `Error::NotFound` will be returned if `path` points to a non-existing directory entry.
+    /// * `Error::InvalidInput` will be returned if `path` points to a file that is not a directory.
+    /// * `Error::DirectoryIsNotEmpty` will be returned if the specified directory is not empty.
+    /// * `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn remove(&self, path: &str) -> Result<(), Error<IO::Error>> {
+        trace!("Dir::remove {}", path);
+        // traverse path
+        let (name, rest_opt) = split_path(path);
+        if let Some(rest) = rest_opt {
+            let e = self.find_entry(name, Some(true), None)?;
+            return e.to_dir().remove(rest);
+        }
+        // in case of directory check if it is empty
+        let e = self.find_entry(name, None, None)?;
+        if e.is_dir() && !e.to_dir().is_empty()? {
+            return Err(Error::DirectoryIsNotEmpty);
+        }
+        // free data
+        if let Some(n) = e.first_cluster() {
+            self.fs.free_cluster_chain(n)?;
+        }
+        // free long and short name entries
+        let mut stream = self.stream.clone();
+        stream.seek(SeekFrom::Start(e.offset_range.0))?;
+        let num = ((e.offset_range.1 - e.offset_range.0) / u64::from(DIR_ENTRY_SIZE)) as usize;
+        for _ in 0..num {
+            let mut data = DirEntryData::deserialize(&mut stream)?;
+            trace!("removing dir entry {:?}", data);
+            data.set_deleted();
+            stream.seek(SeekFrom::Current(-i64::from(DIR_ENTRY_SIZE)))?;
+            data.serialize(&mut stream)?;
+        }
+        Ok(())
+    }
+
+    /// Renames or moves existing file or directory.
+    ///
+    /// `src_path` is a '/' separated source file path relative to self directory.
+    /// `dst_path` is a '/' separated destination file path relative to `dst_dir`.
+    /// `dst_dir` can be set to self directory if rename operation without moving is needed.
+    /// Make sure there is no reference to this file (no File instance) or filesystem corruption
+    /// can happen.
+    ///
+    /// # Errors
+    ///
+    /// Errors that can be returned:
+    ///
+    /// * `Error::NotFound` will be returned if `src_path` points to a non-existing directory entry or if `dst_path`
+    ///   stripped from the last component does not point to an existing directory.
+    /// * `Error::AlreadyExists` will be returned if `dst_path` points to an existing directory entry.
+    /// * `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn rename(&self, src_path: &str, dst_dir: &Dir<IO, TP, OCC>, dst_path: &str) -> Result<(), Error<IO::Error>> {
+        trace!("Dir::rename {} {}", src_path, dst_path);
+        // traverse source path
+        let (src_name, src_rest_opt) = split_path(src_path);
+        if let Some(rest) = src_rest_opt {
+            let e = self.find_entry(src_name, Some(true), None)?;
+            return e.to_dir().rename(rest, dst_dir, dst_path);
+        }
+        // traverse destination path
+        let (dst_name, dst_rest_opt) = split_path(dst_path);
+        if let Some(rest) = dst_rest_opt {
+            let e = dst_dir.find_entry(dst_name, Some(true), None)?;
+            return self.rename(src_path, &e.to_dir(), rest);
+        }
+        // move/rename file
+        self.rename_internal(src_path, dst_dir, dst_path)
+    }
+
+    fn rename_internal(
+        &self,
+        src_name: &str,
+        dst_dir: &Dir<IO, TP, OCC>,
+        dst_name: &str,
+    ) -> Result<(), Error<IO::Error>> {
+        trace!("Dir::rename_internal {} {}", src_name, dst_name);
+        // find existing file
+        let e = self.find_entry(src_name, None, None)?;
+        // check if destionation filename is unused
+        let r = dst_dir.check_for_existence(dst_name, None)?;
+        let short_name = match r {
+            // destination file already exist
+            DirEntryOrShortName::DirEntry(ref dst_e) => {
+                // check if source and destination entry is the same
+                if e.is_same_entry(dst_e) {
+                    // nothing to do
+                    return Ok(());
+                }
+                // destination file exists and it is not the same as source file - fail
+                return Err(Error::AlreadyExists);
+            }
+            // destionation file does not exist, short name has been generated
+            DirEntryOrShortName::ShortName(short_name) => short_name,
+        };
+        // free long and short name entries
+        let mut stream = self.stream.clone();
+        stream.seek(SeekFrom::Start(e.offset_range.0))?;
+        let num = ((e.offset_range.1 - e.offset_range.0) / u64::from(DIR_ENTRY_SIZE)) as usize;
+        for _ in 0..num {
+            let mut data = DirEntryData::deserialize(&mut stream)?;
+            trace!("removing LFN entry {:?}", data);
+            data.set_deleted();
+            stream.seek(SeekFrom::Current(-i64::from(DIR_ENTRY_SIZE)))?;
+            data.serialize(&mut stream)?;
+        }
+        // save new directory entry
+        let sfn_entry = e.data.renamed(short_name);
+        dst_dir.write_entry(dst_name, sfn_entry)?;
+        Ok(())
+    }
+
+    fn find_free_entries(&self, num_entries: u32) -> Result<DirRawStream<'a, IO, TP, OCC>, Error<IO::Error>> {
+        let mut stream = self.stream.clone();
+        let mut first_free: u32 = 0;
+        let mut num_free: u32 = 0;
+        let mut i: u32 = 0;
+        loop {
+            let raw_entry = DirEntryData::deserialize(&mut stream)?;
+            if raw_entry.is_end() {
+                // first unused entry - all remaining space can be used
+                if num_free == 0 {
+                    first_free = i;
+                }
+                let pos = u64::from(first_free * DIR_ENTRY_SIZE);
+                stream.seek(io::SeekFrom::Start(pos))?;
+                return Ok(stream);
+            } else if raw_entry.is_deleted() {
+                // free entry - calculate number of free entries in a row
+                if num_free == 0 {
+                    first_free = i;
+                }
+                num_free += 1;
+                if num_free == num_entries {
+                    // enough space for new file
+                    let pos = u64::from(first_free * DIR_ENTRY_SIZE);
+                    stream.seek(io::SeekFrom::Start(pos))?;
+                    return Ok(stream);
+                }
+            } else {
+                // used entry - start counting from 0
+                num_free = 0;
+            }
+            i += 1;
+        }
+    }
+
+    fn create_sfn_entry(
+        &self,
+        short_name: [u8; SFN_SIZE],
+        attrs: FileAttributes,
+        first_cluster: Option<u32>,
+    ) -> DirFileEntryData {
+        let mut raw_entry = DirFileEntryData::new(short_name, attrs);
+        raw_entry.set_first_cluster(first_cluster, self.fs.fat_type());
+        let now = self.fs.options.time_provider.get_current_date_time();
+        raw_entry.set_created(now);
+        raw_entry.set_accessed(now.date);
+        raw_entry.set_modified(now);
+        raw_entry
+    }
+
+    #[cfg(feature = "lfn")]
+    fn encode_lfn_utf16(name: &str) -> LfnBuffer {
+        LfnBuffer::from_ucs2_units(name.encode_utf16())
+    }
+    #[cfg(not(feature = "lfn"))]
+    fn encode_lfn_utf16(_name: &str) -> LfnBuffer {
+        LfnBuffer {}
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn alloc_and_write_lfn_entries(
+        &self,
+        lfn_utf16: &LfnBuffer,
+        short_name: &[u8; SFN_SIZE],
+    ) -> Result<(DirRawStream<'a, IO, TP, OCC>, u64), Error<IO::Error>> {
+        // get short name checksum
+        let lfn_chsum = lfn_checksum(short_name);
+        // create LFN entries generator
+        let lfn_iter = LfnEntriesGenerator::new(lfn_utf16.as_ucs2_units(), lfn_chsum);
+        // find space for new entries (multiple LFN entries and 1 SFN entry)
+        let num_entries = lfn_iter.len() as u32 + 1;
+        let mut stream = self.find_free_entries(num_entries)?;
+        let start_pos = stream.seek(io::SeekFrom::Current(0))?;
+        // write LFN entries before SFN entry
+        for lfn_entry in lfn_iter {
+            lfn_entry.serialize(&mut stream)?;
+        }
+        Ok((stream, start_pos))
+    }
+
+    fn alloc_sfn_entry(&self) -> Result<(DirRawStream<'a, IO, TP, OCC>, u64), Error<IO::Error>> {
+        let mut stream = self.find_free_entries(1)?;
+        let start_pos = stream.seek(io::SeekFrom::Current(0))?;
+        Ok((stream, start_pos))
+    }
+
+    fn write_entry(
+        &self,
+        name: &str,
+        raw_entry: DirFileEntryData,
+    ) -> Result<DirEntry<'a, IO, TP, OCC>, Error<IO::Error>> {
+        trace!("Dir::write_entry {}", name);
+        // check if name doesn't contain unsupported characters
+        validate_long_name(name)?;
+        // convert long name to UTF-16
+        let lfn_utf16 = Self::encode_lfn_utf16(name);
+        // write LFN entries, except for . and .., which need to be at
+        // the first two slots and don't need LFNs anyway
+        let (mut stream, start_pos) = if name == "." || name == ".." {
+            self.alloc_sfn_entry()?
+        } else {
+            self.alloc_and_write_lfn_entries(&lfn_utf16, raw_entry.name())?
+        };
+        // write short name entry
+        raw_entry.serialize(&mut stream)?;
+        // Get position directory stream after entries were written
+        let end_pos = stream.seek(io::SeekFrom::Current(0))?;
+        // Get current absolute position on the storage
+        // Unwrapping is safe because abs_pos() returns None only if stream is at position 0. This is not
+        // the case because an entry was just written
+        // Note: if current position is on the cluster boundary then a position in the cluster containing the entry is
+        // returned
+        let end_abs_pos = stream.abs_pos().unwrap();
+        // Calculate SFN entry start position on the storage
+        let start_abs_pos = end_abs_pos - u64::from(DIR_ENTRY_SIZE);
+        // return new logical entry descriptor
+        let short_name = ShortName::new(raw_entry.name());
+        Ok(DirEntry {
+            data: raw_entry,
+            short_name,
+            #[cfg(feature = "lfn")]
+            lfn_utf16,
+            fs: self.fs,
+            entry_pos: start_abs_pos,
+            offset_range: (start_pos, end_pos),
+        })
+    }
+}
+
+// Note: derive cannot be used because of invalid bounds. See: https://github.com/rust-lang/rust/issues/26925
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC: OemCpConverter> Clone for Dir<'_, IO, TP, OCC> {
+    fn clone(&self) -> Self {
+        Self {
+            stream: self.stream.clone(),
+            fs: self.fs,
+        }
+    }
+}
+
+/// An iterator over the directory entries.
+///
+/// This struct is created by the `iter` method on `Dir`.
+pub struct DirIter<'a, IO: ReadWriteSeek, TP, OCC> {
+    stream: DirRawStream<'a, IO, TP, OCC>,
+    fs: &'a FileSystem<IO, TP, OCC>,
+    skip_volume: bool,
+    err: bool,
+}
+
+impl<'a, IO: ReadWriteSeek, TP, OCC> DirIter<'a, IO, TP, OCC> {
+    fn new(stream: DirRawStream<'a, IO, TP, OCC>, fs: &'a FileSystem<IO, TP, OCC>, skip_volume: bool) -> Self {
+        DirIter {
+            stream,
+            fs,
+            skip_volume,
+            err: false,
+        }
+    }
+}
+
+impl<'a, IO: ReadWriteSeek, TP: TimeProvider, OCC> DirIter<'a, IO, TP, OCC> {
+    fn should_skip_entry(&self, raw_entry: &DirEntryData) -> bool {
+        if raw_entry.is_deleted() {
+            return true;
+        }
+        match raw_entry {
+            DirEntryData::File(sfn_entry) => self.skip_volume && sfn_entry.is_volume(),
+            DirEntryData::Lfn(_) => false,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn read_dir_entry(&mut self) -> Result<Option<DirEntry<'a, IO, TP, OCC>>, Error<IO::Error>> {
+        trace!("DirIter::read_dir_entry");
+        let mut lfn_builder = LongNameBuilder::new();
+        let mut offset = self.stream.seek(SeekFrom::Current(0))?;
+        let mut begin_offset = offset;
+        loop {
+            let raw_entry = DirEntryData::deserialize(&mut self.stream)?;
+            offset += u64::from(DIR_ENTRY_SIZE);
+            // Check if this is end of dir
+            if raw_entry.is_end() {
+                return Ok(None);
+            }
+            // Check if this is deleted or volume ID entry
+            if self.should_skip_entry(&raw_entry) {
+                trace!("skip entry");
+                lfn_builder.clear();
+                begin_offset = offset;
+                continue;
+            }
+            match raw_entry {
+                DirEntryData::File(data) => {
+                    // Get current absolute position on the storage
+                    // Unwrapping is safe because abs_pos() returns None only if stream is at position 0. This is not
+                    // the case because an entry was just read
+                    // Note: if current position is on the cluster boundary then a position in the cluster containing the entry is
+                    // returned
+                    let end_abs_pos = self.stream.abs_pos().unwrap();
+                    // Calculate SFN entry start position on the storage
+                    let abs_pos = end_abs_pos - u64::from(DIR_ENTRY_SIZE);
+                    // Check if LFN checksum is valid
+                    lfn_builder.validate_chksum(data.name());
+                    // Return directory entry
+                    let short_name = ShortName::new(data.name());
+                    trace!("file entry {:?}", data.name());
+                    return Ok(Some(DirEntry {
+                        data,
+                        short_name,
+                        #[cfg(feature = "lfn")]
+                        lfn_utf16: lfn_builder.into_buf(),
+                        fs: self.fs,
+                        entry_pos: abs_pos,
+                        offset_range: (begin_offset, offset),
+                    }));
+                }
+                DirEntryData::Lfn(data) => {
+                    // Append to LFN buffer
+                    trace!("lfn entry");
+                    lfn_builder.process(&data);
+                }
+            }
+        }
+    }
+}
+
+// Note: derive cannot be used because of invalid bounds. See: https://github.com/rust-lang/rust/issues/26925
+impl<IO: ReadWriteSeek, TP, OCC> Clone for DirIter<'_, IO, TP, OCC> {
+    fn clone(&self) -> Self {
+        Self {
+            stream: self.stream.clone(),
+            fs: self.fs,
+            err: self.err,
+            skip_volume: self.skip_volume,
+        }
+    }
+}
+
+impl<'a, IO: ReadWriteSeek, TP: TimeProvider, OCC> Iterator for DirIter<'a, IO, TP, OCC> {
+    type Item = Result<DirEntry<'a, IO, TP, OCC>, Error<IO::Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.err {
+            return None;
+        }
+        let r = self.read_dir_entry();
+        match r {
+            Ok(Some(e)) => Some(Ok(e)),
+            Ok(None) => None,
+            Err(err) => {
+                self.err = true;
+                Some(Err(err))
+            }
+        }
+    }
+}
+
+#[rustfmt::skip]
+fn validate_long_name<E: IoError>(name: &str) -> Result<(), Error<E>> {
+    // check if length is valid
+    if name.is_empty() {
+        return Err(Error::InvalidFileNameLength);
+    }
+    if name.len() > MAX_LONG_NAME_LEN {
+        return Err(Error::InvalidFileNameLength);
+    }
+    // check if there are only valid characters
+    for c in name.chars() {
+        match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9'
+            | '\u{80}'..='\u{FFFF}'
+            | '$' | '%' | '\'' | '-' | '_' | '@' | '~' | '`' | '!' | '(' | ')' | '{' | '}' | '.' | ' ' | '+' | ','
+            | ';' | '=' | '[' | ']' | '^' | '#' | '&' => {},
+            _ => return Err(Error::UnsupportedFileNameCharacter),
+        }
+    }
+    Ok(())
+}
+
+fn lfn_checksum(short_name: &[u8; SFN_SIZE]) -> u8 {
+    let mut chksum = num::Wrapping(0_u8);
+    for b in short_name {
+        chksum = (chksum << 7) + (chksum >> 1) + num::Wrapping(*b);
+    }
+    chksum.0
+}
+
+#[cfg(all(feature = "lfn", feature = "alloc"))]
+#[derive(Clone)]
+pub(crate) struct LfnBuffer {
+    ucs2_units: Vec<u16>,
+}
+
+const MAX_LONG_NAME_LEN: usize = 255;
+
+#[cfg(feature = "lfn")]
+const MAX_LONG_DIR_ENTRIES: usize = (MAX_LONG_NAME_LEN + LFN_PART_LEN - 1) / LFN_PART_LEN;
+
+#[cfg(all(feature = "lfn", not(feature = "alloc")))]
+const LONG_NAME_BUFFER_LEN: usize = MAX_LONG_DIR_ENTRIES * LFN_PART_LEN;
+
+#[cfg(all(feature = "lfn", not(feature = "alloc")))]
+#[derive(Clone)]
+pub(crate) struct LfnBuffer {
+    ucs2_units: [u16; LONG_NAME_BUFFER_LEN],
+    len: usize,
+}
+
+#[cfg(all(feature = "lfn", feature = "alloc"))]
+impl LfnBuffer {
+    fn new() -> Self {
+        Self {
+            ucs2_units: Vec::<u16>::new(),
+        }
+    }
+
+    fn from_ucs2_units<I: Iterator<Item = u16>>(usc2_units: I) -> Self {
+        Self {
+            ucs2_units: usc2_units.collect(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.ucs2_units.clear();
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.ucs2_units.len()
+    }
+
+    fn set_len(&mut self, len: usize) {
+        self.ucs2_units.resize(len, 0_u16);
+    }
+
+    pub(crate) fn as_ucs2_units(&self) -> &[u16] {
+        &self.ucs2_units
+    }
+}
+
+#[cfg(all(feature = "lfn", not(feature = "alloc")))]
+impl LfnBuffer {
+    fn new() -> Self {
+        Self {
+            ucs2_units: [0_u16; LONG_NAME_BUFFER_LEN],
+            len: 0,
+        }
+    }
+
+    fn from_ucs2_units<I: Iterator<Item = u16>>(usc2_units: I) -> Self {
+        let mut lfn = Self {
+            ucs2_units: [0_u16; LONG_NAME_BUFFER_LEN],
+            len: 0,
+        };
+        for (i, usc2_unit) in usc2_units.enumerate() {
+            lfn.ucs2_units[i] = usc2_unit;
+            lfn.len += 1;
+        }
+        lfn
+    }
+
+    fn clear(&mut self) {
+        self.ucs2_units = [0_u16; LONG_NAME_BUFFER_LEN];
+        self.len = 0;
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    fn set_len(&mut self, len: usize) {
+        self.len = len;
+    }
+
+    pub(crate) fn as_ucs2_units(&self) -> &[u16] {
+        &self.ucs2_units[..self.len]
+    }
+}
+
+#[cfg(not(feature = "lfn"))]
+#[derive(Clone)]
+pub(crate) struct LfnBuffer {}
+
+#[cfg(not(feature = "lfn"))]
+impl LfnBuffer {
+    pub(crate) fn as_ucs2_units(&self) -> &[u16] {
+        &[]
+    }
+}
+
+#[cfg(feature = "lfn")]
+struct LongNameBuilder {
+    buf: LfnBuffer,
+    chksum: u8,
+    index: u8,
+}
+
+#[cfg(feature = "lfn")]
+impl LongNameBuilder {
+    fn new() -> Self {
+        Self {
+            buf: LfnBuffer::new(),
+            chksum: 0,
+            index: 0,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.buf.clear();
+        self.index = 0;
+    }
+
+    fn into_buf(mut self) -> LfnBuffer {
+        // Check if last processed entry had index 1
+        if self.index == 1 {
+            self.truncate();
+        } else if !self.is_empty() {
+            warn!("unfinished LFN sequence {}", self.index);
+            self.clear();
+        }
+        self.buf
+    }
+
+    fn truncate(&mut self) {
+        // Truncate 0 and 0xFFFF characters from LFN buffer
+        let ucs2_units = &self.buf.ucs2_units;
+        let new_len = ucs2_units
+            .iter()
+            .rposition(|c| *c != 0xFFFF && *c != 0)
+            .map_or(0, |n| n + 1);
+        self.buf.set_len(new_len);
+    }
+
+    fn is_empty(&self) -> bool {
+        // Check if any LFN entry has been processed
+        // Note: index 0 is not a valid index in LFN and can be seen only after struct initialization
+        self.index == 0
+    }
+
+    fn process(&mut self, data: &DirLfnEntryData) {
+        let is_last = (data.order() & LFN_ENTRY_LAST_FLAG) != 0;
+        let index = data.order() & 0x1F;
+        if index == 0 || usize::from(index) > MAX_LONG_DIR_ENTRIES {
+            // Corrupted entry
+            warn!("currupted lfn entry! {:x}", data.order());
+            self.clear();
+            return;
+        }
+        if is_last {
+            // last entry is actually first entry in stream
+            self.index = index;
+            self.chksum = data.checksum();
+            self.buf.set_len(usize::from(index) * LFN_PART_LEN);
+        } else if self.index == 0 || index != self.index - 1 || data.checksum() != self.chksum {
+            // Corrupted entry
+            warn!(
+                "currupted lfn entry! {:x} {:x} {:x} {:x}",
+                data.order(),
+                self.index,
+                data.checksum(),
+                self.chksum
+            );
+            self.clear();
+            return;
+        } else {
+            // Decrement LFN index only for non-last entries
+            self.index -= 1;
+        }
+        let pos = LFN_PART_LEN * usize::from(index - 1);
+        // copy name parts into LFN buffer
+        data.copy_name_to_slice(&mut self.buf.ucs2_units[pos..pos + 13]);
+    }
+
+    fn validate_chksum(&mut self, short_name: &[u8; SFN_SIZE]) {
+        if self.is_empty() {
+            // Nothing to validate - no LFN entries has been processed
+            return;
+        }
+        let chksum = lfn_checksum(short_name);
+        if chksum != self.chksum {
+            warn!("checksum mismatch {:x} {:x} {:?}", chksum, self.chksum, short_name);
+            self.clear();
+        }
+    }
+}
+
+// Dummy implementation for non-alloc build
+#[cfg(not(feature = "lfn"))]
+struct LongNameBuilder {}
+#[cfg(not(feature = "lfn"))]
+impl LongNameBuilder {
+    fn new() -> Self {
+        LongNameBuilder {}
+    }
+    fn clear(&mut self) {}
+    fn into_vec(self) {}
+    fn truncate(&mut self) {}
+    fn process(&mut self, _data: &DirLfnEntryData) {}
+    fn validate_chksum(&mut self, _short_name: &[u8; SFN_SIZE]) {}
+}
+
+#[cfg(feature = "lfn")]
+struct LfnEntriesGenerator<'a> {
+    name_parts_iter: iter::Rev<slice::Chunks<'a, u16>>,
+    checksum: u8,
+    index: usize,
+    num: usize,
+    ended: bool,
+}
+
+#[cfg(feature = "lfn")]
+impl<'a> LfnEntriesGenerator<'a> {
+    fn new(name_utf16: &'a [u16], checksum: u8) -> Self {
+        let num_entries = (name_utf16.len() + LFN_PART_LEN - 1) / LFN_PART_LEN;
+        // create generator using reverse iterator over chunks - first chunk can be shorter
+        LfnEntriesGenerator {
+            checksum,
+            name_parts_iter: name_utf16.chunks(LFN_PART_LEN).rev(),
+            index: 0,
+            num: num_entries,
+            ended: false,
+        }
+    }
+}
+
+#[cfg(feature = "lfn")]
+impl Iterator for LfnEntriesGenerator<'_> {
+    type Item = DirLfnEntryData;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ended {
+            return None;
+        }
+
+        // get next part from reverse iterator
+        if let Some(name_part) = self.name_parts_iter.next() {
+            let lfn_index = self.num - self.index;
+            let mut order = lfn_index as u8;
+            if self.index == 0 {
+                // this is last name part (written as first)
+                order |= LFN_ENTRY_LAST_FLAG;
+            }
+            debug_assert!(order > 0);
+            let mut lfn_part = [LFN_PADDING; LFN_PART_LEN];
+            lfn_part[..name_part.len()].copy_from_slice(name_part);
+            if name_part.len() < LFN_PART_LEN {
+                // name is only zero-terminated if its length is not multiplicity of LFN_PART_LEN
+                lfn_part[name_part.len()] = 0;
+            }
+            // create and return new LFN entry
+            let mut lfn_entry = DirLfnEntryData::new(order, self.checksum);
+            lfn_entry.copy_name_from_slice(&lfn_part);
+            self.index += 1;
+            Some(lfn_entry)
+        } else {
+            // end of name
+            self.ended = true;
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.name_parts_iter.size_hint()
+    }
+}
+
+// name_parts_iter is ExactSizeIterator so size_hint returns one limit
+#[cfg(feature = "lfn")]
+impl ExactSizeIterator for LfnEntriesGenerator<'_> {}
+
+// Dummy implementation for non-alloc build
+#[cfg(not(feature = "lfn"))]
+struct LfnEntriesGenerator {}
+#[cfg(not(feature = "lfn"))]
+impl LfnEntriesGenerator {
+    fn new(_name_utf16: &[u16], _checksum: u8) -> Self {
+        LfnEntriesGenerator {}
+    }
+}
+#[cfg(not(feature = "lfn"))]
+impl Iterator for LfnEntriesGenerator {
+    type Item = DirLfnEntryData;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
+}
+#[cfg(not(feature = "lfn"))]
+impl ExactSizeIterator for LfnEntriesGenerator {}
+
+#[derive(Default, Debug, Clone)]
+struct ShortNameGenerator {
+    chksum: u16,
+    long_prefix_bitmap: u16,
+    prefix_chksum_bitmap: u16,
+    name_fits: bool,
+    lossy_conv: bool,
+    exact_match: bool,
+    basename_len: usize,
+    short_name: [u8; SFN_SIZE],
+}
+
+impl ShortNameGenerator {
+    fn new(name: &str) -> Self {
+        // padded by ' '
+        let mut short_name = [SFN_PADDING; SFN_SIZE];
+        // find extension after last dot
+        // Note: short file name cannot start with the extension
+        let dot_index_opt = name[1..].rfind('.').map(|index| index + 1);
+        // copy basename (part of filename before a dot)
+        let basename_src = dot_index_opt.map_or(name, |dot_index| &name[..dot_index]);
+        let (basename_len, basename_fits, basename_lossy) =
+            Self::copy_short_name_part(&mut short_name[0..8], basename_src);
+        // copy file extension if exists
+        let (name_fits, lossy_conv) = dot_index_opt.map_or((basename_fits, basename_lossy), |dot_index| {
+            let (_, ext_fits, ext_lossy) = Self::copy_short_name_part(&mut short_name[8..11], &name[dot_index + 1..]);
+            (basename_fits && ext_fits, basename_lossy || ext_lossy)
+        });
+        let chksum = Self::checksum(name);
+        Self {
+            chksum,
+            name_fits,
+            lossy_conv,
+            basename_len,
+            short_name,
+            ..Self::default()
+        }
+    }
+
+    fn generate_dot() -> [u8; SFN_SIZE] {
+        let mut short_name = [SFN_PADDING; SFN_SIZE];
+        short_name[0] = b'.';
+        short_name
+    }
+
+    fn generate_dotdot() -> [u8; SFN_SIZE] {
+        let mut short_name = [SFN_PADDING; SFN_SIZE];
+        short_name[0] = b'.';
+        short_name[1] = b'.';
+        short_name
+    }
+
+    fn copy_short_name_part(dst: &mut [u8], src: &str) -> (usize, bool, bool) {
+        let mut dst_pos = 0;
+        let mut lossy_conv = false;
+        for c in src.chars() {
+            if dst_pos == dst.len() {
+                // result buffer is full
+                return (dst_pos, false, lossy_conv);
+            }
+            // Make sure character is allowed in 8.3 name
+            #[rustfmt::skip]
+            let fixed_c = match c {
+                // strip spaces and dots
+                ' ' | '.' => {
+                    lossy_conv = true;
+                    continue;
+                },
+                // copy allowed characters
+                'A'..='Z' | 'a'..='z' | '0'..='9'
+                | '!' | '#' | '$' | '%' | '&' | '\'' | '(' | ')' | '-' | '@' | '^' | '_' | '`' | '{' | '}' | '~' => c,
+                // replace disallowed characters by underscore
+                _ => '_',
+            };
+            // Update 'lossy conversion' flag
+            lossy_conv = lossy_conv || (fixed_c != c);
+            // short name is always uppercase
+            let upper = fixed_c.to_ascii_uppercase();
+            dst[dst_pos] = upper as u8; // SAFE: upper is in range 0x20-0x7F
+            dst_pos += 1;
+        }
+        (dst_pos, true, lossy_conv)
+    }
+
+    fn add_existing(&mut self, short_name: &[u8; SFN_SIZE]) {
+        // check for exact match collision
+        if short_name == &self.short_name {
+            self.exact_match = true;
+        }
+        // check for long prefix form collision (TEXTFI~1.TXT)
+        self.check_for_long_prefix_collision(short_name);
+
+        // check for short prefix + checksum form collision (TE021F~1.TXT)
+        self.check_for_short_prefix_collision(short_name);
+    }
+
+    fn check_for_long_prefix_collision(&mut self, short_name: &[u8; SFN_SIZE]) {
+        // check for long prefix form collision (TEXTFI~1.TXT)
+        let long_prefix_len = 6.min(self.basename_len);
+        if short_name[long_prefix_len] != b'~' {
+            return;
+        }
+        if let Some(num_suffix) = char::from(short_name[long_prefix_len + 1]).to_digit(10) {
+            let long_prefix_matches = short_name[..long_prefix_len] == self.short_name[..long_prefix_len];
+            let ext_matches = short_name[8..] == self.short_name[8..];
+            if long_prefix_matches && ext_matches {
+                self.long_prefix_bitmap |= 1 << num_suffix;
+            }
+        }
+    }
+
+    fn check_for_short_prefix_collision(&mut self, short_name: &[u8; SFN_SIZE]) {
+        // check for short prefix + checksum form collision (TE021F~1.TXT)
+        let short_prefix_len = 2.min(self.basename_len);
+        if short_name[short_prefix_len + 4] != b'~' {
+            return;
+        }
+        if let Some(num_suffix) = char::from(short_name[short_prefix_len + 4 + 1]).to_digit(10) {
+            let short_prefix_matches = short_name[..short_prefix_len] == self.short_name[..short_prefix_len];
+            let ext_matches = short_name[8..] == self.short_name[8..];
+            if short_prefix_matches && ext_matches {
+                let chksum_res = str::from_utf8(&short_name[short_prefix_len..short_prefix_len + 4])
+                    .map(|s| u16::from_str_radix(s, 16));
+                if chksum_res == Ok(Ok(self.chksum)) {
+                    self.prefix_chksum_bitmap |= 1 << num_suffix;
+                }
+            }
+        }
+    }
+
+    fn checksum(name: &str) -> u16 {
+        // BSD checksum algorithm
+        let mut chksum = num::Wrapping(0_u16);
+        for c in name.chars() {
+            chksum = (chksum >> 1) + (chksum << 15) + num::Wrapping(c as u16);
+        }
+        chksum.0
+    }
+
+    fn generate(&self) -> Result<[u8; SFN_SIZE], Error<()>> {
+        if !self.lossy_conv && self.name_fits && !self.exact_match {
+            // If there was no lossy conversion and name fits into
+            // 8.3 convention and there is no collision return it as is
+            return Ok(self.short_name);
+        }
+        // Try using long 6-characters prefix
+        for i in 1..5 {
+            if self.long_prefix_bitmap & (1 << i) == 0 {
+                return Ok(self.build_prefixed_name(i, false));
+            }
+        }
+        // Try prefix with checksum
+        for i in 1..10 {
+            if self.prefix_chksum_bitmap & (1 << i) == 0 {
+                return Ok(self.build_prefixed_name(i, true));
+            }
+        }
+        // Too many collisions - fail
+        Err(Error::AlreadyExists)
+    }
+
+    fn next_iteration(&mut self) {
+        // Try different checksum in next iteration
+        self.chksum = (num::Wrapping(self.chksum) + num::Wrapping(1)).0;
+        // Zero bitmaps
+        self.long_prefix_bitmap = 0;
+        self.prefix_chksum_bitmap = 0;
+    }
+
+    fn build_prefixed_name(&self, num: u32, with_chksum: bool) -> [u8; SFN_SIZE] {
+        let mut buf = [SFN_PADDING; SFN_SIZE];
+        let prefix_len = if with_chksum {
+            let prefix_len = 2.min(self.basename_len);
+            buf[..prefix_len].copy_from_slice(&self.short_name[..prefix_len]);
+            buf[prefix_len..prefix_len + 4].copy_from_slice(&Self::u16_to_hex(self.chksum));
+            prefix_len + 4
+        } else {
+            let prefix_len = 6.min(self.basename_len);
+            buf[..prefix_len].copy_from_slice(&self.short_name[..prefix_len]);
+            prefix_len
+        };
+        buf[prefix_len] = b'~';
+        buf[prefix_len + 1] = char::from_digit(num, 10).unwrap() as u8; // SAFE: num is in range [1, 9]
+        buf[8..].copy_from_slice(&self.short_name[8..]);
+        buf
+    }
+
+    fn u16_to_hex(x: u16) -> [u8; 4] {
+        // Unwrapping below is safe because each line takes 4 bits of `x` and shifts them to the right so they form
+        // a number in range [0, 15]
+        let x_u32 = u32::from(x);
+        let mut hex_bytes = [
+            char::from_digit((x_u32 >> 12) & 0xF, 16).unwrap() as u8,
+            char::from_digit((x_u32 >> 8) & 0xF, 16).unwrap() as u8,
+            char::from_digit((x_u32 >> 4) & 0xF, 16).unwrap() as u8,
+            char::from_digit(x_u32 & 0xF, 16).unwrap() as u8,
+        ];
+        hex_bytes.make_ascii_uppercase();
+        hex_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_path() {
+        assert_eq!(split_path("aaa/bbb/ccc"), ("aaa", Some("bbb/ccc")));
+        assert_eq!(split_path("aaa/bbb"), ("aaa", Some("bbb")));
+        assert_eq!(split_path("aaa"), ("aaa", None));
+    }
+
+    #[test]
+    fn test_generate_short_name() {
+        assert_eq!(ShortNameGenerator::new("Foo").generate().ok(), Some(*b"FOO        "));
+        assert_eq!(ShortNameGenerator::new("Foo.b").generate().ok(), Some(*b"FOO     B  "));
+        assert_eq!(
+            ShortNameGenerator::new("Foo.baR").generate().ok(),
+            Some(*b"FOO     BAR")
+        );
+        assert_eq!(
+            ShortNameGenerator::new("Foo+1.baR").generate().ok(),
+            Some(*b"FOO_1~1 BAR")
+        );
+        assert_eq!(
+            ShortNameGenerator::new("ver +1.2.text").generate().ok(),
+            Some(*b"VER_12~1TEX")
+        );
+        assert_eq!(
+            ShortNameGenerator::new(".bashrc.swp").generate().ok(),
+            Some(*b"BASHRC~1SWP")
+        );
+        assert_eq!(ShortNameGenerator::new(".foo").generate().ok(), Some(*b"FOO~1      "));
+    }
+
+    #[test]
+    fn test_short_name_checksum_overflow() {
+        ShortNameGenerator::checksum("\u{FF5A}\u{FF5A}\u{FF5A}\u{FF5A}");
+    }
+
+    #[test]
+    fn test_lfn_checksum_overflow() {
+        lfn_checksum(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn test_generate_short_name_collisions_long() {
+        let mut buf: [u8; SFN_SIZE];
+        let mut gen = ShortNameGenerator::new("TextFile.Mine.txt");
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"TEXTFI~1TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"TEXTFI~2TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"TEXTFI~3TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"TEXTFI~4TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"TE527D~1TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"TE527D~2TXT");
+        for i in 3..10 {
+            gen.add_existing(&buf);
+            buf = gen.generate().unwrap();
+            assert_eq!(&buf, format!("TE527D~{}TXT", i).as_bytes());
+        }
+        gen.add_existing(&buf);
+        assert!(gen.generate().is_err());
+        gen.next_iteration();
+        for _i in 0..4 {
+            buf = gen.generate().unwrap();
+            gen.add_existing(&buf);
+        }
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"TE527E~1TXT");
+    }
+
+    #[test]
+    fn test_generate_short_name_collisions_short() {
+        let mut buf: [u8; SFN_SIZE];
+        let mut gen = ShortNameGenerator::new("x.txt");
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"X       TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"X~1     TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"X~2     TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"X~3     TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"X~4     TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"X40DA~1 TXT");
+        gen.add_existing(&buf);
+        buf = gen.generate().unwrap();
+        assert_eq!(&buf, b"X40DA~2 TXT");
+    }
+}

--- a/fatfs/src/dir_entry.rs
+++ b/fatfs/src/dir_entry.rs
@@ -1,0 +1,783 @@
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::string::String;
+use bitflags::bitflags;
+use core::char;
+use core::convert::TryInto;
+use core::fmt;
+#[cfg(not(feature = "unicode"))]
+use core::iter;
+
+#[cfg(feature = "lfn")]
+use crate::dir::LfnBuffer;
+use crate::dir::{Dir, DirRawStream};
+use crate::error::{Error, IoError};
+use crate::file::File;
+use crate::fs::{FatType, FileSystem, OemCpConverter, ReadWriteSeek};
+use crate::io::{self, Read, ReadLeExt, Write, WriteLeExt};
+use crate::time::{Date, DateTime};
+
+bitflags! {
+    /// A FAT file attributes.
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct FileAttributes: u8 {
+        const READ_ONLY  = 0x01;
+        const HIDDEN     = 0x02;
+        const SYSTEM     = 0x04;
+        const VOLUME_ID  = 0x08;
+        const DIRECTORY  = 0x10;
+        const ARCHIVE    = 0x20;
+        const LFN        = Self::READ_ONLY.bits() | Self::HIDDEN.bits()
+                         | Self::SYSTEM.bits() | Self::VOLUME_ID.bits();
+    }
+}
+
+// Size of single directory entry in bytes
+pub(crate) const DIR_ENTRY_SIZE: u32 = 32;
+
+// Directory entry flags available in first byte of the short name
+pub(crate) const DIR_ENTRY_DELETED_FLAG: u8 = 0xE5;
+pub(crate) const DIR_ENTRY_REALLY_E5_FLAG: u8 = 0x05;
+
+// Short file name field size in bytes (besically 8 + 3)
+pub(crate) const SFN_SIZE: usize = 11;
+
+// Byte used for short name padding
+pub(crate) const SFN_PADDING: u8 = b' ';
+
+// Length in characters of a LFN fragment packed in one directory entry
+pub(crate) const LFN_PART_LEN: usize = 13;
+
+// Bit used in order field to mark last LFN entry
+#[cfg(feature = "lfn")]
+pub(crate) const LFN_ENTRY_LAST_FLAG: u8 = 0x40;
+
+// Character to upper case conversion which supports Unicode only if `unicode` feature is enabled
+#[cfg(feature = "unicode")]
+fn char_to_uppercase(c: char) -> char::ToUppercase {
+    c.to_uppercase()
+}
+#[cfg(not(feature = "unicode"))]
+fn char_to_uppercase(c: char) -> iter::Once<char> {
+    iter::once(c.to_ascii_uppercase())
+}
+
+/// Decoded file short name
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ShortName {
+    name: [u8; 12],
+    len: u8,
+}
+
+impl ShortName {
+    pub(crate) fn new(raw_name: &[u8; SFN_SIZE]) -> Self {
+        // get name components length by looking for space character
+        let name_len = raw_name[0..8]
+            .iter()
+            .rposition(|x| *x != SFN_PADDING)
+            .map_or(0, |p| p + 1);
+        let ext_len = raw_name[8..11]
+            .iter()
+            .rposition(|x| *x != SFN_PADDING)
+            .map_or(0, |p| p + 1);
+        let mut name = [SFN_PADDING; 12];
+        name[..name_len].copy_from_slice(&raw_name[..name_len]);
+        let total_len = if ext_len > 0 {
+            name[name_len] = b'.';
+            name[name_len + 1..name_len + 1 + ext_len].copy_from_slice(&raw_name[8..8 + ext_len]);
+            // Return total name length
+            name_len + 1 + ext_len
+        } else {
+            // No extension - return length of name part
+            name_len
+        };
+        // FAT encodes character 0xE5 as 0x05 because 0xE5 marks deleted files
+        if name[0] == DIR_ENTRY_REALLY_E5_FLAG {
+            name[0] = 0xE5;
+        }
+        // Short names in FAT filesystem are encoded in OEM code-page
+        Self {
+            name,
+            len: total_len as u8,
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.name[..usize::from(self.len)]
+    }
+
+    #[cfg(feature = "alloc")]
+    fn to_string<OCC: OemCpConverter>(&self, oem_cp_converter: &OCC) -> String {
+        // Strip non-ascii characters from short name
+        self.as_bytes()
+            .iter()
+            .copied()
+            .map(|c| oem_cp_converter.decode(c))
+            .collect()
+    }
+
+    fn eq_ignore_case<OCC: OemCpConverter>(&self, name: &str, oem_cp_converter: &OCC) -> bool {
+        // Convert name to UTF-8 character iterator
+        let byte_iter = self.as_bytes().iter().copied();
+        let char_iter = byte_iter.map(|c| oem_cp_converter.decode(c));
+        // Compare interators ignoring case
+        let uppercase_char_iter = char_iter.flat_map(char_to_uppercase);
+        uppercase_char_iter.eq(name.chars().flat_map(char_to_uppercase))
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DirFileEntryData {
+    name: [u8; SFN_SIZE],
+    attrs: FileAttributes,
+    reserved_0: u8,
+    create_time_0: u8,
+    create_time_1: u16,
+    create_date: u16,
+    access_date: u16,
+    first_cluster_hi: u16,
+    modify_time: u16,
+    modify_date: u16,
+    first_cluster_lo: u16,
+    size: u32,
+}
+
+impl DirFileEntryData {
+    pub(crate) fn new(name: [u8; SFN_SIZE], attrs: FileAttributes) -> Self {
+        Self {
+            name,
+            attrs,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn renamed(&self, new_name: [u8; SFN_SIZE]) -> Self {
+        let mut sfn_entry = self.clone();
+        sfn_entry.name = new_name;
+        sfn_entry
+    }
+
+    pub(crate) fn name(&self) -> &[u8; SFN_SIZE] {
+        &self.name
+    }
+
+    #[cfg(feature = "alloc")]
+    fn lowercase_name(&self) -> ShortName {
+        let mut name_copy: [u8; SFN_SIZE] = self.name;
+        if self.lowercase_basename() {
+            name_copy[..8].make_ascii_lowercase();
+        }
+        if self.lowercase_ext() {
+            name_copy[8..].make_ascii_lowercase();
+        }
+        ShortName::new(&name_copy)
+    }
+
+    pub(crate) fn first_cluster(&self, fat_type: FatType) -> Option<u32> {
+        let first_cluster_hi = if fat_type == FatType::Fat32 {
+            self.first_cluster_hi
+        } else {
+            0
+        };
+        let n = (u32::from(first_cluster_hi) << 16) | u32::from(self.first_cluster_lo);
+        if n == 0 {
+            None
+        } else {
+            Some(n)
+        }
+    }
+
+    pub(crate) fn set_first_cluster(&mut self, cluster: Option<u32>, fat_type: FatType) {
+        let n = cluster.unwrap_or(0);
+        if fat_type == FatType::Fat32 {
+            self.first_cluster_hi = (n >> 16) as u16;
+        }
+        self.first_cluster_lo = (n & 0xFFFF) as u16;
+    }
+
+    pub(crate) fn size(&self) -> Option<u32> {
+        if self.is_file() {
+            Some(self.size)
+        } else {
+            None
+        }
+    }
+
+    fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+
+    pub(crate) fn is_dir(&self) -> bool {
+        self.attrs.contains(FileAttributes::DIRECTORY)
+    }
+
+    fn is_file(&self) -> bool {
+        !self.is_dir()
+    }
+
+    fn lowercase_basename(&self) -> bool {
+        self.reserved_0 & (1 << 3) != 0
+    }
+
+    fn lowercase_ext(&self) -> bool {
+        self.reserved_0 & (1 << 4) != 0
+    }
+
+    fn created(&self) -> DateTime {
+        DateTime::decode(self.create_date, self.create_time_1, self.create_time_0)
+    }
+
+    fn accessed(&self) -> Date {
+        Date::decode(self.access_date)
+    }
+
+    fn modified(&self) -> DateTime {
+        DateTime::decode(self.modify_date, self.modify_time, 0)
+    }
+
+    pub(crate) fn set_created(&mut self, date_time: DateTime) {
+        self.create_date = date_time.date.encode();
+        let encoded_time = date_time.time.encode();
+        self.create_time_1 = encoded_time.0;
+        self.create_time_0 = encoded_time.1;
+    }
+
+    pub(crate) fn set_accessed(&mut self, date: Date) {
+        self.access_date = date.encode();
+    }
+
+    pub(crate) fn set_modified(&mut self, date_time: DateTime) {
+        self.modify_date = date_time.date.encode();
+        self.modify_time = date_time.time.encode().0;
+    }
+
+    pub(crate) fn serialize<W: Write>(&self, wrt: &mut W) -> Result<(), W::Error> {
+        wrt.write_all(&self.name)?;
+        wrt.write_u8(self.attrs.bits())?;
+        wrt.write_u8(self.reserved_0)?;
+        wrt.write_u8(self.create_time_0)?;
+        wrt.write_u16_le(self.create_time_1)?;
+        wrt.write_u16_le(self.create_date)?;
+        wrt.write_u16_le(self.access_date)?;
+        wrt.write_u16_le(self.first_cluster_hi)?;
+        wrt.write_u16_le(self.modify_time)?;
+        wrt.write_u16_le(self.modify_date)?;
+        wrt.write_u16_le(self.first_cluster_lo)?;
+        wrt.write_u32_le(self.size)?;
+        Ok(())
+    }
+
+    pub(crate) fn is_deleted(&self) -> bool {
+        self.name[0] == DIR_ENTRY_DELETED_FLAG
+    }
+
+    pub(crate) fn set_deleted(&mut self) {
+        self.name[0] = DIR_ENTRY_DELETED_FLAG;
+    }
+
+    pub(crate) fn is_end(&self) -> bool {
+        self.name[0] == 0
+    }
+
+    pub(crate) fn is_volume(&self) -> bool {
+        self.attrs.contains(FileAttributes::VOLUME_ID)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DirLfnEntryData {
+    order: u8,
+    name_0: [u16; 5],
+    attrs: FileAttributes,
+    entry_type: u8,
+    checksum: u8,
+    name_1: [u16; 6],
+    reserved_0: u16,
+    name_2: [u16; 2],
+}
+
+impl DirLfnEntryData {
+    pub(crate) fn new(order: u8, checksum: u8) -> Self {
+        Self {
+            order,
+            checksum,
+            attrs: FileAttributes::LFN,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn copy_name_from_slice(&mut self, lfn_part: &[u16; LFN_PART_LEN]) {
+        self.name_0.copy_from_slice(&lfn_part[0..5]);
+        self.name_1.copy_from_slice(&lfn_part[5..5 + 6]);
+        self.name_2.copy_from_slice(&lfn_part[11..11 + 2]);
+    }
+
+    pub(crate) fn copy_name_to_slice(&self, lfn_part: &mut [u16]) {
+        debug_assert!(lfn_part.len() == LFN_PART_LEN);
+        lfn_part[0..5].copy_from_slice(&self.name_0);
+        lfn_part[5..11].copy_from_slice(&self.name_1);
+        lfn_part[11..13].copy_from_slice(&self.name_2);
+    }
+
+    pub(crate) fn serialize<W: Write>(&self, wrt: &mut W) -> Result<(), W::Error> {
+        wrt.write_u8(self.order)?;
+        for ch in &self.name_0 {
+            wrt.write_u16_le(*ch)?;
+        }
+        wrt.write_u8(self.attrs.bits())?;
+        wrt.write_u8(self.entry_type)?;
+        wrt.write_u8(self.checksum)?;
+        for ch in &self.name_1 {
+            wrt.write_u16_le(*ch)?;
+        }
+        wrt.write_u16_le(self.reserved_0)?;
+        for ch in &self.name_2 {
+            wrt.write_u16_le(*ch)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn order(&self) -> u8 {
+        self.order
+    }
+
+    pub(crate) fn checksum(&self) -> u8 {
+        self.checksum
+    }
+
+    pub(crate) fn is_deleted(&self) -> bool {
+        self.order == DIR_ENTRY_DELETED_FLAG
+    }
+
+    pub(crate) fn set_deleted(&mut self) {
+        self.order = DIR_ENTRY_DELETED_FLAG;
+    }
+
+    pub(crate) fn is_end(&self) -> bool {
+        self.order == 0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum DirEntryData {
+    File(DirFileEntryData),
+    Lfn(DirLfnEntryData),
+}
+
+impl DirEntryData {
+    pub(crate) fn serialize<E: IoError, W: Write<Error = Error<E>>>(&self, wrt: &mut W) -> Result<(), Error<E>> {
+        trace!("DirEntryData::serialize");
+        match self {
+            DirEntryData::File(file) => file.serialize(wrt),
+            DirEntryData::Lfn(lfn) => lfn.serialize(wrt),
+        }
+    }
+
+    pub(crate) fn deserialize<E: IoError, R: Read<Error = Error<E>>>(rdr: &mut R) -> Result<Self, Error<E>> {
+        trace!("DirEntryData::deserialize");
+        let mut name = [0; SFN_SIZE];
+        match rdr.read_exact(&mut name) {
+            Err(Error::UnexpectedEof) => {
+                // entries can occupy all clusters of directory so there is no zero entry at the end
+                // handle it here by returning non-existing empty entry
+                return Ok(DirEntryData::File(DirFileEntryData::default()));
+            }
+            Err(err) => {
+                return Err(err);
+            }
+            Ok(()) => {}
+        }
+        let attrs = FileAttributes::from_bits_truncate(rdr.read_u8()?);
+        if attrs & FileAttributes::LFN == FileAttributes::LFN {
+            // read long name entry
+            let mut data = DirLfnEntryData {
+                attrs,
+                ..DirLfnEntryData::default()
+            };
+            // divide the name into order and LFN name_0
+            data.order = name[0];
+            for (dst, src) in data.name_0.iter_mut().zip(name[1..].chunks_exact(2)) {
+                // unwrap cannot panic because src has exactly 2 values
+                *dst = u16::from_le_bytes(src.try_into().unwrap());
+            }
+
+            data.entry_type = rdr.read_u8()?;
+            data.checksum = rdr.read_u8()?;
+            for x in &mut data.name_1 {
+                *x = rdr.read_u16_le()?;
+            }
+            data.reserved_0 = rdr.read_u16_le()?;
+            for x in &mut data.name_2 {
+                *x = rdr.read_u16_le()?;
+            }
+            Ok(DirEntryData::Lfn(data))
+        } else {
+            // read short name entry
+            let data = DirFileEntryData {
+                name,
+                attrs,
+                reserved_0: rdr.read_u8()?,
+                create_time_0: rdr.read_u8()?,
+                create_time_1: rdr.read_u16_le()?,
+                create_date: rdr.read_u16_le()?,
+                access_date: rdr.read_u16_le()?,
+                first_cluster_hi: rdr.read_u16_le()?,
+                modify_time: rdr.read_u16_le()?,
+                modify_date: rdr.read_u16_le()?,
+                first_cluster_lo: rdr.read_u16_le()?,
+                size: rdr.read_u32_le()?,
+            };
+            Ok(DirEntryData::File(data))
+        }
+    }
+
+    pub(crate) fn is_deleted(&self) -> bool {
+        match self {
+            DirEntryData::File(file) => file.is_deleted(),
+            DirEntryData::Lfn(lfn) => lfn.is_deleted(),
+        }
+    }
+
+    pub(crate) fn set_deleted(&mut self) {
+        match self {
+            DirEntryData::File(file) => file.set_deleted(),
+            DirEntryData::Lfn(lfn) => lfn.set_deleted(),
+        }
+    }
+
+    pub(crate) fn is_end(&self) -> bool {
+        match self {
+            DirEntryData::File(file) => file.is_end(),
+            DirEntryData::Lfn(lfn) => lfn.is_end(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DirEntryEditor {
+    data: DirFileEntryData,
+    pos: u64,
+    dirty: bool,
+}
+
+impl DirEntryEditor {
+    fn new(data: DirFileEntryData, pos: u64) -> Self {
+        Self {
+            data,
+            pos,
+            dirty: false,
+        }
+    }
+
+    pub(crate) fn inner(&self) -> &DirFileEntryData {
+        &self.data
+    }
+
+    pub(crate) fn set_first_cluster(&mut self, first_cluster: Option<u32>, fat_type: FatType) {
+        if first_cluster != self.data.first_cluster(fat_type) {
+            self.data.set_first_cluster(first_cluster, fat_type);
+            self.dirty = true;
+        }
+    }
+
+    pub(crate) fn set_size(&mut self, size: u32) {
+        match self.data.size() {
+            Some(n) if size != n => {
+                self.data.set_size(size);
+                self.dirty = true;
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn set_created(&mut self, date_time: DateTime) {
+        if date_time != self.data.created() {
+            self.data.set_created(date_time);
+            self.dirty = true;
+        }
+    }
+
+    pub(crate) fn set_accessed(&mut self, date: Date) {
+        if date != self.data.accessed() {
+            self.data.set_accessed(date);
+            self.dirty = true;
+        }
+    }
+
+    pub(crate) fn set_modified(&mut self, date_time: DateTime) {
+        if date_time != self.data.modified() {
+            self.data.set_modified(date_time);
+            self.dirty = true;
+        }
+    }
+
+    pub(crate) fn flush<IO: ReadWriteSeek, TP, OCC>(&mut self, fs: &FileSystem<IO, TP, OCC>) -> Result<(), IO::Error> {
+        if self.dirty {
+            self.write(fs)?;
+            self.dirty = false;
+        }
+        Ok(())
+    }
+
+    fn write<IO: ReadWriteSeek, TP, OCC>(&self, fs: &FileSystem<IO, TP, OCC>) -> Result<(), IO::Error> {
+        let mut disk = fs.disk.borrow_mut();
+        disk.seek(io::SeekFrom::Start(self.pos))?;
+        self.data.serialize(&mut *disk)
+    }
+}
+
+/// A FAT directory entry.
+///
+/// `DirEntry` is returned by `DirIter` when reading a directory.
+#[derive(Clone)]
+pub struct DirEntry<'a, IO: ReadWriteSeek, TP, OCC> {
+    pub(crate) data: DirFileEntryData,
+    pub(crate) short_name: ShortName,
+    #[cfg(feature = "lfn")]
+    pub(crate) lfn_utf16: LfnBuffer,
+    pub(crate) entry_pos: u64,
+    pub(crate) offset_range: (u64, u64),
+    pub(crate) fs: &'a FileSystem<IO, TP, OCC>,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl<'a, IO: ReadWriteSeek, TP, OCC: OemCpConverter> DirEntry<'a, IO, TP, OCC> {
+    /// Returns short file name.
+    ///
+    /// Non-ASCII characters are replaced by the replacement character (U+FFFD).
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn short_file_name(&self) -> String {
+        self.short_name.to_string(&self.fs.options.oem_cp_converter)
+    }
+
+    /// Returns short file name as byte array slice.
+    ///
+    /// Characters are encoded in the OEM codepage.
+    #[must_use]
+    pub fn short_file_name_as_bytes(&self) -> &[u8] {
+        self.short_name.as_bytes()
+    }
+
+    /// Returns long file name as u16 array slice.
+    ///
+    /// Characters are encoded in the UCS-2 encoding.
+    #[cfg(feature = "lfn")]
+    #[must_use]
+    pub fn long_file_name_as_ucs2_units(&self) -> Option<&[u16]> {
+        if self.lfn_utf16.len() > 0 {
+            Some(self.lfn_utf16.as_ucs2_units())
+        } else {
+            None
+        }
+    }
+
+    /// Returns long file name or if it doesn't exist fallbacks to short file name.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn file_name(&self) -> String {
+        #[cfg(feature = "lfn")]
+        {
+            let lfn_opt = self.long_file_name_as_ucs2_units();
+            if let Some(lfn) = lfn_opt {
+                return String::from_utf16_lossy(lfn);
+            }
+        }
+
+        self.data.lowercase_name().to_string(&self.fs.options.oem_cp_converter)
+    }
+
+    /// Returns file attributes.
+    #[must_use]
+    pub fn attributes(&self) -> FileAttributes {
+        self.data.attrs
+    }
+
+    /// Checks if entry belongs to directory.
+    #[must_use]
+    pub fn is_dir(&self) -> bool {
+        self.data.is_dir()
+    }
+
+    /// Checks if entry belongs to regular file.
+    #[must_use]
+    pub fn is_file(&self) -> bool {
+        self.data.is_file()
+    }
+
+    pub(crate) fn first_cluster(&self) -> Option<u32> {
+        self.data.first_cluster(self.fs.fat_type())
+    }
+
+    fn editor(&self) -> DirEntryEditor {
+        DirEntryEditor::new(self.data.clone(), self.entry_pos)
+    }
+
+    pub(crate) fn is_same_entry(&self, other: &DirEntry<IO, TP, OCC>) -> bool {
+        self.entry_pos == other.entry_pos
+    }
+
+    /// Returns `File` struct for this entry.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if this is not a file.
+    #[must_use]
+    pub fn to_file(&self) -> File<'a, IO, TP, OCC> {
+        assert!(!self.is_dir(), "Not a file entry");
+        File::new(self.first_cluster(), Some(self.editor()), self.fs)
+    }
+
+    /// Returns `Dir` struct for this entry.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if this is not a directory.
+    #[must_use]
+    pub fn to_dir(&self) -> Dir<'a, IO, TP, OCC> {
+        assert!(self.is_dir(), "Not a directory entry");
+        match self.first_cluster() {
+            Some(n) => {
+                let file = File::new(Some(n), Some(self.editor()), self.fs);
+                Dir::new(DirRawStream::File(file), self.fs)
+            }
+            None => self.fs.root_dir(),
+        }
+    }
+
+    /// Returns file size or 0 for directory.
+    #[must_use]
+    pub fn len(&self) -> u64 {
+        u64::from(self.data.size)
+    }
+
+    /// Returns file creation date and time.
+    ///
+    /// Resolution of the time field is 1/100s.
+    #[must_use]
+    pub fn created(&self) -> DateTime {
+        self.data.created()
+    }
+
+    /// Returns file last access date.
+    #[must_use]
+    pub fn accessed(&self) -> Date {
+        self.data.accessed()
+    }
+
+    /// Returns file last modification date and time.
+    ///
+    /// Resolution of the time field is 2s.
+    #[must_use]
+    pub fn modified(&self) -> DateTime {
+        self.data.modified()
+    }
+
+    pub(crate) fn raw_short_name(&self) -> &[u8; SFN_SIZE] {
+        &self.data.name
+    }
+
+    #[cfg(feature = "lfn")]
+    fn eq_name_lfn(&self, name: &str) -> bool {
+        if let Some(lfn) = self.long_file_name_as_ucs2_units() {
+            let self_decode_iter = char::decode_utf16(lfn.iter().copied());
+            let mut other_uppercase_iter = name.chars().flat_map(char_to_uppercase);
+            for decode_result in self_decode_iter {
+                if let Ok(self_char) = decode_result {
+                    for self_uppercase_char in char_to_uppercase(self_char) {
+                        // compare each character in uppercase
+                        if Some(self_uppercase_char) != other_uppercase_iter.next() {
+                            return false;
+                        }
+                    }
+                } else {
+                    // decoding failed
+                    return false;
+                }
+            }
+            // both iterators should be at the end here
+            other_uppercase_iter.next().is_none()
+        } else {
+            // entry has no long name
+            false
+        }
+    }
+
+    pub(crate) fn eq_name(&self, name: &str) -> bool {
+        #[cfg(feature = "lfn")]
+        {
+            if self.eq_name_lfn(name) {
+                return true;
+            }
+        }
+
+        self.short_name.eq_ignore_case(name, &self.fs.options.oem_cp_converter)
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> fmt::Debug for DirEntry<'_, IO, TP, OCC> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.data.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::LossyOemCpConverter;
+
+    #[test]
+    fn short_name_with_ext() {
+        let oem_cp_conv = LossyOemCpConverter::new();
+        assert_eq!(ShortName::new(b"FOO     BAR").to_string(&oem_cp_conv), "FOO.BAR");
+        assert_eq!(ShortName::new(b"LOOK AT M E").to_string(&oem_cp_conv), "LOOK AT.M E");
+        assert_eq!(
+            ShortName::new(b"\x99OOK AT M \x99").to_string(&oem_cp_conv),
+            "\u{FFFD}OOK AT.M \u{FFFD}"
+        );
+        assert!(ShortName::new(b"\x99OOK AT M \x99").eq_ignore_case("\u{FFFD}OOK AT.M \u{FFFD}", &oem_cp_conv));
+    }
+
+    #[test]
+    fn short_name_without_ext() {
+        let oem_cp_conv = LossyOemCpConverter::new();
+        assert_eq!(ShortName::new(b"FOO        ").to_string(&oem_cp_conv), "FOO");
+        assert_eq!(ShortName::new(b"LOOK AT    ").to_string(&oem_cp_conv), "LOOK AT");
+    }
+
+    #[test]
+    fn short_name_eq_ignore_case() {
+        let oem_cp_conv = LossyOemCpConverter::new();
+        let raw_short_name: &[u8; SFN_SIZE] = b"\x99OOK AT M \x99";
+        assert!(ShortName::new(raw_short_name).eq_ignore_case("\u{FFFD}OOK AT.M \u{FFFD}", &oem_cp_conv));
+        assert!(ShortName::new(raw_short_name).eq_ignore_case("\u{FFFD}ook AT.m \u{FFFD}", &oem_cp_conv));
+    }
+
+    #[test]
+    fn short_name_05_changed_to_e5() {
+        let raw_short_name = [0x05; SFN_SIZE];
+        assert_eq!(
+            ShortName::new(&raw_short_name).as_bytes(),
+            [0xE5, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, b'.', 0x05, 0x05, 0x05]
+        );
+    }
+
+    #[test]
+    fn lowercase_short_name() {
+        let oem_cp_conv = LossyOemCpConverter::new();
+        let raw_short_name: &[u8; SFN_SIZE] = b"FOO     RS ";
+        let mut raw_entry = DirFileEntryData {
+            name: *raw_short_name,
+            reserved_0: (1 << 3) | (1 << 4),
+            ..DirFileEntryData::default()
+        };
+        assert_eq!(raw_entry.lowercase_name().to_string(&oem_cp_conv), "foo.rs");
+        raw_entry.reserved_0 = 1 << 3;
+        assert_eq!(raw_entry.lowercase_name().to_string(&oem_cp_conv), "foo.RS");
+        raw_entry.reserved_0 = 1 << 4;
+        assert_eq!(raw_entry.lowercase_name().to_string(&oem_cp_conv), "FOO.rs");
+        raw_entry.reserved_0 = 0;
+        assert_eq!(raw_entry.lowercase_name().to_string(&oem_cp_conv), "FOO.RS");
+    }
+}

--- a/fatfs/src/error.rs
+++ b/fatfs/src/error.rs
@@ -1,0 +1,137 @@
+/// Error enum with all errors that can be returned by functions from this crate
+///
+/// Generic parameter `T` is a type of external error returned by the user provided storage
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error<T> {
+    /// A user provided storage instance returned an error during an input/output operation.
+    Io(T),
+    /// A read operation cannot be completed because an end of a file has been reached prematurely.
+    UnexpectedEof,
+    /// A write operation cannot be completed because `Write::write` returned 0.
+    WriteZero,
+    /// A parameter was incorrect.
+    InvalidInput,
+    /// A requested file or directory has not been found.
+    NotFound,
+    /// A file or a directory with the same name already exists.
+    AlreadyExists,
+    /// An operation cannot be finished because a directory is not empty.
+    DirectoryIsNotEmpty,
+    /// File system internal structures are corrupted/invalid.
+    CorruptedFileSystem,
+    /// There is not enough free space on the storage to finish the requested operation.
+    NotEnoughSpace,
+    /// The provided file name is either too long or empty.
+    InvalidFileNameLength,
+    /// The provided file name contains an invalid character.
+    UnsupportedFileNameCharacter,
+}
+
+impl<T: IoError> From<T> for Error<T> {
+    fn from(error: T) -> Self {
+        Error::Io(error)
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<Error<std::io::Error>> for std::io::Error {
+    fn from(error: Error<Self>) -> Self {
+        match error {
+            Error::Io(io_error) => io_error,
+            Error::UnexpectedEof | Error::NotEnoughSpace => Self::new(std::io::ErrorKind::UnexpectedEof, error),
+            Error::WriteZero => Self::new(std::io::ErrorKind::WriteZero, error),
+            Error::InvalidInput
+            | Error::InvalidFileNameLength
+            | Error::UnsupportedFileNameCharacter
+            | Error::DirectoryIsNotEmpty => Self::new(std::io::ErrorKind::InvalidInput, error),
+            Error::NotFound => Self::new(std::io::ErrorKind::NotFound, error),
+            Error::AlreadyExists => Self::new(std::io::ErrorKind::AlreadyExists, error),
+            Error::CorruptedFileSystem => Self::new(std::io::ErrorKind::InvalidData, error),
+        }
+    }
+}
+
+impl<T: core::fmt::Display> core::fmt::Display for Error<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::Io(io_error) => write!(f, "IO error: {}", io_error),
+            Error::UnexpectedEof => write!(f, "Unexpected end of file"),
+            Error::NotEnoughSpace => write!(f, "Not enough space"),
+            Error::WriteZero => write!(f, "Write zero"),
+            Error::InvalidInput => write!(f, "Invalid input"),
+            Error::InvalidFileNameLength => write!(f, "Invalid file name length"),
+            Error::UnsupportedFileNameCharacter => write!(f, "Unsupported file name character"),
+            Error::DirectoryIsNotEmpty => write!(f, "Directory is not empty"),
+            Error::NotFound => write!(f, "No such file or directory"),
+            Error::AlreadyExists => write!(f, "File or directory already exists"),
+            Error::CorruptedFileSystem => write!(f, "Corrupted file system"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::error::Error + 'static> std::error::Error for Error<T> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        if let Error::Io(io_error) = self {
+            Some(io_error)
+        } else {
+            None
+        }
+    }
+}
+
+/// Trait that should be implemented by errors returned from the user supplied storage.
+///
+/// Implementations for `std::io::Error` and `()` are provided by this crate.
+pub trait IoError: core::fmt::Debug {
+    fn is_interrupted(&self) -> bool;
+    fn new_unexpected_eof_error() -> Self;
+    fn new_write_zero_error() -> Self;
+}
+
+impl<T: core::fmt::Debug + IoError> IoError for Error<T> {
+    fn is_interrupted(&self) -> bool {
+        match self {
+            Error::<T>::Io(io_error) => io_error.is_interrupted(),
+            _ => false,
+        }
+    }
+
+    fn new_unexpected_eof_error() -> Self {
+        Error::<T>::UnexpectedEof
+    }
+
+    fn new_write_zero_error() -> Self {
+        Error::<T>::WriteZero
+    }
+}
+
+impl IoError for () {
+    fn is_interrupted(&self) -> bool {
+        false
+    }
+
+    fn new_unexpected_eof_error() -> Self {
+        // empty
+    }
+
+    fn new_write_zero_error() -> Self {
+        // empty
+    }
+}
+
+#[cfg(feature = "std")]
+impl IoError for std::io::Error {
+    fn is_interrupted(&self) -> bool {
+        self.kind() == std::io::ErrorKind::Interrupted
+    }
+
+    fn new_unexpected_eof_error() -> Self {
+        Self::new(std::io::ErrorKind::UnexpectedEof, "failed to fill whole buffer")
+    }
+
+    fn new_write_zero_error() -> Self {
+        Self::new(std::io::ErrorKind::WriteZero, "failed to write whole buffer")
+    }
+}

--- a/fatfs/src/file.rs
+++ b/fatfs/src/file.rs
@@ -1,0 +1,478 @@
+use core::convert::TryFrom;
+
+use crate::dir_entry::DirEntryEditor;
+use crate::error::Error;
+use crate::fs::{FileSystem, ReadWriteSeek};
+use crate::io::{IoBase, Read, Seek, SeekFrom, Write};
+use crate::time::{Date, DateTime, TimeProvider};
+
+const MAX_FILE_SIZE: u32 = u32::MAX;
+
+/// A FAT filesystem file object used for reading and writing data.
+///
+/// This struct is created by the `open_file` or `create_file` methods on `Dir`.
+pub struct File<'a, IO: ReadWriteSeek, TP, OCC> {
+    // Note first_cluster is None if file is empty
+    first_cluster: Option<u32>,
+    // Note: if offset points between clusters current_cluster is the previous cluster
+    current_cluster: Option<u32>,
+    // current position in this file
+    offset: u32,
+    // file dir entry editor - None for root dir
+    entry: Option<DirEntryEditor>,
+    // file-system reference
+    fs: &'a FileSystem<IO, TP, OCC>,
+}
+
+/// An extent containing a file's data on disk.
+///
+/// This is created by the `extents` method on `File`, and represents
+/// a byte range on the disk that contains a file's data. All values
+/// are in bytes.
+#[derive(Clone, Debug)]
+pub struct Extent {
+    pub offset: u64,
+    pub size: u32,
+}
+
+impl<'a, IO: ReadWriteSeek, TP, OCC> File<'a, IO, TP, OCC> {
+    pub(crate) fn new(
+        first_cluster: Option<u32>,
+        entry: Option<DirEntryEditor>,
+        fs: &'a FileSystem<IO, TP, OCC>,
+    ) -> Self {
+        File {
+            first_cluster,
+            entry,
+            fs,
+            current_cluster: None, // cluster before first one
+            offset: 0,
+        }
+    }
+
+    /// Truncate file in current position.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if this is the root directory.
+    pub fn truncate(&mut self) -> Result<(), Error<IO::Error>> {
+        trace!("File::truncate");
+        if let Some(ref mut e) = self.entry {
+            e.set_size(self.offset);
+            if self.offset == 0 {
+                e.set_first_cluster(None, self.fs.fat_type());
+            }
+        } else {
+            // Note: we cannot handle this case because there is no size field
+            panic!("Trying to truncate a file without an entry");
+        }
+        if let Some(current_cluster) = self.current_cluster {
+            // current cluster is none only if offset is 0
+            debug_assert!(self.offset > 0);
+            self.fs.truncate_cluster_chain(current_cluster)
+        } else {
+            debug_assert!(self.offset == 0);
+            if let Some(n) = self.first_cluster {
+                self.fs.free_cluster_chain(n)?;
+                self.first_cluster = None;
+            }
+            Ok(())
+        }
+    }
+
+    /// Get the extents of a file on disk.
+    ///
+    /// This returns an iterator over the byte ranges on-disk occupied by
+    /// this file.
+    pub fn extents(&mut self) -> impl Iterator<Item = Result<Extent, Error<IO::Error>>> + 'a {
+        let fs = self.fs;
+        let cluster_size = fs.cluster_size();
+        let Some(mut bytes_left) = self.size() else {
+            return None.into_iter().flatten();
+        };
+        let Some(first) = self.first_cluster else {
+            return None.into_iter().flatten();
+        };
+
+        Some(
+            core::iter::once(Ok(first))
+                .chain(fs.cluster_iter(first))
+                .map(move |cluster_err| match cluster_err {
+                    Ok(cluster) => {
+                        let size = cluster_size.min(bytes_left);
+                        bytes_left -= size;
+                        Ok(Extent {
+                            offset: fs.offset_from_cluster(cluster),
+                            size,
+                        })
+                    }
+                    Err(e) => Err(e),
+                }),
+        )
+        .into_iter()
+        .flatten()
+    }
+
+    pub(crate) fn abs_pos(&self) -> Option<u64> {
+        // Returns current position relative to filesystem start
+        // Note: when between clusters it returns position after previous cluster
+        match self.current_cluster {
+            Some(n) => {
+                let cluster_size = self.fs.cluster_size();
+                let offset_mod_cluster_size = self.offset % cluster_size;
+                let offset_in_cluster = if offset_mod_cluster_size == 0 {
+                    // position points between clusters - we are returning previous cluster so
+                    // offset must be set to the cluster size
+                    cluster_size
+                } else {
+                    offset_mod_cluster_size
+                };
+                let offset_in_fs = self.fs.offset_from_cluster(n) + u64::from(offset_in_cluster);
+                Some(offset_in_fs)
+            }
+            None => None,
+        }
+    }
+
+    fn flush_dir_entry(&mut self) -> Result<(), Error<IO::Error>> {
+        if let Some(ref mut e) = self.entry {
+            e.flush(self.fs)?;
+        }
+        Ok(())
+    }
+
+    /// Sets date and time of creation for this file.
+    ///
+    /// Note: it is set to a value from the `TimeProvider` when creating a file.
+    #[deprecated]
+    pub fn set_created(&mut self, date_time: DateTime) {
+        if let Some(ref mut e) = self.entry {
+            e.set_created(date_time);
+        }
+    }
+
+    /// Sets date of last access for this file.
+    ///
+    /// Note: it is overwritten by a value from the `TimeProvider` on every file read operation.
+    #[deprecated]
+    pub fn set_accessed(&mut self, date: Date) {
+        if let Some(ref mut e) = self.entry {
+            e.set_accessed(date);
+        }
+    }
+
+    /// Sets date and time of last modification for this file.
+    ///
+    /// Note: it is overwritten by a value from the `TimeProvider` on every file write operation.
+    #[deprecated]
+    pub fn set_modified(&mut self, date_time: DateTime) {
+        if let Some(ref mut e) = self.entry {
+            e.set_modified(date_time);
+        }
+    }
+
+    fn size(&self) -> Option<u32> {
+        match self.entry {
+            Some(ref e) => e.inner().size(),
+            None => None,
+        }
+    }
+
+    fn is_dir(&self) -> bool {
+        match self.entry {
+            Some(ref e) => e.inner().is_dir(),
+            None => true, // root directory
+        }
+    }
+
+    fn bytes_left_in_file(&self) -> Option<usize> {
+        // Note: seeking beyond end of file is not allowed so overflow is impossible
+        self.size().map(|s| (s - self.offset) as usize)
+    }
+
+    fn set_first_cluster(&mut self, cluster: u32) {
+        self.first_cluster = Some(cluster);
+        if let Some(ref mut e) = self.entry {
+            e.set_first_cluster(self.first_cluster, self.fs.fat_type());
+        }
+    }
+
+    pub(crate) fn first_cluster(&self) -> Option<u32> {
+        self.first_cluster
+    }
+
+    fn flush(&mut self) -> Result<(), Error<IO::Error>> {
+        self.flush_dir_entry()?;
+        let mut disk = self.fs.disk.borrow_mut();
+        disk.flush()?;
+        Ok(())
+    }
+
+    pub(crate) fn is_root_dir(&self) -> bool {
+        self.entry.is_none()
+    }
+}
+
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> File<'_, IO, TP, OCC> {
+    fn update_dir_entry_after_write(&mut self) {
+        let offset = self.offset;
+        if let Some(ref mut e) = self.entry {
+            let now = self.fs.options.time_provider.get_current_date_time();
+            e.set_modified(now);
+            if e.inner().size().map_or(false, |s| offset > s) {
+                e.set_size(offset);
+            }
+        }
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> Drop for File<'_, IO, TP, OCC> {
+    fn drop(&mut self) {
+        if let Err(err) = self.flush() {
+            error!("flush failed {:?}", err);
+        }
+    }
+}
+
+// Note: derive cannot be used because of invalid bounds. See: https://github.com/rust-lang/rust/issues/26925
+impl<IO: ReadWriteSeek, TP, OCC> Clone for File<'_, IO, TP, OCC> {
+    fn clone(&self) -> Self {
+        File {
+            first_cluster: self.first_cluster,
+            current_cluster: self.current_cluster,
+            offset: self.offset,
+            entry: self.entry.clone(),
+            fs: self.fs,
+        }
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> IoBase for File<'_, IO, TP, OCC> {
+    type Error = Error<IO::Error>;
+}
+
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> Read for File<'_, IO, TP, OCC> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        trace!("File::read");
+        let cluster_size = self.fs.cluster_size();
+        let current_cluster_opt = if self.offset % cluster_size == 0 {
+            // next cluster
+            match self.current_cluster {
+                None => self.first_cluster,
+                Some(n) => {
+                    let r = self.fs.cluster_iter(n).next();
+                    match r {
+                        Some(Err(err)) => return Err(err),
+                        Some(Ok(n)) => Some(n),
+                        None => None,
+                    }
+                }
+            }
+        } else {
+            self.current_cluster
+        };
+        let Some(current_cluster) = current_cluster_opt else {
+            return Ok(0);
+        };
+        let offset_in_cluster = self.offset % cluster_size;
+        let bytes_left_in_cluster = (cluster_size - offset_in_cluster) as usize;
+        let bytes_left_in_file = self.bytes_left_in_file().unwrap_or(bytes_left_in_cluster);
+        let read_size = buf.len().min(bytes_left_in_cluster).min(bytes_left_in_file);
+        if read_size == 0 {
+            return Ok(0);
+        }
+        trace!("read {} bytes in cluster {}", read_size, current_cluster);
+        let offset_in_fs = self.fs.offset_from_cluster(current_cluster) + u64::from(offset_in_cluster);
+        let read_bytes = {
+            let mut disk = self.fs.disk.borrow_mut();
+            disk.seek(SeekFrom::Start(offset_in_fs))?;
+            disk.read(&mut buf[..read_size])?
+        };
+        if read_bytes == 0 {
+            return Ok(0);
+        }
+        self.offset += read_bytes as u32;
+        self.current_cluster = Some(current_cluster);
+
+        if let Some(ref mut e) = self.entry {
+            if self.fs.options.update_accessed_date {
+                let now = self.fs.options.time_provider.get_current_date();
+                e.set_accessed(now);
+            }
+        }
+        Ok(read_bytes)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> std::io::Read for File<'_, IO, TP, OCC>
+where
+    std::io::Error: From<Error<IO::Error>>,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        Ok(Read::read(self, buf)?)
+    }
+}
+
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> Write for File<'_, IO, TP, OCC> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        trace!("File::write");
+        let cluster_size = self.fs.cluster_size();
+        let offset_in_cluster = self.offset % cluster_size;
+        let bytes_left_in_cluster = (cluster_size - offset_in_cluster) as usize;
+        let bytes_left_until_max_file_size = (MAX_FILE_SIZE - self.offset) as usize;
+        let write_size = buf.len().min(bytes_left_in_cluster).min(bytes_left_until_max_file_size);
+        // Exit early if we are going to write no data
+        if write_size == 0 {
+            return Ok(0);
+        }
+        // Mark the volume 'dirty'
+        self.fs.set_dirty_flag(true)?;
+        // Get cluster for write possibly allocating new one
+        let current_cluster = if self.offset % cluster_size == 0 {
+            // next cluster
+            let next_cluster = match self.current_cluster {
+                None => self.first_cluster,
+                Some(n) => {
+                    let r = self.fs.cluster_iter(n).next();
+                    match r {
+                        Some(Err(err)) => return Err(err),
+                        Some(Ok(n)) => Some(n),
+                        None => None,
+                    }
+                }
+            };
+            if let Some(n) = next_cluster {
+                n
+            } else {
+                // end of chain reached - allocate new cluster
+                let new_cluster = self.fs.alloc_cluster(self.current_cluster, self.is_dir())?;
+                trace!("allocated cluster {}", new_cluster);
+                if self.first_cluster.is_none() {
+                    self.set_first_cluster(new_cluster);
+                }
+                new_cluster
+            }
+        } else {
+            // self.current_cluster should be a valid cluster
+            match self.current_cluster {
+                Some(n) => n,
+                None => panic!("Offset inside cluster but no cluster allocated"),
+            }
+        };
+        trace!("write {} bytes in cluster {}", write_size, current_cluster);
+        let offset_in_fs = self.fs.offset_from_cluster(current_cluster) + u64::from(offset_in_cluster);
+        let written_bytes = {
+            let mut disk = self.fs.disk.borrow_mut();
+            disk.seek(SeekFrom::Start(offset_in_fs))?;
+            disk.write(&buf[..write_size])?
+        };
+        if written_bytes == 0 {
+            return Ok(0);
+        }
+        // some bytes were writter - update position and optionally size
+        self.offset += written_bytes as u32;
+        self.current_cluster = Some(current_cluster);
+        self.update_dir_entry_after_write();
+        Ok(written_bytes)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Self::flush(self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> std::io::Write for File<'_, IO, TP, OCC>
+where
+    std::io::Error: From<Error<IO::Error>>,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Ok(Write::write(self, buf)?)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        Ok(Write::write_all(self, buf)?)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(Write::flush(self)?)
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> Seek for File<'_, IO, TP, OCC> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        trace!("File::seek");
+        let size_opt = self.size();
+        let new_offset_opt: Option<u32> = match pos {
+            SeekFrom::Current(x) => i64::from(self.offset)
+                .checked_add(x)
+                .and_then(|n| u32::try_from(n).ok()),
+            SeekFrom::Start(x) => u32::try_from(x).ok(),
+            SeekFrom::End(o) => size_opt
+                .and_then(|s| i64::from(s).checked_add(o))
+                .and_then(|n| u32::try_from(n).ok()),
+        };
+        let Some(mut new_offset) = new_offset_opt else {
+            error!("Invalid seek offset");
+            return Err(Error::InvalidInput);
+        };
+        if let Some(size) = size_opt {
+            if new_offset > size {
+                warn!("Seek beyond the end of the file");
+                new_offset = size;
+            }
+        }
+        trace!("file seek {} -> {} - entry {:?}", self.offset, new_offset, self.entry);
+        if new_offset == self.offset {
+            // position is the same - nothing to do
+            return Ok(u64::from(self.offset));
+        }
+        let new_offset_in_clusters = self.fs.clusters_from_bytes(u64::from(new_offset));
+        let old_offset_in_clusters = self.fs.clusters_from_bytes(u64::from(self.offset));
+        let new_cluster = if new_offset == 0 {
+            None
+        } else if new_offset_in_clusters == old_offset_in_clusters {
+            self.current_cluster
+        } else if let Some(first_cluster) = self.first_cluster {
+            // calculate number of clusters to skip
+            // return the previous cluster if the offset points to the cluster boundary
+            // Note: new_offset_in_clusters cannot be 0 here because new_offset is not 0
+            debug_assert!(new_offset_in_clusters > 0);
+            let clusters_to_skip = new_offset_in_clusters - 1;
+            let mut cluster = first_cluster;
+            let mut iter = self.fs.cluster_iter(first_cluster);
+            for i in 0..clusters_to_skip {
+                cluster = if let Some(r) = iter.next() {
+                    r?
+                } else {
+                    // cluster chain ends before the new position - seek to the end of the last cluster
+                    new_offset = self.fs.bytes_from_clusters(i + 1) as u32;
+                    break;
+                };
+            }
+            Some(cluster)
+        } else {
+            // empty file - always seek to 0
+            new_offset = 0;
+            None
+        };
+        self.offset = new_offset;
+        self.current_cluster = new_cluster;
+        Ok(u64::from(self.offset))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> std::io::Seek for File<'_, IO, TP, OCC>
+where
+    std::io::Error: From<Error<IO::Error>>,
+{
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        Ok(Seek::seek(self, pos.into())?)
+    }
+}

--- a/fatfs/src/fs.rs
+++ b/fatfs/src/fs.rs
@@ -1,0 +1,1235 @@
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::string::String;
+use core::borrow::BorrowMut;
+use core::cell::{Cell, RefCell};
+use core::convert::TryFrom;
+use core::fmt::Debug;
+use core::marker::PhantomData;
+
+use crate::boot_sector::{format_boot_sector, BiosParameterBlock, BootSector};
+use crate::dir::{Dir, DirRawStream};
+use crate::dir_entry::{DirFileEntryData, FileAttributes, SFN_PADDING, SFN_SIZE};
+use crate::error::Error;
+use crate::file::File;
+use crate::io::{self, IoBase, Read, ReadLeExt, Seek, SeekFrom, Write, WriteLeExt};
+use crate::table::{
+    alloc_cluster, count_free_clusters, format_fat, read_fat_flags, ClusterIterator, RESERVED_FAT_ENTRIES,
+};
+use crate::time::{DefaultTimeProvider, TimeProvider};
+
+// FAT implementation based on:
+//   http://wiki.osdev.org/FAT
+//   https://www.win.tue.nl/~aeb/linux/fs/fat/fat-1.html
+
+/// A type of FAT filesystem.
+///
+/// `FatType` values are based on the size of File Allocation Table entry.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum FatType {
+    /// 12 bits per FAT entry
+    Fat12,
+    /// 16 bits per FAT entry
+    Fat16,
+    /// 32 bits per FAT entry
+    Fat32,
+}
+
+impl FatType {
+    const FAT16_MIN_CLUSTERS: u32 = 4085;
+    const FAT32_MIN_CLUSTERS: u32 = 65525;
+    const FAT32_MAX_CLUSTERS: u32 = 0x0FFF_FFF4;
+
+    pub(crate) fn from_clusters(total_clusters: u32) -> Self {
+        if total_clusters < Self::FAT16_MIN_CLUSTERS {
+            FatType::Fat12
+        } else if total_clusters < Self::FAT32_MIN_CLUSTERS {
+            FatType::Fat16
+        } else {
+            FatType::Fat32
+        }
+    }
+
+    pub(crate) fn bits_per_fat_entry(self) -> u32 {
+        match self {
+            FatType::Fat12 => 12,
+            FatType::Fat16 => 16,
+            FatType::Fat32 => 32,
+        }
+    }
+
+    pub(crate) fn min_clusters(self) -> u32 {
+        match self {
+            FatType::Fat12 => 0,
+            FatType::Fat16 => Self::FAT16_MIN_CLUSTERS,
+            FatType::Fat32 => Self::FAT32_MIN_CLUSTERS,
+        }
+    }
+
+    pub(crate) fn max_clusters(self) -> u32 {
+        match self {
+            FatType::Fat12 => Self::FAT16_MIN_CLUSTERS - 1,
+            FatType::Fat16 => Self::FAT32_MIN_CLUSTERS - 1,
+            FatType::Fat32 => Self::FAT32_MAX_CLUSTERS,
+        }
+    }
+}
+
+/// A FAT volume status flags retrived from the Boot Sector and the allocation table second entry.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct FsStatusFlags {
+    pub(crate) dirty: bool,
+    pub(crate) io_error: bool,
+}
+
+impl FsStatusFlags {
+    /// Checks if the volume is marked as dirty.
+    ///
+    /// Dirty flag means volume has been suddenly ejected from filesystem without unmounting.
+    #[must_use]
+    pub fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Checks if the volume has the IO Error flag active.
+    #[must_use]
+    pub fn io_error(&self) -> bool {
+        self.io_error
+    }
+
+    fn encode(self) -> u8 {
+        let mut res = 0_u8;
+        if self.dirty {
+            res |= 1;
+        }
+        if self.io_error {
+            res |= 2;
+        }
+        res
+    }
+
+    pub(crate) fn decode(flags: u8) -> Self {
+        Self {
+            dirty: flags & 1 != 0,
+            io_error: flags & 2 != 0,
+        }
+    }
+}
+
+/// A sum of `Read` and `Seek` traits.
+pub trait ReadSeek: Read + Seek {}
+impl<T: Read + Seek> ReadSeek for T {}
+
+/// A sum of `Read`, `Write` and `Seek` traits.
+pub trait ReadWriteSeek: Read + Write + Seek {}
+impl<T: Read + Write + Seek> ReadWriteSeek for T {}
+
+#[derive(Clone, Default, Debug)]
+struct FsInfoSector {
+    free_cluster_count: Option<u32>,
+    next_free_cluster: Option<u32>,
+    dirty: bool,
+}
+
+impl FsInfoSector {
+    const LEAD_SIG: u32 = 0x4161_5252;
+    const STRUC_SIG: u32 = 0x6141_7272;
+    const TRAIL_SIG: u32 = 0xAA55_0000;
+
+    fn deserialize<R: Read>(rdr: &mut R) -> Result<Self, Error<R::Error>> {
+        let lead_sig = rdr.read_u32_le()?;
+        if lead_sig != Self::LEAD_SIG {
+            error!("invalid lead_sig in FsInfo sector: {}", lead_sig);
+            return Err(Error::CorruptedFileSystem);
+        }
+        let mut reserved = [0_u8; 480];
+        rdr.read_exact(&mut reserved)?;
+        let struc_sig = rdr.read_u32_le()?;
+        if struc_sig != Self::STRUC_SIG {
+            error!("invalid struc_sig in FsInfo sector: {}", struc_sig);
+            return Err(Error::CorruptedFileSystem);
+        }
+        let free_cluster_count = match rdr.read_u32_le()? {
+            0xFFFF_FFFF => None,
+            // Note: value is validated in FileSystem::new function using values from BPB
+            n => Some(n),
+        };
+        let next_free_cluster = match rdr.read_u32_le()? {
+            0xFFFF_FFFF => None,
+            0 | 1 => {
+                warn!("invalid next_free_cluster in FsInfo sector (values 0 and 1 are reserved)");
+                None
+            }
+            // Note: other values are validated in FileSystem::new function using values from BPB
+            n => Some(n),
+        };
+        let mut reserved2 = [0_u8; 12];
+        rdr.read_exact(&mut reserved2)?;
+        let trail_sig = rdr.read_u32_le()?;
+        if trail_sig != Self::TRAIL_SIG {
+            error!("invalid trail_sig in FsInfo sector: {}", trail_sig);
+            return Err(Error::CorruptedFileSystem);
+        }
+        Ok(Self {
+            free_cluster_count,
+            next_free_cluster,
+            dirty: false,
+        })
+    }
+
+    fn serialize<W: Write>(&self, wrt: &mut W) -> Result<(), Error<W::Error>> {
+        wrt.write_u32_le(Self::LEAD_SIG)?;
+        let reserved = [0_u8; 480];
+        wrt.write_all(&reserved)?;
+        wrt.write_u32_le(Self::STRUC_SIG)?;
+        wrt.write_u32_le(self.free_cluster_count.unwrap_or(0xFFFF_FFFF))?;
+        wrt.write_u32_le(self.next_free_cluster.unwrap_or(0xFFFF_FFFF))?;
+        let reserved2 = [0_u8; 12];
+        wrt.write_all(&reserved2)?;
+        wrt.write_u32_le(Self::TRAIL_SIG)?;
+        Ok(())
+    }
+
+    fn validate_and_fix(&mut self, total_clusters: u32) {
+        let max_valid_cluster_number = total_clusters + RESERVED_FAT_ENTRIES;
+        if let Some(n) = self.free_cluster_count {
+            if n > total_clusters {
+                warn!(
+                    "invalid free_cluster_count ({}) in fs_info exceeds total cluster count ({})",
+                    n, total_clusters
+                );
+                self.free_cluster_count = None;
+            }
+        }
+        if let Some(n) = self.next_free_cluster {
+            if n > max_valid_cluster_number {
+                warn!(
+                    "invalid free_cluster_count ({}) in fs_info exceeds maximum cluster number ({})",
+                    n, max_valid_cluster_number
+                );
+                self.next_free_cluster = None;
+            }
+        }
+    }
+
+    fn map_free_clusters(&mut self, map_fn: impl Fn(u32) -> u32) {
+        if let Some(n) = self.free_cluster_count {
+            self.free_cluster_count = Some(map_fn(n));
+            self.dirty = true;
+        }
+    }
+
+    fn set_next_free_cluster(&mut self, cluster: u32) {
+        self.next_free_cluster = Some(cluster);
+        self.dirty = true;
+    }
+
+    fn set_free_cluster_count(&mut self, free_cluster_count: u32) {
+        self.free_cluster_count = Some(free_cluster_count);
+        self.dirty = true;
+    }
+}
+
+/// A FAT filesystem mount options.
+///
+/// Options are specified as an argument for `FileSystem::new` method.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct FsOptions<TP, OCC> {
+    pub(crate) update_accessed_date: bool,
+    pub(crate) oem_cp_converter: OCC,
+    pub(crate) time_provider: TP,
+    pub(crate) strict: bool,
+}
+
+impl FsOptions<DefaultTimeProvider, LossyOemCpConverter> {
+    /// Creates a `FsOptions` struct with default options.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            update_accessed_date: false,
+            oem_cp_converter: LossyOemCpConverter::new(),
+            time_provider: DefaultTimeProvider::new(),
+            strict: true,
+        }
+    }
+}
+
+impl<TP: TimeProvider, OCC: OemCpConverter> FsOptions<TP, OCC> {
+    /// If enabled accessed date field in directory entry is updated when reading or writing a file.
+    #[must_use]
+    pub fn update_accessed_date(mut self, enabled: bool) -> Self {
+        self.update_accessed_date = enabled;
+        self
+    }
+
+    /// Changes default OEM code page encoder-decoder.
+    pub fn oem_cp_converter<OCC2: OemCpConverter>(self, oem_cp_converter: OCC2) -> FsOptions<TP, OCC2> {
+        FsOptions::<TP, OCC2> {
+            update_accessed_date: self.update_accessed_date,
+            oem_cp_converter,
+            time_provider: self.time_provider,
+            strict: self.strict,
+        }
+    }
+
+    /// Changes default time provider.
+    pub fn time_provider<TP2: TimeProvider>(self, time_provider: TP2) -> FsOptions<TP2, OCC> {
+        FsOptions::<TP2, OCC> {
+            update_accessed_date: self.update_accessed_date,
+            oem_cp_converter: self.oem_cp_converter,
+            time_provider,
+            strict: self.strict,
+        }
+    }
+
+    /// If enabled more validations are performed to check if file-system is conforming to specification.
+    pub fn strict(self, strict: bool) -> Self {
+        Self {
+            update_accessed_date: self.update_accessed_date,
+            oem_cp_converter: self.oem_cp_converter,
+            time_provider: self.time_provider,
+            strict,
+        }
+    }
+}
+
+/// A FAT volume statistics.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct FileSystemStats {
+    cluster_size: u32,
+    total_clusters: u32,
+    free_clusters: u32,
+}
+
+impl FileSystemStats {
+    /// Cluster size in bytes
+    #[must_use]
+    pub fn cluster_size(&self) -> u32 {
+        self.cluster_size
+    }
+
+    /// Number of total clusters in filesystem usable for file allocation
+    #[must_use]
+    pub fn total_clusters(&self) -> u32 {
+        self.total_clusters
+    }
+
+    /// Number of free clusters
+    #[must_use]
+    pub fn free_clusters(&self) -> u32 {
+        self.free_clusters
+    }
+}
+
+/// A FAT filesystem object.
+///
+/// `FileSystem` struct is representing a state of a mounted FAT volume.
+pub struct FileSystem<IO: ReadWriteSeek, TP = DefaultTimeProvider, OCC = LossyOemCpConverter> {
+    pub(crate) disk: RefCell<IO>,
+    pub(crate) options: FsOptions<TP, OCC>,
+    fat_type: FatType,
+    bpb: BiosParameterBlock,
+    first_data_sector: u32,
+    root_dir_sectors: u32,
+    total_clusters: u32,
+    fs_info: RefCell<FsInfoSector>,
+    current_status_flags: Cell<FsStatusFlags>,
+}
+
+pub trait IntoStorage<T: Read + Write + Seek> {
+    fn into_storage(self) -> T;
+}
+
+impl<T: Read + Write + Seek> IntoStorage<T> for T {
+    fn into_storage(self) -> Self {
+        self
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Read + std::io::Write + std::io::Seek> IntoStorage<io::StdIoWrapper<T>> for T {
+    fn into_storage(self) -> io::StdIoWrapper<Self> {
+        io::StdIoWrapper::new(self)
+    }
+}
+
+impl<IO: Read + Write + Seek, TP, OCC> FileSystem<IO, TP, OCC> {
+    /// Creates a new filesystem object instance.
+    ///
+    /// Supplied `storage` parameter cannot be seeked. If there is a need to read a fragment of disk
+    /// image (e.g. partition) library user should wrap the file struct in a struct limiting
+    /// access to partition bytes only e.g. `fscommon::StreamSlice`.
+    ///
+    /// Note: creating multiple filesystem objects with a single underlying storage can
+    /// cause a filesystem corruption.
+    ///
+    /// # Errors
+    ///
+    /// Errors that can be returned:
+    ///
+    /// * `Error::CorruptedFileSystem` will be returned if the boot sector and/or the file system information sector
+    ///   contains invalid values.
+    /// * `Error::Io` will be returned if the provided storage object returned an I/O error.
+    ///
+    /// # Panics
+    ///
+    /// Panics in non-optimized build if `storage` position returned by `seek` is not zero.
+    pub fn new<T: IntoStorage<IO>>(storage: T, options: FsOptions<TP, OCC>) -> Result<Self, Error<IO::Error>> {
+        // Make sure given image is not seeked
+        let mut disk = storage.into_storage();
+        trace!("FileSystem::new");
+        debug_assert!(disk.seek(SeekFrom::Current(0))? == 0);
+
+        // read boot sector
+        let bpb = {
+            let boot = BootSector::deserialize(&mut disk)?;
+            boot.validate(options.strict)?;
+            boot.bpb
+        };
+
+        let root_dir_sectors = bpb.root_dir_sectors();
+        let first_data_sector = bpb.first_data_sector();
+        let total_clusters = bpb.total_clusters();
+        let fat_type = FatType::from_clusters(total_clusters);
+
+        // read FSInfo sector if this is FAT32
+        let mut fs_info = if fat_type == FatType::Fat32 {
+            disk.seek(SeekFrom::Start(bpb.bytes_from_sectors(bpb.fs_info_sector())))?;
+            FsInfoSector::deserialize(&mut disk)?
+        } else {
+            FsInfoSector::default()
+        };
+
+        // if dirty flag is set completly ignore free_cluster_count in FSInfo
+        if bpb.status_flags().dirty {
+            fs_info.free_cluster_count = None;
+        }
+
+        // Validate the numbers stored in the free_cluster_count and next_free_cluster are within bounds for volume
+        fs_info.validate_and_fix(total_clusters);
+
+        // return FileSystem struct
+        let status_flags = bpb.status_flags();
+        trace!("FileSystem::new end");
+        Ok(Self {
+            disk: RefCell::new(disk),
+            options,
+            fat_type,
+            bpb,
+            first_data_sector,
+            root_dir_sectors,
+            total_clusters,
+            fs_info: RefCell::new(fs_info),
+            current_status_flags: Cell::new(status_flags),
+        })
+    }
+
+    /// Returns a type of File Allocation Table (FAT) used by this filesystem.
+    pub fn fat_type(&self) -> FatType {
+        self.fat_type
+    }
+
+    /// Returns a volume identifier read from BPB in the Boot Sector.
+    pub fn volume_id(&self) -> u32 {
+        self.bpb.volume_id
+    }
+
+    /// Returns a volume label from BPB in the Boot Sector as byte array slice.
+    ///
+    /// Label is encoded in the OEM codepage.
+    /// Note: This function returns label stored in the BPB block. Use `read_volume_label_from_root_dir_as_bytes` to
+    /// read label from the root directory.
+    pub fn volume_label_as_bytes(&self) -> &[u8] {
+        let full_label_slice = &self.bpb.volume_label;
+        let len = full_label_slice
+            .iter()
+            .rposition(|b| *b != SFN_PADDING)
+            .map_or(0, |p| p + 1);
+        &full_label_slice[..len]
+    }
+
+    fn offset_from_sector(&self, sector: u32) -> u64 {
+        self.bpb.bytes_from_sectors(sector)
+    }
+
+    fn sector_from_cluster(&self, cluster: u32) -> u32 {
+        self.first_data_sector + self.bpb.sectors_from_clusters(cluster - RESERVED_FAT_ENTRIES)
+    }
+
+    pub fn cluster_size(&self) -> u32 {
+        self.bpb.cluster_size()
+    }
+
+    pub(crate) fn offset_from_cluster(&self, cluster: u32) -> u64 {
+        self.offset_from_sector(self.sector_from_cluster(cluster))
+    }
+
+    pub(crate) fn bytes_from_clusters(&self, clusters: u32) -> u64 {
+        self.bpb.bytes_from_sectors(self.bpb.sectors_from_clusters(clusters))
+    }
+
+    pub(crate) fn clusters_from_bytes(&self, bytes: u64) -> u32 {
+        self.bpb.clusters_from_bytes(bytes)
+    }
+
+    fn fat_slice(&self) -> impl ReadWriteSeek<Error = Error<IO::Error>> + '_ {
+        let io = FsIoAdapter { fs: self };
+        fat_slice(io, &self.bpb)
+    }
+
+    pub(crate) fn cluster_iter(
+        &self,
+        cluster: u32,
+    ) -> ClusterIterator<impl ReadWriteSeek<Error = Error<IO::Error>> + '_, IO::Error> {
+        let disk_slice = self.fat_slice();
+        ClusterIterator::new(disk_slice, self.fat_type, cluster)
+    }
+
+    pub(crate) fn truncate_cluster_chain(&self, cluster: u32) -> Result<(), Error<IO::Error>> {
+        let mut iter = self.cluster_iter(cluster);
+        let num_free = iter.truncate()?;
+        let mut fs_info = self.fs_info.borrow_mut();
+        fs_info.map_free_clusters(|n| n + num_free);
+        Ok(())
+    }
+
+    pub(crate) fn free_cluster_chain(&self, cluster: u32) -> Result<(), Error<IO::Error>> {
+        let mut iter = self.cluster_iter(cluster);
+        let num_free = iter.free()?;
+        let mut fs_info = self.fs_info.borrow_mut();
+        fs_info.map_free_clusters(|n| n + num_free);
+        Ok(())
+    }
+
+    pub(crate) fn alloc_cluster(&self, prev_cluster: Option<u32>, zero: bool) -> Result<u32, Error<IO::Error>> {
+        trace!("alloc_cluster");
+        let hint = self.fs_info.borrow().next_free_cluster;
+        let cluster = {
+            let mut fat = self.fat_slice();
+            alloc_cluster(&mut fat, self.fat_type, prev_cluster, hint, self.total_clusters)?
+        };
+        if zero {
+            let mut disk = self.disk.borrow_mut();
+            disk.seek(SeekFrom::Start(self.offset_from_cluster(cluster)))?;
+            write_zeros(&mut *disk, u64::from(self.cluster_size()))?;
+        }
+        let mut fs_info = self.fs_info.borrow_mut();
+        fs_info.set_next_free_cluster(cluster + 1);
+        fs_info.map_free_clusters(|n| n - 1);
+        Ok(cluster)
+    }
+
+    /// Returns status flags for this volume.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn read_status_flags(&self) -> Result<FsStatusFlags, Error<IO::Error>> {
+        let bpb_status = self.bpb.status_flags();
+        let fat_status = read_fat_flags(&mut self.fat_slice(), self.fat_type)?;
+        Ok(FsStatusFlags {
+            dirty: bpb_status.dirty || fat_status.dirty,
+            io_error: bpb_status.io_error || fat_status.io_error,
+        })
+    }
+
+    /// Returns filesystem statistics like number of total and free clusters.
+    ///
+    /// For FAT32 volumes number of free clusters from the FS Information Sector is returned (may be incorrect).
+    /// For other FAT variants number is computed on the first call to this method and cached for later use.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn stats(&self) -> Result<FileSystemStats, Error<IO::Error>> {
+        let free_clusters_option = self.fs_info.borrow().free_cluster_count;
+        let free_clusters = if let Some(n) = free_clusters_option {
+            n
+        } else {
+            self.recalc_free_clusters()?
+        };
+        Ok(FileSystemStats {
+            cluster_size: self.cluster_size(),
+            total_clusters: self.total_clusters,
+            free_clusters,
+        })
+    }
+
+    /// Forces free clusters recalculation.
+    fn recalc_free_clusters(&self) -> Result<u32, Error<IO::Error>> {
+        let mut fat = self.fat_slice();
+        let free_cluster_count = count_free_clusters(&mut fat, self.fat_type, self.total_clusters)?;
+        self.fs_info.borrow_mut().set_free_cluster_count(free_cluster_count);
+        Ok(free_cluster_count)
+    }
+
+    /// Unmounts the filesystem.
+    ///
+    /// Updates the FS Information Sector if needed.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn unmount(self) -> Result<(), Error<IO::Error>> {
+        self.unmount_internal()
+    }
+
+    fn unmount_internal(&self) -> Result<(), Error<IO::Error>> {
+        self.flush_fs_info()?;
+        self.set_dirty_flag(false)?;
+        Ok(())
+    }
+
+    fn flush_fs_info(&self) -> Result<(), Error<IO::Error>> {
+        let mut fs_info = self.fs_info.borrow_mut();
+        if self.fat_type == FatType::Fat32 && fs_info.dirty {
+            let mut disk = self.disk.borrow_mut();
+            let fs_info_sector_offset = self.offset_from_sector(u32::from(self.bpb.fs_info_sector));
+            disk.seek(SeekFrom::Start(fs_info_sector_offset))?;
+            fs_info.serialize(&mut *disk)?;
+            fs_info.dirty = false;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_dirty_flag(&self, dirty: bool) -> Result<(), IO::Error> {
+        // Do not overwrite flags read from BPB on mount
+        let mut flags = self.bpb.status_flags();
+        flags.dirty |= dirty;
+        // Check if flags has changed
+        let current_flags = self.current_status_flags.get();
+        if flags == current_flags {
+            // Nothing to do
+            return Ok(());
+        }
+        let encoded = flags.encode();
+        // Note: only one field is written to avoid rewriting entire boot-sector which could be dangerous
+        // Compute reserver_1 field offset and write new flags
+        let offset = if self.fat_type() == FatType::Fat32 {
+            0x041
+        } else {
+            0x025
+        };
+        let mut disk = self.disk.borrow_mut();
+        disk.seek(io::SeekFrom::Start(offset))?;
+        disk.write_u8(encoded)?;
+        self.current_status_flags.set(flags);
+        Ok(())
+    }
+
+    /// Returns a root directory object allowing for futher penetration of a filesystem structure.
+    pub fn root_dir(&self) -> Dir<IO, TP, OCC> {
+        trace!("root_dir");
+        let root_rdr = {
+            match self.fat_type {
+                FatType::Fat12 | FatType::Fat16 => DirRawStream::Root(DiskSlice::from_sectors(
+                    self.first_data_sector - self.root_dir_sectors,
+                    self.root_dir_sectors,
+                    1,
+                    &self.bpb,
+                    FsIoAdapter { fs: self },
+                )),
+                FatType::Fat32 => DirRawStream::File(File::new(Some(self.bpb.root_dir_first_cluster), None, self)),
+            }
+        };
+        Dir::new(root_rdr, self)
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC: OemCpConverter> FileSystem<IO, TP, OCC> {
+    /// Returns a volume label from BPB in the Boot Sector as `String`.
+    ///
+    /// Non-ASCII characters are replaced by the replacement character (U+FFFD).
+    /// Note: This function returns label stored in the BPB block. Use `read_volume_label_from_root_dir` to read label
+    /// from the root directory.
+    #[cfg(feature = "alloc")]
+    pub fn volume_label(&self) -> String {
+        // Decode volume label from OEM codepage
+        let volume_label_iter = self.volume_label_as_bytes().iter().copied();
+        let char_iter = volume_label_iter.map(|c| self.options.oem_cp_converter.decode(c));
+        // Build string from character iterator
+        char_iter.collect()
+    }
+}
+
+impl<IO: ReadWriteSeek, TP: TimeProvider, OCC: OemCpConverter> FileSystem<IO, TP, OCC> {
+    /// Returns a volume label from root directory as `String`.
+    ///
+    /// It finds file with `VOLUME_ID` attribute and returns its short name.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    #[cfg(feature = "alloc")]
+    pub fn read_volume_label_from_root_dir(&self) -> Result<Option<String>, Error<IO::Error>> {
+        // Note: DirEntry::file_short_name() cannot be used because it interprets name as 8.3
+        // (adds dot before an extension)
+        let volume_label_opt = self.read_volume_label_from_root_dir_as_bytes()?;
+        volume_label_opt.map_or(Ok(None), |volume_label| {
+            // Strip label padding
+            let len = volume_label
+                .iter()
+                .rposition(|b| *b != SFN_PADDING)
+                .map_or(0, |p| p + 1);
+            let label_slice = &volume_label[..len];
+            // Decode volume label from OEM codepage
+            let volume_label_iter = label_slice.iter().copied();
+            let char_iter = volume_label_iter.map(|c| self.options.oem_cp_converter.decode(c));
+            // Build string from character iterator
+            Ok(Some(char_iter.collect::<String>()))
+        })
+    }
+
+    /// Returns a volume label from root directory as byte array.
+    ///
+    /// Label is encoded in the OEM codepage.
+    /// It finds file with `VOLUME_ID` attribute and returns its short name.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Io` will be returned if the underlying storage object returned an I/O error.
+    pub fn read_volume_label_from_root_dir_as_bytes(&self) -> Result<Option<[u8; SFN_SIZE]>, Error<IO::Error>> {
+        let entry_opt = self.root_dir().find_volume_entry()?;
+        Ok(entry_opt.map(|e| *e.raw_short_name()))
+    }
+}
+
+/// `Drop` implementation tries to unmount the filesystem when dropping.
+impl<IO: ReadWriteSeek, TP, OCC> Drop for FileSystem<IO, TP, OCC> {
+    fn drop(&mut self) {
+        if let Err(err) = self.unmount_internal() {
+            error!("unmount failed {:?}", err);
+        }
+    }
+}
+
+pub(crate) struct FsIoAdapter<'a, IO: ReadWriteSeek, TP, OCC> {
+    fs: &'a FileSystem<IO, TP, OCC>,
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> IoBase for FsIoAdapter<'_, IO, TP, OCC> {
+    type Error = IO::Error;
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> Read for FsIoAdapter<'_, IO, TP, OCC> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.fs.disk.borrow_mut().read(buf)
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> Write for FsIoAdapter<'_, IO, TP, OCC> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        let size = self.fs.disk.borrow_mut().write(buf)?;
+        if size > 0 {
+            self.fs.set_dirty_flag(true)?;
+        }
+        Ok(size)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.fs.disk.borrow_mut().flush()
+    }
+}
+
+impl<IO: ReadWriteSeek, TP, OCC> Seek for FsIoAdapter<'_, IO, TP, OCC> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        self.fs.disk.borrow_mut().seek(pos)
+    }
+}
+
+// Note: derive cannot be used because of invalid bounds. See: https://github.com/rust-lang/rust/issues/26925
+impl<IO: ReadWriteSeek, TP, OCC> Clone for FsIoAdapter<'_, IO, TP, OCC> {
+    fn clone(&self) -> Self {
+        FsIoAdapter { fs: self.fs }
+    }
+}
+
+fn fat_slice<S: ReadWriteSeek, B: BorrowMut<S>>(
+    io: B,
+    bpb: &BiosParameterBlock,
+) -> impl ReadWriteSeek<Error = Error<S::Error>> {
+    let sectors_per_fat = bpb.sectors_per_fat();
+    let mirroring_enabled = bpb.mirroring_enabled();
+    let (fat_first_sector, mirrors) = if mirroring_enabled {
+        (bpb.reserved_sectors(), bpb.fats)
+    } else {
+        let active_fat = u32::from(bpb.active_fat());
+        let fat_first_sector = (bpb.reserved_sectors()) + active_fat * sectors_per_fat;
+        (fat_first_sector, 1)
+    };
+    DiskSlice::from_sectors(fat_first_sector, sectors_per_fat, mirrors, bpb, io)
+}
+
+pub(crate) struct DiskSlice<B, S = B> {
+    begin: u64,
+    size: u64,
+    offset: u64,
+    mirrors: u8,
+    inner: B,
+    phantom: PhantomData<S>,
+}
+
+impl<B: BorrowMut<S>, S: ReadWriteSeek> DiskSlice<B, S> {
+    pub(crate) fn new(begin: u64, size: u64, mirrors: u8, inner: B) -> Self {
+        Self {
+            begin,
+            size,
+            mirrors,
+            inner,
+            offset: 0,
+            phantom: PhantomData,
+        }
+    }
+
+    fn from_sectors(first_sector: u32, sector_count: u32, mirrors: u8, bpb: &BiosParameterBlock, inner: B) -> Self {
+        Self::new(
+            bpb.bytes_from_sectors(first_sector),
+            bpb.bytes_from_sectors(sector_count),
+            mirrors,
+            inner,
+        )
+    }
+
+    pub(crate) fn abs_pos(&self) -> u64 {
+        self.begin + self.offset
+    }
+}
+
+// Note: derive cannot be used because of invalid bounds. See: https://github.com/rust-lang/rust/issues/26925
+impl<B: Clone, S> Clone for DiskSlice<B, S> {
+    fn clone(&self) -> Self {
+        Self {
+            begin: self.begin,
+            size: self.size,
+            offset: self.offset,
+            mirrors: self.mirrors,
+            inner: self.inner.clone(),
+            // phantom is needed to add type bounds on the storage type
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<B, S: IoBase> IoBase for DiskSlice<B, S> {
+    type Error = Error<S::Error>;
+}
+
+impl<B: BorrowMut<S>, S: Read + Seek> Read for DiskSlice<B, S> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let offset = self.begin + self.offset;
+        let read_size = (buf.len() as u64).min(self.size - self.offset) as usize;
+        self.inner.borrow_mut().seek(SeekFrom::Start(offset))?;
+        let size = self.inner.borrow_mut().read(&mut buf[..read_size])?;
+        self.offset += size as u64;
+        Ok(size)
+    }
+}
+
+impl<B: BorrowMut<S>, S: Write + Seek> Write for DiskSlice<B, S> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        let offset = self.begin + self.offset;
+        let write_size = (buf.len() as u64).min(self.size - self.offset) as usize;
+        if write_size == 0 {
+            return Ok(0);
+        }
+        // Write data
+        let storage = self.inner.borrow_mut();
+        for i in 0..self.mirrors {
+            storage.seek(SeekFrom::Start(offset + u64::from(i) * self.size))?;
+            storage.write_all(&buf[..write_size])?;
+        }
+        self.offset += write_size as u64;
+        Ok(write_size)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(self.inner.borrow_mut().flush()?)
+    }
+}
+
+impl<B, S: IoBase> Seek for DiskSlice<B, S> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        let new_offset_opt: Option<u64> = match pos {
+            SeekFrom::Current(x) => i64::try_from(self.offset)
+                .ok()
+                .and_then(|n| n.checked_add(x))
+                .and_then(|n| u64::try_from(n).ok()),
+            SeekFrom::Start(x) => Some(x),
+            SeekFrom::End(o) => i64::try_from(self.size)
+                .ok()
+                .and_then(|size| size.checked_add(o))
+                .and_then(|n| u64::try_from(n).ok()),
+        };
+        if let Some(new_offset) = new_offset_opt {
+            if new_offset > self.size {
+                error!("Seek beyond the end of the file");
+                Err(Error::InvalidInput)
+            } else {
+                self.offset = new_offset;
+                Ok(self.offset)
+            }
+        } else {
+            error!("Invalid seek offset");
+            Err(Error::InvalidInput)
+        }
+    }
+}
+
+/// An OEM code page encoder/decoder.
+///
+/// Provides a custom implementation for a short name encoding/decoding.
+/// `OemCpConverter` is specified by the `oem_cp_converter` property in `FsOptions` struct.
+pub trait OemCpConverter: Debug {
+    fn decode(&self, oem_char: u8) -> char;
+    fn encode(&self, uni_char: char) -> Option<u8>;
+}
+
+/// Default implementation of `OemCpConverter` that changes all non-ASCII characters to the replacement character (U+FFFD).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LossyOemCpConverter {
+    _dummy: (),
+}
+
+impl LossyOemCpConverter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { _dummy: () }
+    }
+}
+
+impl OemCpConverter for LossyOemCpConverter {
+    fn decode(&self, oem_char: u8) -> char {
+        if oem_char <= 0x7F {
+            char::from(oem_char)
+        } else {
+            '\u{FFFD}'
+        }
+    }
+    fn encode(&self, uni_char: char) -> Option<u8> {
+        if uni_char <= '\x7F' {
+            Some(uni_char as u8) // safe cast: value is in range [0, 0x7F]
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) fn write_zeros<IO: ReadWriteSeek>(disk: &mut IO, mut len: u64) -> Result<(), IO::Error> {
+    const ZEROS: [u8; 512] = [0_u8; 512];
+    while len > 0 {
+        let write_size = len.min(ZEROS.len() as u64) as usize;
+        disk.write_all(&ZEROS[..write_size])?;
+        len -= write_size as u64;
+    }
+    Ok(())
+}
+
+fn write_zeros_until_end_of_sector<IO: ReadWriteSeek>(disk: &mut IO, bytes_per_sector: u16) -> Result<(), IO::Error> {
+    let pos = disk.seek(SeekFrom::Current(0))?;
+    let total_bytes_to_write = u64::from(bytes_per_sector) - (pos % u64::from(bytes_per_sector));
+    if total_bytes_to_write != u64::from(bytes_per_sector) {
+        write_zeros(disk, total_bytes_to_write)?;
+    }
+    Ok(())
+}
+
+/// A FAT filesystem formatting options
+///
+/// This struct implements a builder pattern.
+/// Options are specified as an argument for `format_volume` function.
+#[derive(Debug, Clone)]
+pub struct FormatVolumeOptions {
+    pub(crate) bytes_per_sector: u16,
+    pub(crate) total_sectors: Option<u32>,
+    pub(crate) bytes_per_cluster: Option<u32>,
+    pub(crate) fat_type: Option<FatType>,
+    pub(crate) max_root_dir_entries: u16,
+    pub(crate) fats: u8,
+    pub(crate) media: u8,
+    pub(crate) sectors_per_track: u16,
+    pub(crate) heads: u16,
+    pub(crate) drive_num: Option<u8>,
+    pub(crate) volume_id: u32,
+    pub(crate) volume_label: Option<[u8; SFN_SIZE]>,
+}
+
+impl Default for FormatVolumeOptions {
+    fn default() -> Self {
+        Self {
+            bytes_per_sector: 512,
+            total_sectors: None,
+            bytes_per_cluster: None,
+            fat_type: None,
+            max_root_dir_entries: 512,
+            fats: 2,
+            media: 0xF8,
+            sectors_per_track: 0x20,
+            heads: 0x40,
+            drive_num: None,
+            volume_id: 0x1234_5678,
+            volume_label: None,
+        }
+    }
+}
+
+impl FormatVolumeOptions {
+    /// Create options struct for `format_volume` function
+    ///
+    /// Allows to overwrite many filesystem parameters.
+    /// In normal use-case defaults should suffice.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set size of cluster in bytes (must be dividable by sector size)
+    ///
+    /// Cluster size must be a power of two and be greater or equal to sector size.
+    /// If option is not specified optimal cluster size is selected based on partition size and
+    /// optionally FAT type override (if specified using `fat_type` method).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bytes_per_cluster` is not a power of two or is lower than `512`.
+    #[must_use]
+    pub fn bytes_per_cluster(mut self, bytes_per_cluster: u32) -> Self {
+        assert!(
+            bytes_per_cluster.is_power_of_two() && bytes_per_cluster >= 512,
+            "Invalid bytes_per_cluster"
+        );
+        self.bytes_per_cluster = Some(bytes_per_cluster);
+        self
+    }
+
+    /// Set File Allocation Table type
+    ///
+    /// Option allows to override File Allocation Table (FAT) entry size.
+    /// It is unrecommended to set this option unless you know what you are doing.
+    /// Note: FAT type is determined from total number of clusters. Changing this option can cause formatting to fail
+    /// if the volume cannot be divided into proper number of clusters for selected FAT type.
+    #[must_use]
+    pub fn fat_type(mut self, fat_type: FatType) -> Self {
+        self.fat_type = Some(fat_type);
+        self
+    }
+
+    /// Set sector size in bytes
+    ///
+    /// Sector size must be a power of two and be in range 512 - 4096.
+    /// Default is `512`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bytes_per_sector` is not a power of two or is lower than `512`.
+    #[must_use]
+    pub fn bytes_per_sector(mut self, bytes_per_sector: u16) -> Self {
+        assert!(
+            bytes_per_sector.is_power_of_two() && bytes_per_sector >= 512,
+            "Invalid bytes_per_sector"
+        );
+        self.bytes_per_sector = bytes_per_sector;
+        self
+    }
+
+    /// Set total number of sectors
+    ///
+    /// If option is not specified total number of sectors is calculated as storage device size divided by sector size.
+    #[must_use]
+    pub fn total_sectors(mut self, total_sectors: u32) -> Self {
+        self.total_sectors = Some(total_sectors);
+        self
+    }
+
+    /// Set maximal numer of entries in root directory for FAT12/FAT16 volumes
+    ///
+    /// Total root directory size should be dividable by sectors size so keep it a multiple of 16 (for default sector
+    /// size).
+    /// Note: this limit is not used on FAT32 volumes.
+    /// Default is `512`.
+    #[must_use]
+    pub fn max_root_dir_entries(mut self, max_root_dir_entries: u16) -> Self {
+        self.max_root_dir_entries = max_root_dir_entries;
+        self
+    }
+
+    /// Set number of File Allocation Tables
+    ///
+    /// The only allowed values are `1` and `2`. If value `2` is used the FAT is mirrored.
+    /// Default is `2`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `fats` is outside of the range [1, 2].
+    #[must_use]
+    pub fn fats(mut self, fats: u8) -> Self {
+        assert!((1..=2).contains(&fats), "Invalid number of FATs");
+        self.fats = fats;
+        self
+    }
+
+    /// Set media field for Bios Parameters Block
+    ///
+    /// Default is `0xF8`.
+    #[must_use]
+    pub fn media(mut self, media: u8) -> Self {
+        self.media = media;
+        self
+    }
+
+    /// Set number of physical sectors per track for Bios Parameters Block (INT 13h CHS geometry)
+    ///
+    /// Default is `0x20`.
+    #[must_use]
+    pub fn sectors_per_track(mut self, sectors_per_track: u16) -> Self {
+        self.sectors_per_track = sectors_per_track;
+        self
+    }
+
+    /// Set number of heads for Bios Parameters Block (INT 13h CHS geometry)
+    ///
+    /// Default is `0x40`.
+    #[must_use]
+    pub fn heads(mut self, heads: u16) -> Self {
+        self.heads = heads;
+        self
+    }
+
+    /// Set drive number for Bios Parameters Block
+    ///
+    /// Default is `0` for FAT12, `0x80` for FAT16/FAT32.
+    #[must_use]
+    pub fn drive_num(mut self, drive_num: u8) -> Self {
+        self.drive_num = Some(drive_num);
+        self
+    }
+
+    /// Set volume ID for Bios Parameters Block
+    ///
+    /// Default is `0x12345678`.
+    #[must_use]
+    pub fn volume_id(mut self, volume_id: u32) -> Self {
+        self.volume_id = volume_id;
+        self
+    }
+
+    /// Set volume label
+    ///
+    /// Default is empty label.
+    #[must_use]
+    pub fn volume_label(mut self, volume_label: [u8; SFN_SIZE]) -> Self {
+        self.volume_label = Some(volume_label);
+        self
+    }
+}
+
+/// Create FAT filesystem on a disk or partition (format a volume)
+///
+/// Warning: this function overrides internal FAT filesystem structures and causes a loss of all data on provided
+/// partition. Please use it with caution.
+/// Only quick formatting is supported. To achieve a full format zero entire partition before calling this function.
+/// Supplied `storage` parameter cannot be seeked (internal pointer must be on position 0).
+/// To format a fragment of a disk image (e.g. partition) library user should wrap the file struct in a struct
+/// limiting access to partition bytes only e.g. `fscommon::StreamSlice`.
+///
+/// # Errors
+///
+/// Errors that can be returned:
+///
+/// * `Error::InvalidInput` will be returned if `options` describes an invalid file system that cannot be created.
+///   Possible reason can be requesting a fat type that is not compatible with the total number of clusters or
+///   formatting a too big storage. If sectors/clusters related options in `options` structure were left set to
+///   defaults this error is very unlikely to happen.
+/// * `Error::Io` will be returned if the provided storage object returned an I/O error.
+///
+/// # Panics
+///
+/// Panics in non-optimized build if `storage` position returned by `seek` is not zero.
+#[allow(clippy::needless_pass_by_value)]
+pub fn format_volume<S: ReadWriteSeek>(storage: &mut S, options: FormatVolumeOptions) -> Result<(), Error<S::Error>> {
+    trace!("format_volume");
+    debug_assert!(storage.seek(SeekFrom::Current(0))? == 0);
+
+    let total_sectors = if let Some(total_sectors) = options.total_sectors {
+        total_sectors
+    } else {
+        let total_bytes: u64 = storage.seek(SeekFrom::End(0))?;
+        let total_sectors_64 = total_bytes / u64::from(options.bytes_per_sector);
+        storage.seek(SeekFrom::Start(0))?;
+        if total_sectors_64 > u64::from(u32::MAX) {
+            error!("Volume has too many sectors: {}", total_sectors_64);
+            return Err(Error::InvalidInput);
+        }
+        total_sectors_64 as u32 // safe case: possible overflow is handled above
+    };
+
+    // Create boot sector, validate and write to storage device
+    let (boot, fat_type) = format_boot_sector(&options, total_sectors)?;
+    if boot.validate::<S::Error>(true).is_err() {
+        return Err(Error::InvalidInput);
+    }
+    boot.serialize(storage)?;
+    // Make sure entire logical sector is updated (serialize method always writes 512 bytes)
+    let bytes_per_sector = boot.bpb.bytes_per_sector;
+    write_zeros_until_end_of_sector(storage, bytes_per_sector)?;
+
+    let bpb = &boot.bpb;
+    if bpb.is_fat32() {
+        // FSInfo sector
+        let fs_info_sector = FsInfoSector {
+            free_cluster_count: None,
+            next_free_cluster: None,
+            dirty: false,
+        };
+        storage.seek(SeekFrom::Start(bpb.bytes_from_sectors(bpb.fs_info_sector())))?;
+        fs_info_sector.serialize(storage)?;
+        write_zeros_until_end_of_sector(storage, bytes_per_sector)?;
+
+        // backup boot sector
+        storage.seek(SeekFrom::Start(bpb.bytes_from_sectors(bpb.backup_boot_sector())))?;
+        boot.serialize(storage)?;
+        write_zeros_until_end_of_sector(storage, bytes_per_sector)?;
+    }
+
+    // format File Allocation Table
+    let reserved_sectors = bpb.reserved_sectors();
+    let fat_pos = bpb.bytes_from_sectors(reserved_sectors);
+    let sectors_per_all_fats = bpb.sectors_per_all_fats();
+    storage.seek(SeekFrom::Start(fat_pos))?;
+    write_zeros(storage, bpb.bytes_from_sectors(sectors_per_all_fats))?;
+    {
+        let mut fat_slice = fat_slice::<S, &mut S>(storage, bpb);
+        let sectors_per_fat = bpb.sectors_per_fat();
+        let bytes_per_fat = bpb.bytes_from_sectors(sectors_per_fat);
+        format_fat(&mut fat_slice, fat_type, bpb.media, bytes_per_fat, bpb.total_clusters())?;
+    }
+
+    // init root directory - zero root directory region for FAT12/16 and alloc first root directory cluster for FAT32
+    let root_dir_first_sector = reserved_sectors + sectors_per_all_fats;
+    let root_dir_sectors = bpb.root_dir_sectors();
+    let root_dir_pos = bpb.bytes_from_sectors(root_dir_first_sector);
+    storage.seek(SeekFrom::Start(root_dir_pos))?;
+    write_zeros(storage, bpb.bytes_from_sectors(root_dir_sectors))?;
+    if fat_type == FatType::Fat32 {
+        let root_dir_first_cluster = {
+            let mut fat_slice = fat_slice::<S, &mut S>(storage, bpb);
+            alloc_cluster(&mut fat_slice, fat_type, None, None, 1)?
+        };
+        assert!(root_dir_first_cluster == bpb.root_dir_first_cluster);
+        let first_data_sector = reserved_sectors + sectors_per_all_fats + root_dir_sectors;
+        let data_sectors_before_root_dir = bpb.sectors_from_clusters(root_dir_first_cluster - RESERVED_FAT_ENTRIES);
+        let fat32_root_dir_first_sector = first_data_sector + data_sectors_before_root_dir;
+        let fat32_root_dir_pos = bpb.bytes_from_sectors(fat32_root_dir_first_sector);
+        storage.seek(SeekFrom::Start(fat32_root_dir_pos))?;
+        write_zeros(storage, u64::from(bpb.cluster_size()))?;
+    }
+
+    // Create volume label directory entry if volume label is specified in options
+    if let Some(volume_label) = options.volume_label {
+        storage.seek(SeekFrom::Start(root_dir_pos))?;
+        let volume_entry = DirFileEntryData::new(volume_label, FileAttributes::VOLUME_ID);
+        volume_entry.serialize(storage)?;
+    }
+
+    storage.seek(SeekFrom::Start(0))?;
+    trace!("format_volume end");
+    Ok(())
+}

--- a/fatfs/src/io.rs
+++ b/fatfs/src/io.rs
@@ -1,0 +1,292 @@
+use crate::error::IoError;
+
+/// Provides IO error as an associated type.
+///
+/// Must be implemented for all types that also implement at least one of the following traits: `Read`, `Write`,
+/// `Seek`.
+pub trait IoBase {
+    /// Type of errors returned by input/output operations.
+    type Error: IoError;
+}
+
+/// The `Read` trait allows for reading bytes from a source.
+///
+/// It is based on the `std::io::Read` trait.
+pub trait Read: IoBase {
+    /// Pull some bytes from this source into the specified buffer, returning how many bytes were read.
+    ///
+    /// This function does not provide any guarantees about whether it blocks waiting for data, but if an object needs
+    /// to block for a read and cannot, it will typically signal this via an Err return value.
+    ///
+    /// If the return value of this method is `Ok(n)`, then it must be guaranteed that `0 <= n <= buf.len()`. A nonzero
+    /// `n` value indicates that the buffer buf has been filled in with n bytes of data from this source. If `n` is
+    /// `0`, then it can indicate one of two scenarios:
+    ///
+    /// 1. This reader has reached its "end of file" and will likely no longer be able to produce bytes. Note that this
+    ///    does not mean that the reader will always no longer be able to produce bytes.
+    /// 2. The buffer specified was 0 bytes in length.
+    ///
+    /// It is not an error if the returned value `n` is smaller than the buffer size, even when the reader is not at
+    /// the end of the stream yet. This may happen for example because fewer bytes are actually available right now
+    /// (e. g. being close to end-of-file) or because `read()` was interrupted by a signal.
+    ///
+    /// # Errors
+    ///
+    /// If this function encounters any form of I/O or other error, an error will be returned. If an error is returned
+    /// then it must be guaranteed that no bytes were read.
+    /// An error for which `IoError::is_interrupted` returns true is non-fatal and the read operation should be retried
+    /// if there is nothing else to do.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
+
+    /// Read the exact number of bytes required to fill `buf`.
+    ///
+    /// This function reads as many bytes as necessary to completely fill the specified buffer `buf`.
+    ///
+    /// # Errors
+    ///
+    /// If this function encounters an error for which `IoError::is_interrupted` returns true then the error is ignored
+    /// and the operation will continue.
+    ///
+    /// If this function encounters an end of file before completely filling the buffer, it returns an error
+    /// instantiated by a call to `IoError::new_unexpected_eof_error`. The contents of `buf` are unspecified in this
+    /// case.
+    ///
+    /// If this function returns an error, it is unspecified how many bytes it has read, but it will never read more
+    /// than would be necessary to completely fill the buffer.
+    fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<(), Self::Error> {
+        while !buf.is_empty() {
+            match self.read(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                }
+                Err(ref e) if e.is_interrupted() => {}
+                Err(e) => return Err(e),
+            }
+        }
+        if buf.is_empty() {
+            Ok(())
+        } else {
+            debug!("failed to fill whole buffer in read_exact");
+            Err(Self::Error::new_unexpected_eof_error())
+        }
+    }
+}
+
+/// The `Write` trait allows for writing bytes into the sink.
+///
+/// It is based on the `std::io::Write` trait.
+pub trait Write: IoBase {
+    /// Write a buffer into this writer, returning how many bytes were written.
+    ///
+    /// # Errors
+    ///
+    /// Each call to write may generate an I/O error indicating that the operation could not be completed. If an error
+    /// is returned then no bytes in the buffer were written to this writer.
+    /// It is not considered an error if the entire buffer could not be written to this writer.
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error>;
+
+    /// Attempts to write an entire buffer into this writer.
+    ///
+    /// This method will continuously call `write` until there is no more data to be written or an error is returned.
+    /// Errors for which `IoError::is_interrupted` method returns true are being skipped. This method will not return
+    /// until the entire buffer has been successfully written or such an error occurs.
+    /// If `write` returns 0 before the entire buffer has been written this method will return an error instantiated by
+    /// a call to `IoError::new_write_zero_error`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return the first error for which `IoError::is_interrupted` method returns false that `write`
+    /// returns.
+    fn write_all(&mut self, mut buf: &[u8]) -> Result<(), Self::Error> {
+        while !buf.is_empty() {
+            match self.write(buf) {
+                Ok(0) => {
+                    debug!("failed to write whole buffer in write_all");
+                    return Err(Self::Error::new_write_zero_error());
+                }
+                Ok(n) => buf = &buf[n..],
+                Err(ref e) if e.is_interrupted() => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Flush this output stream, ensuring that all intermediately buffered contents reach their destination.
+    ///
+    /// # Errors
+    ///
+    /// It is considered an error if not all bytes could be written due to I/O errors or EOF being reached.
+    fn flush(&mut self) -> Result<(), Self::Error>;
+}
+
+/// Enumeration of possible methods to seek within an I/O object.
+///
+/// It is based on the `std::io::SeekFrom` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeekFrom {
+    /// Sets the offset to the provided number of bytes.
+    Start(u64),
+    /// Sets the offset to the size of this object plus the specified number of bytes.
+    End(i64),
+    /// Sets the offset to the current position plus the specified number of bytes.
+    Current(i64),
+}
+
+/// The `Seek` trait provides a cursor which can be moved within a stream of bytes.
+///
+/// It is based on the `std::io::Seek` trait.
+pub trait Seek: IoBase {
+    /// Seek to an offset, in bytes, in a stream.
+    ///
+    /// A seek beyond the end of a stream or to a negative position is not allowed.
+    ///
+    /// If the seek operation completed successfully, this method returns the new position from the start of the
+    /// stream. That position can be used later with `SeekFrom::Start`.
+    ///
+    /// # Errors
+    /// Seeking to a negative offset is considered an error.
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error>;
+}
+
+#[cfg(feature = "std")]
+impl From<SeekFrom> for std::io::SeekFrom {
+    fn from(from: SeekFrom) -> Self {
+        match from {
+            SeekFrom::Start(n) => std::io::SeekFrom::Start(n),
+            SeekFrom::End(n) => std::io::SeekFrom::End(n),
+            SeekFrom::Current(n) => std::io::SeekFrom::Current(n),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::SeekFrom> for SeekFrom {
+    fn from(from: std::io::SeekFrom) -> Self {
+        match from {
+            std::io::SeekFrom::Start(n) => SeekFrom::Start(n),
+            std::io::SeekFrom::End(n) => SeekFrom::End(n),
+            std::io::SeekFrom::Current(n) => SeekFrom::Current(n),
+        }
+    }
+}
+
+/// A wrapper struct for types that have implementations for `std::io` traits.
+///
+/// `Read`, `Write`, `Seek` traits from this crate are implemented for this type if
+/// corresponding types from `std::io` are implemented by the inner instance.
+#[cfg(feature = "std")]
+pub struct StdIoWrapper<T> {
+    inner: T,
+}
+
+#[cfg(feature = "std")]
+impl<T> StdIoWrapper<T> {
+    /// Creates a new `StdIoWrapper` instance that wraps the provided `inner` instance.
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// Returns inner struct
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> IoBase for StdIoWrapper<T> {
+    type Error = std::io::Error;
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Read> Read for StdIoWrapper<T> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.inner.read(buf)
+    }
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.inner.read_exact(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Write> Write for StdIoWrapper<T> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.inner.write(buf)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.inner.write_all(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Seek> Seek for StdIoWrapper<T> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        self.inner.seek(pos.into())
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> From<T> for StdIoWrapper<T> {
+    fn from(from: T) -> Self {
+        Self::new(from)
+    }
+}
+
+pub(crate) trait ReadLeExt {
+    type Error;
+    fn read_u8(&mut self) -> Result<u8, Self::Error>;
+    fn read_u16_le(&mut self) -> Result<u16, Self::Error>;
+    fn read_u32_le(&mut self) -> Result<u32, Self::Error>;
+}
+
+impl<T: Read> ReadLeExt for T {
+    type Error = <Self as IoBase>::Error;
+
+    fn read_u8(&mut self) -> Result<u8, Self::Error> {
+        let mut buf = [0_u8; 1];
+        self.read_exact(&mut buf)?;
+        Ok(buf[0])
+    }
+
+    fn read_u16_le(&mut self) -> Result<u16, Self::Error> {
+        let mut buf = [0_u8; 2];
+        self.read_exact(&mut buf)?;
+        Ok(u16::from_le_bytes(buf))
+    }
+
+    fn read_u32_le(&mut self) -> Result<u32, Self::Error> {
+        let mut buf = [0_u8; 4];
+        self.read_exact(&mut buf)?;
+        Ok(u32::from_le_bytes(buf))
+    }
+}
+
+pub(crate) trait WriteLeExt {
+    type Error;
+    fn write_u8(&mut self, n: u8) -> Result<(), Self::Error>;
+    fn write_u16_le(&mut self, n: u16) -> Result<(), Self::Error>;
+    fn write_u32_le(&mut self, n: u32) -> Result<(), Self::Error>;
+}
+
+impl<T: Write> WriteLeExt for T {
+    type Error = <Self as IoBase>::Error;
+
+    fn write_u8(&mut self, n: u8) -> Result<(), Self::Error> {
+        self.write_all(&[n])
+    }
+
+    fn write_u16_le(&mut self, n: u16) -> Result<(), Self::Error> {
+        self.write_all(&n.to_le_bytes())
+    }
+
+    fn write_u32_le(&mut self, n: u32) -> Result<(), Self::Error> {
+        self.write_all(&n.to_le_bytes())
+    }
+}

--- a/fatfs/src/lib.rs
+++ b/fatfs/src/lib.rs
@@ -1,0 +1,81 @@
+//! A FAT filesystem library implemented in Rust.
+//!
+//! # Usage
+//!
+//! This crate is [on crates.io](https://crates.io/crates/fatfs) and can be
+//! used by adding `fatfs` to the dependencies in your project's `Cargo.toml`.
+//!
+//! ```toml
+//! [dependencies]
+//! fatfs = "0.4"
+//! ```
+//!
+//! # Examples
+//!
+//! ```rust
+//! use std::io::prelude::*;
+//!
+//! fn main() -> std::io::Result<()> {
+//!     # std::fs::copy("resources/fat16.img", "tmp/fat.img")?;
+//!     // Initialize a filesystem object
+//!     let img_file = std::fs::OpenOptions::new().read(true).write(true)
+//!         .open("tmp/fat.img")?;
+//!     let buf_stream = fscommon::BufStream::new(img_file);
+//!     let fs = fatfs::FileSystem::new(buf_stream, fatfs::FsOptions::new())?;
+//!     let root_dir = fs.root_dir();
+//!
+//!     // Write a file
+//!     root_dir.create_dir("foo")?;
+//!     let mut file = root_dir.create_file("foo/hello.txt")?;
+//!     file.truncate()?;
+//!     file.write_all(b"Hello World!")?;
+//!
+//!     // Read a directory
+//!     let dir = root_dir.open_dir("foo")?;
+//!     for r in dir.iter() {
+//!         let entry = r?;
+//!         println!("{}", entry.file_name());
+//!     }
+//!     # std::fs::remove_file("tmp/fat.img")?;
+//!     # Ok(())
+//! }
+//! ```
+
+#![crate_type = "lib"]
+#![crate_name = "fatfs"]
+#![cfg_attr(not(feature = "std"), no_std)]
+// Disable warnings to not clutter code with cfg too much
+#![cfg_attr(not(all(feature = "alloc", feature = "lfn")), allow(dead_code, unused_imports))]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::cast_possible_truncation,
+    clippy::bool_to_int_with_if, // less readable
+    clippy::uninlined_format_args, // not supported before Rust 1.58.0
+)]
+
+extern crate log;
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
+
+#[macro_use]
+mod log_macros;
+
+mod boot_sector;
+mod dir;
+mod dir_entry;
+mod error;
+mod file;
+mod fs;
+mod io;
+mod table;
+mod time;
+
+pub use crate::dir::*;
+pub use crate::dir_entry::*;
+pub use crate::error::*;
+pub use crate::file::*;
+pub use crate::fs::*;
+pub use crate::io::*;
+pub use crate::time::*;

--- a/fatfs/src/log_macros.rs
+++ b/fatfs/src/log_macros.rs
@@ -1,0 +1,110 @@
+//! This module offers a convenient way to enable only a subset of logging levels
+//! for just this `fatfs` crate only without changing the logging levels
+//! of other crates in a given project.
+
+use log::LevelFilter;
+
+#[cfg(feature = "log_level_trace")]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Trace;
+
+#[cfg(all(not(feature = "log_level_trace"), feature = "log_level_debug",))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Debug;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    feature = "log_level_info",
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Info;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    not(feature = "log_level_info"),
+    feature = "log_level_warn",
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    not(feature = "log_level_info"),
+    not(feature = "log_level_warn"),
+    feature = "log_level_error",
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Error;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    not(feature = "log_level_info"),
+    not(feature = "log_level_warn"),
+    not(feature = "log_level_error"),
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Off;
+
+#[macro_export]
+macro_rules! log {
+    (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= $crate::log_macros::MAX_LOG_LEVEL {
+            log::log!(target: $target, lvl, $($arg)+);
+        }
+    });
+    ($lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= $crate::log_macros::MAX_LOG_LEVEL {
+            log::log!(lvl, $($arg)+);
+        }
+    })
+}
+
+#[macro_export]
+macro_rules! error {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Error, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Error, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! warn {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Warn, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Warn, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! info {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Info, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Info, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! debug {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Debug, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Debug, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! trace {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Trace, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Trace, $($arg)+);
+    )
+}

--- a/fatfs/src/table.rs
+++ b/fatfs/src/table.rs
@@ -1,0 +1,768 @@
+use core::borrow::BorrowMut;
+use core::marker::PhantomData;
+
+use crate::error::{Error, IoError};
+use crate::fs::{FatType, FsStatusFlags};
+use crate::io::{self, Read, ReadLeExt, Seek, Write, WriteLeExt};
+
+struct Fat<S> {
+    phantom: PhantomData<S>,
+}
+
+type Fat12 = Fat<u8>;
+type Fat16 = Fat<u16>;
+type Fat32 = Fat<u32>;
+
+pub const RESERVED_FAT_ENTRIES: u32 = 2;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum FatValue {
+    Free,
+    Data(u32),
+    Bad,
+    EndOfChain,
+}
+
+trait FatTrait {
+    fn get_raw<S, E>(fat: &mut S, cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>;
+
+    fn get<S, E>(fat: &mut S, cluster: u32) -> Result<FatValue, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>;
+
+    fn set_raw<S, E>(fat: &mut S, cluster: u32, raw_value: u32) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>;
+
+    fn set<S, E>(fat: &mut S, cluster: u32, value: FatValue) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>;
+
+    fn find_free<S, E>(fat: &mut S, start_cluster: u32, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>;
+
+    fn count_free<S, E>(fat: &mut S, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>;
+}
+
+fn read_fat<S, E>(fat: &mut S, fat_type: FatType, cluster: u32) -> Result<FatValue, Error<E>>
+where
+    S: Read + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    match fat_type {
+        FatType::Fat12 => Fat12::get(fat, cluster),
+        FatType::Fat16 => Fat16::get(fat, cluster),
+        FatType::Fat32 => Fat32::get(fat, cluster),
+    }
+}
+
+fn write_fat<S, E>(fat: &mut S, fat_type: FatType, cluster: u32, value: FatValue) -> Result<(), Error<E>>
+where
+    S: Read + Write + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    trace!("write FAT - cluster {} value {:?}", cluster, value);
+    match fat_type {
+        FatType::Fat12 => Fat12::set(fat, cluster, value),
+        FatType::Fat16 => Fat16::set(fat, cluster, value),
+        FatType::Fat32 => Fat32::set(fat, cluster, value),
+    }
+}
+
+fn get_next_cluster<S, E>(fat: &mut S, fat_type: FatType, cluster: u32) -> Result<Option<u32>, Error<E>>
+where
+    S: Read + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    let val = read_fat(fat, fat_type, cluster)?;
+    match val {
+        FatValue::Data(n) => Ok(Some(n)),
+        _ => Ok(None),
+    }
+}
+
+fn find_free_cluster<S, E>(
+    fat: &mut S,
+    fat_type: FatType,
+    start_cluster: u32,
+    end_cluster: u32,
+) -> Result<u32, Error<E>>
+where
+    S: Read + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    match fat_type {
+        FatType::Fat12 => Fat12::find_free(fat, start_cluster, end_cluster),
+        FatType::Fat16 => Fat16::find_free(fat, start_cluster, end_cluster),
+        FatType::Fat32 => Fat32::find_free(fat, start_cluster, end_cluster),
+    }
+}
+
+pub(crate) fn alloc_cluster<S, E>(
+    fat: &mut S,
+    fat_type: FatType,
+    prev_cluster: Option<u32>,
+    hint: Option<u32>,
+    total_clusters: u32,
+) -> Result<u32, Error<E>>
+where
+    S: Read + Write + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    let end_cluster = total_clusters + RESERVED_FAT_ENTRIES;
+    let start_cluster = match hint {
+        Some(n) if n < end_cluster => n,
+        _ => RESERVED_FAT_ENTRIES,
+    };
+    let new_cluster = match find_free_cluster(fat, fat_type, start_cluster, end_cluster) {
+        Ok(n) => n,
+        Err(_) if start_cluster > RESERVED_FAT_ENTRIES => {
+            find_free_cluster(fat, fat_type, RESERVED_FAT_ENTRIES, start_cluster)?
+        }
+        Err(e) => return Err(e),
+    };
+    write_fat(fat, fat_type, new_cluster, FatValue::EndOfChain)?;
+    if let Some(n) = prev_cluster {
+        write_fat(fat, fat_type, n, FatValue::Data(new_cluster))?;
+    }
+    trace!("allocated cluster {}", new_cluster);
+    Ok(new_cluster)
+}
+
+pub(crate) fn read_fat_flags<S, E>(fat: &mut S, fat_type: FatType) -> Result<FsStatusFlags, Error<E>>
+where
+    S: Read + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    // check MSB (except in FAT12)
+    let val = match fat_type {
+        FatType::Fat12 => 0xFFF,
+        FatType::Fat16 => Fat16::get_raw(fat, 1)?,
+        FatType::Fat32 => Fat32::get_raw(fat, 1)?,
+    };
+    let dirty = match fat_type {
+        FatType::Fat12 => false,
+        FatType::Fat16 => val & (1 << 15) == 0,
+        FatType::Fat32 => val & (1 << 27) == 0,
+    };
+    let io_error = match fat_type {
+        FatType::Fat12 => false,
+        FatType::Fat16 => val & (1 << 14) == 0,
+        FatType::Fat32 => val & (1 << 26) == 0,
+    };
+    Ok(FsStatusFlags { dirty, io_error })
+}
+
+pub(crate) fn count_free_clusters<S, E>(fat: &mut S, fat_type: FatType, total_clusters: u32) -> Result<u32, Error<E>>
+where
+    S: Read + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    let end_cluster = total_clusters + RESERVED_FAT_ENTRIES;
+    match fat_type {
+        FatType::Fat12 => Fat12::count_free(fat, end_cluster),
+        FatType::Fat16 => Fat16::count_free(fat, end_cluster),
+        FatType::Fat32 => Fat32::count_free(fat, end_cluster),
+    }
+}
+
+pub(crate) fn format_fat<S, E>(
+    fat: &mut S,
+    fat_type: FatType,
+    media: u8,
+    bytes_per_fat: u64,
+    total_clusters: u32,
+) -> Result<(), Error<E>>
+where
+    S: Read + Write + Seek,
+    E: IoError,
+    Error<E>: From<S::Error>,
+{
+    const BITS_PER_BYTE: u64 = 8;
+    // init first two reserved entries to FAT ID
+    match fat_type {
+        FatType::Fat12 => {
+            fat.write_u8(media)?;
+            fat.write_u16_le(0xFFFF)?;
+        }
+        FatType::Fat16 => {
+            fat.write_u16_le(u16::from(media) | 0xFF00)?;
+            fat.write_u16_le(0xFFFF)?;
+        }
+        FatType::Fat32 => {
+            fat.write_u32_le(u32::from(media) | 0xFFF_FF00)?;
+            fat.write_u32_le(0xFFFF_FFFF)?;
+        }
+    };
+    // mark entries at the end of FAT as used (after FAT but before sector end)
+    let start_cluster = total_clusters + RESERVED_FAT_ENTRIES;
+    let end_cluster = (bytes_per_fat * BITS_PER_BYTE / u64::from(fat_type.bits_per_fat_entry())) as u32;
+    for cluster in start_cluster..end_cluster {
+        write_fat(fat, fat_type, cluster, FatValue::EndOfChain)?;
+    }
+    // mark special entries 0x0FFFFFF0 - 0x0FFFFFFF as BAD if they exists on FAT32 volume
+    if end_cluster > 0x0FFF_FFF0 {
+        let end_bad_cluster = (0x0FFF_FFFF + 1).min(end_cluster);
+        for cluster in 0x0FFF_FFF0..end_bad_cluster {
+            write_fat(fat, fat_type, cluster, FatValue::Bad)?;
+        }
+    }
+    Ok(())
+}
+
+impl FatTrait for Fat12 {
+    fn get_raw<S, E>(fat: &mut S, cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let fat_offset = cluster + (cluster / 2);
+        fat.seek(io::SeekFrom::Start(u64::from(fat_offset)))?;
+        let packed_val = fat.read_u16_le()?;
+        Ok(u32::from(match cluster & 1 {
+            0 => packed_val & 0x0FFF,
+            _ => packed_val >> 4,
+        }))
+    }
+
+    fn get<S, E>(fat: &mut S, cluster: u32) -> Result<FatValue, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let val = Self::get_raw(fat, cluster)?;
+        Ok(match val {
+            0 => FatValue::Free,
+            0xFF7 => FatValue::Bad,
+            0xFF8..=0xFFF => FatValue::EndOfChain,
+            n => FatValue::Data(n),
+        })
+    }
+
+    fn set<S, E>(fat: &mut S, cluster: u32, value: FatValue) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let raw_val = match value {
+            FatValue::Free => 0,
+            FatValue::Bad => 0xFF7,
+            FatValue::EndOfChain => 0xFFF,
+            FatValue::Data(n) => n,
+        };
+        Self::set_raw(fat, cluster, raw_val)
+    }
+
+    fn set_raw<S, E>(fat: &mut S, cluster: u32, raw_val: u32) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let fat_offset = cluster + (cluster / 2);
+        fat.seek(io::SeekFrom::Start(u64::from(fat_offset)))?;
+        let old_packed = fat.read_u16_le()?;
+        fat.seek(io::SeekFrom::Start(u64::from(fat_offset)))?;
+        let new_packed = match cluster & 1 {
+            0 => (old_packed & 0xF000) | raw_val as u16,
+            _ => (old_packed & 0x000F) | ((raw_val as u16) << 4),
+        };
+        fat.write_u16_le(new_packed)?;
+        Ok(())
+    }
+
+    fn find_free<S, E>(fat: &mut S, start_cluster: u32, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let mut cluster = start_cluster;
+        let fat_offset = cluster + (cluster / 2);
+        fat.seek(io::SeekFrom::Start(u64::from(fat_offset)))?;
+        let mut packed_val = fat.read_u16_le()?;
+        loop {
+            let val = match cluster & 1 {
+                0 => packed_val & 0x0FFF,
+                _ => packed_val >> 4,
+            };
+            if val == 0 {
+                return Ok(cluster);
+            }
+            cluster += 1;
+            if cluster == end_cluster {
+                return Err(Error::NotEnoughSpace);
+            }
+            packed_val = if cluster & 1 == 0 {
+                fat.read_u16_le()?
+            } else {
+                let next_byte = fat.read_u8()?;
+                (packed_val >> 8) | (u16::from(next_byte) << 8)
+            };
+        }
+    }
+
+    fn count_free<S, E>(fat: &mut S, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let mut count = 0;
+        let mut cluster = RESERVED_FAT_ENTRIES;
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 3 / 2)))?;
+        let mut prev_packed_val = 0_u16;
+        while cluster < end_cluster {
+            let res = match cluster & 1 {
+                0 => fat.read_u16_le(),
+                _ => fat.read_u8().map(u16::from),
+            };
+            let packed_val = match res {
+                Err(err) => return Err(err.into()),
+                Ok(n) => n,
+            };
+            let val = match cluster & 1 {
+                0 => packed_val & 0x0FFF,
+                _ => (packed_val << 8) | (prev_packed_val >> 12),
+            };
+            prev_packed_val = packed_val;
+            if val == 0 {
+                count += 1;
+            }
+            cluster += 1;
+        }
+        Ok(count)
+    }
+}
+
+impl FatTrait for Fat16 {
+    fn get_raw<S, E>(fat: &mut S, cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 2)))?;
+        Ok(u32::from(fat.read_u16_le()?))
+    }
+
+    fn get<S, E>(fat: &mut S, cluster: u32) -> Result<FatValue, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let val = Self::get_raw(fat, cluster)?;
+        Ok(match val {
+            0 => FatValue::Free,
+            0xFFF7 => FatValue::Bad,
+            0xFFF8..=0xFFFF => FatValue::EndOfChain,
+            n => FatValue::Data(n),
+        })
+    }
+
+    fn set_raw<S, E>(fat: &mut S, cluster: u32, raw_value: u32) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 2)))?;
+        fat.write_u16_le(raw_value as u16)?;
+        Ok(())
+    }
+
+    fn set<S, E>(fat: &mut S, cluster: u32, value: FatValue) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let raw_value = match value {
+            FatValue::Free => 0,
+            FatValue::Bad => 0xFFF7,
+            FatValue::EndOfChain => 0xFFFF,
+            FatValue::Data(n) => n,
+        };
+        Self::set_raw(fat, cluster, raw_value)
+    }
+
+    fn find_free<S, E>(fat: &mut S, start_cluster: u32, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let mut cluster = start_cluster;
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 2)))?;
+        while cluster < end_cluster {
+            let val = fat.read_u16_le()?;
+            if val == 0 {
+                return Ok(cluster);
+            }
+            cluster += 1;
+        }
+        Err(Error::NotEnoughSpace)
+    }
+
+    fn count_free<S, E>(fat: &mut S, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let mut count = 0;
+        let mut cluster = RESERVED_FAT_ENTRIES;
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 2)))?;
+        while cluster < end_cluster {
+            let val = fat.read_u16_le()?;
+            if val == 0 {
+                count += 1;
+            }
+            cluster += 1;
+        }
+        Ok(count)
+    }
+}
+
+impl FatTrait for Fat32 {
+    fn get_raw<S, E>(fat: &mut S, cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 4)))?;
+        Ok(fat.read_u32_le()?)
+    }
+
+    fn get<S, E>(fat: &mut S, cluster: u32) -> Result<FatValue, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let val = Self::get_raw(fat, cluster)? & 0x0FFF_FFFF;
+        Ok(match val {
+            0 if (0x0FFF_FFF7..=0x0FFF_FFFF).contains(&cluster) => {
+                let tmp = if cluster == 0x0FFF_FFF7 {
+                    "BAD_CLUSTER"
+                } else {
+                    "end-of-chain"
+                };
+                warn!(
+                    "cluster number {} is a special value in FAT to indicate {}; it should never be seen as free",
+                    cluster, tmp
+                );
+                FatValue::Bad // avoid accidental use or allocation into a FAT chain
+            }
+            0 => FatValue::Free,
+            0x0FFF_FFF7 => FatValue::Bad,
+            0x0FFF_FFF8..=0x0FFF_FFFF => FatValue::EndOfChain,
+            n if (0x0FFF_FFF7..=0x0FFF_FFFF).contains(&cluster) => {
+                let tmp = if cluster == 0x0FFF_FFF7 {
+                    "BAD_CLUSTER"
+                } else {
+                    "end-of-chain"
+                };
+                warn!("cluster number {} is a special value in FAT to indicate {}; hiding potential FAT chain value {} and instead reporting as a bad sector", cluster, tmp, n);
+                FatValue::Bad // avoid accidental use or allocation into a FAT chain
+            }
+            n => FatValue::Data(n),
+        })
+    }
+
+    fn set_raw<S, E>(fat: &mut S, cluster: u32, raw_value: u32) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 4)))?;
+        fat.write_u32_le(raw_value)?;
+        Ok(())
+    }
+
+    fn set<S, E>(fat: &mut S, cluster: u32, value: FatValue) -> Result<(), Error<E>>
+    where
+        S: Read + Write + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let old_reserved_bits = Self::get_raw(fat, cluster)? & 0xF000_0000;
+
+        if value == FatValue::Free && (0x0FFF_FFF7..=0x0FFF_FFFF).contains(&cluster) {
+            // NOTE: it is technically allowed for them to store FAT chain loops,
+            //       or even have them all store value '4' as their next cluster.
+            //       Some believe only FatValue::Bad should be allowed for this edge case.
+            let tmp = if cluster == 0x0FFF_FFF7 {
+                "BAD_CLUSTER"
+            } else {
+                "end-of-chain"
+            };
+            panic!(
+                "cluster number {} is a special value in FAT to indicate {}; it should never be set as free",
+                cluster, tmp
+            );
+        };
+        let raw_val = match value {
+            FatValue::Free => 0,
+            FatValue::Bad => 0x0FFF_FFF7,
+            FatValue::EndOfChain => 0x0FFF_FFFF,
+            FatValue::Data(n) => n,
+        };
+        let raw_val = raw_val | old_reserved_bits; // must preserve original reserved values
+        Self::set_raw(fat, cluster, raw_val)
+    }
+
+    fn find_free<S, E>(fat: &mut S, start_cluster: u32, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let mut cluster = start_cluster;
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 4)))?;
+        while cluster < end_cluster {
+            let val = fat.read_u32_le()? & 0x0FFF_FFFF;
+            if val == 0 {
+                return Ok(cluster);
+            }
+            cluster += 1;
+        }
+        Err(Error::NotEnoughSpace)
+    }
+
+    fn count_free<S, E>(fat: &mut S, end_cluster: u32) -> Result<u32, Error<E>>
+    where
+        S: Read + Seek,
+        E: IoError,
+        Error<E>: From<S::Error>,
+    {
+        let mut count = 0;
+        let mut cluster = RESERVED_FAT_ENTRIES;
+        fat.seek(io::SeekFrom::Start(u64::from(cluster * 4)))?;
+        while cluster < end_cluster {
+            let val = fat.read_u32_le()? & 0x0FFF_FFFF;
+            if val == 0 {
+                count += 1;
+            }
+            cluster += 1;
+        }
+        Ok(count)
+    }
+}
+
+pub(crate) struct ClusterIterator<B, E, S = B> {
+    fat: B,
+    fat_type: FatType,
+    cluster: Option<u32>,
+    err: bool,
+    // phantom is needed to add type bounds on the storage type
+    phantom_s: PhantomData<S>,
+    phantom_e: PhantomData<E>,
+}
+
+impl<B, E, S> ClusterIterator<B, E, S>
+where
+    B: BorrowMut<S>,
+    E: IoError,
+    S: Read + Write + Seek,
+    Error<E>: From<S::Error>,
+{
+    pub(crate) fn new(fat: B, fat_type: FatType, cluster: u32) -> Self {
+        Self {
+            fat,
+            fat_type,
+            cluster: Some(cluster),
+            err: false,
+            phantom_s: PhantomData,
+            phantom_e: PhantomData,
+        }
+    }
+
+    pub(crate) fn truncate(&mut self) -> Result<u32, Error<E>> {
+        if let Some(n) = self.cluster {
+            // Move to the next cluster
+            self.next();
+            // Mark previous cluster as end of chain
+            write_fat(self.fat.borrow_mut(), self.fat_type, n, FatValue::EndOfChain)?;
+            // Free rest of chain
+            self.free()
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub(crate) fn free(&mut self) -> Result<u32, Error<E>> {
+        let mut num_free = 0;
+        while let Some(n) = self.cluster {
+            self.next();
+            write_fat(self.fat.borrow_mut(), self.fat_type, n, FatValue::Free)?;
+            num_free += 1;
+        }
+        Ok(num_free)
+    }
+}
+
+impl<B, E, S> Iterator for ClusterIterator<B, E, S>
+where
+    B: BorrowMut<S>,
+    E: IoError,
+    S: Read + Write + Seek,
+    Error<E>: From<S::Error>,
+{
+    type Item = Result<u32, Error<E>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.err {
+            return None;
+        }
+        if let Some(current_cluster) = self.cluster {
+            self.cluster = match get_next_cluster(self.fat.borrow_mut(), self.fat_type, current_cluster) {
+                Ok(next_cluster) => next_cluster,
+                Err(err) => {
+                    self.err = true;
+                    return Some(Err(err));
+                }
+            }
+        }
+        self.cluster.map(Ok)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use io::StdIoWrapper;
+    use std::io::Cursor;
+
+    fn test_fat<S: Read + Write + Seek>(fat_type: FatType, mut cur: S) {
+        // based on cluster maps from Wikipedia:
+        // https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#Cluster_map
+        assert_eq!(read_fat(&mut cur, fat_type, 1).ok(), Some(FatValue::EndOfChain));
+        assert_eq!(read_fat(&mut cur, fat_type, 4).ok(), Some(FatValue::Data(5)));
+        assert_eq!(read_fat(&mut cur, fat_type, 5).ok(), Some(FatValue::Data(6)));
+        assert_eq!(read_fat(&mut cur, fat_type, 8).ok(), Some(FatValue::EndOfChain));
+        assert_eq!(read_fat(&mut cur, fat_type, 9).ok(), Some(FatValue::Data(0xA)));
+        assert_eq!(read_fat(&mut cur, fat_type, 0xA).ok(), Some(FatValue::Data(0x14)));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x12).ok(), Some(FatValue::Free));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x17).ok(), Some(FatValue::Bad));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x18).ok(), Some(FatValue::Bad));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x1B).ok(), Some(FatValue::Free));
+
+        assert_eq!(find_free_cluster(&mut cur, fat_type, 2, 0x20).ok(), Some(0x12));
+        assert_eq!(find_free_cluster(&mut cur, fat_type, 0x12, 0x20).ok(), Some(0x12));
+        assert_eq!(find_free_cluster(&mut cur, fat_type, 0x13, 0x20).ok(), Some(0x1B));
+        assert!(find_free_cluster(&mut cur, fat_type, 0x13, 0x14).is_err());
+
+        assert_eq!(count_free_clusters(&mut cur, fat_type, 0x1E).ok(), Some(5));
+
+        // test allocation
+        assert_eq!(
+            alloc_cluster(&mut cur, fat_type, None, Some(0x13), 0x1E).ok(),
+            Some(0x1B)
+        );
+        assert_eq!(read_fat(&mut cur, fat_type, 0x1B).ok(), Some(FatValue::EndOfChain));
+        assert_eq!(
+            alloc_cluster(&mut cur, fat_type, Some(0x1B), None, 0x1E).ok(),
+            Some(0x12)
+        );
+        assert_eq!(read_fat(&mut cur, fat_type, 0x1B).ok(), Some(FatValue::Data(0x12)));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x12).ok(), Some(FatValue::EndOfChain));
+        assert_eq!(count_free_clusters(&mut cur, fat_type, 0x1E).ok(), Some(3));
+        // test reading from iterator
+        {
+            let iter = ClusterIterator::<&mut S, S::Error, S>::new(&mut cur, fat_type, 0x9);
+            let actual_cluster_numbers = iter.map(Result::ok).collect::<Vec<_>>();
+            let expected_cluster_numbers = [0xA_u32, 0x14_u32, 0x15_u32, 0x16_u32, 0x19_u32, 0x1A_u32]
+                .iter()
+                .copied()
+                .map(Some)
+                .collect::<Vec<_>>();
+            assert_eq!(actual_cluster_numbers, expected_cluster_numbers);
+        }
+        // test truncating a chain
+        {
+            let mut iter = ClusterIterator::<&mut S, S::Error, S>::new(&mut cur, fat_type, 0x9);
+            assert_eq!(iter.nth(3).map(Result::ok), Some(Some(0x16)));
+            assert!(iter.truncate().is_ok());
+        }
+        assert_eq!(read_fat(&mut cur, fat_type, 0x16).ok(), Some(FatValue::EndOfChain));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x19).ok(), Some(FatValue::Free));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x1A).ok(), Some(FatValue::Free));
+        // test freeing a chain
+        {
+            let mut iter = ClusterIterator::<&mut S, S::Error, S>::new(&mut cur, fat_type, 0x9);
+            assert!(iter.free().is_ok());
+        }
+        assert_eq!(read_fat(&mut cur, fat_type, 0x9).ok(), Some(FatValue::Free));
+        assert_eq!(read_fat(&mut cur, fat_type, 0xA).ok(), Some(FatValue::Free));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x14).ok(), Some(FatValue::Free));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x15).ok(), Some(FatValue::Free));
+        assert_eq!(read_fat(&mut cur, fat_type, 0x16).ok(), Some(FatValue::Free));
+    }
+
+    #[test]
+    fn test_fat12() {
+        let fat: Vec<u8> = vec![
+            0xF0, 0xFF, 0xFF, 0x03, 0x40, 0x00, 0x05, 0x60, 0x00, 0x07, 0x80, 0x00, 0xFF, 0xAF, 0x00, 0x14, 0xC0, 0x00,
+            0x0D, 0xE0, 0x00, 0x0F, 0x00, 0x01, 0x11, 0xF0, 0xFF, 0x00, 0xF0, 0xFF, 0x15, 0x60, 0x01, 0x19, 0x70, 0xFF,
+            0xF7, 0xAF, 0x01, 0xFF, 0x0F, 0x00, 0x00, 0x70, 0xFF, 0x00, 0x00, 0x00,
+        ];
+        test_fat(FatType::Fat12, StdIoWrapper::new(Cursor::<Vec<u8>>::new(fat)));
+    }
+
+    #[test]
+    fn test_fat16() {
+        let fat: Vec<u8> = vec![
+            0xF0, 0xFF, 0xFF, 0xFF, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0xFF, 0xFF,
+            0x0A, 0x00, 0x14, 0x00, 0x0C, 0x00, 0x0D, 0x00, 0x0E, 0x00, 0x0F, 0x00, 0x10, 0x00, 0x11, 0x00, 0xFF, 0xFF,
+            0x00, 0x00, 0xFF, 0xFF, 0x15, 0x00, 0x16, 0x00, 0x19, 0x00, 0xF7, 0xFF, 0xF7, 0xFF, 0x1A, 0x00, 0xFF, 0xFF,
+            0x00, 0x00, 0x00, 0x00, 0xF7, 0xFF, 0x00, 0x00, 0x00, 0x00,
+        ];
+        test_fat(FatType::Fat16, StdIoWrapper::new(Cursor::<Vec<u8>>::new(fat)));
+    }
+
+    #[test]
+    fn test_fat32() {
+        let fat: Vec<u8> = vec![
+            0xF0, 0xFF, 0xFF, 0x0F, 0xFF, 0xFF, 0xFF, 0x0F, 0xFF, 0xFF, 0xFF, 0x0F, 0x04, 0x00, 0x00, 0x00, 0x05, 0x00,
+            0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0x0F,
+            0x0A, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x0D, 0x00, 0x00, 0x00, 0x0E, 0x00,
+            0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0x0F,
+            0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0x0F, 0x15, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00, 0x19, 0x00,
+            0x00, 0x00, 0xF7, 0xFF, 0xFF, 0x0F, 0xF7, 0xFF, 0xFF, 0x0F, 0x1A, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0x0F,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF7, 0xFF, 0xFF, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ];
+        test_fat(FatType::Fat32, StdIoWrapper::new(Cursor::<Vec<u8>>::new(fat)));
+    }
+}

--- a/fatfs/src/time.rs
+++ b/fatfs/src/time.rs
@@ -1,0 +1,313 @@
+#[cfg(feature = "chrono")]
+use core::convert::TryFrom;
+use core::fmt::Debug;
+
+#[cfg(feature = "chrono")]
+use chrono::{self, Datelike, Timelike};
+
+const MIN_YEAR: u16 = 1980;
+const MAX_YEAR: u16 = 2107;
+const MIN_MONTH: u16 = 1;
+const MAX_MONTH: u16 = 12;
+const MIN_DAY: u16 = 1;
+const MAX_DAY: u16 = 31;
+
+/// A DOS compatible date.
+///
+/// Used by `DirEntry` time-related methods.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
+pub struct Date {
+    /// Full year - [1980, 2107]
+    pub year: u16,
+    /// Month of the year - [1, 12]
+    pub month: u16,
+    /// Day of the month - [1, 31]
+    pub day: u16,
+}
+
+impl Date {
+    /// Creates a new `Date` instance.
+    ///
+    /// * `year` - full year number in the range [1980, 2107]
+    /// * `month` - month of the year in the range [1, 12]
+    /// * `day` - a day of the month in the range [1, 31]
+    ///
+    /// # Panics
+    ///
+    /// Panics if one of provided arguments is out of the supported range.
+    #[must_use]
+    pub fn new(year: u16, month: u16, day: u16) -> Self {
+        assert!((MIN_YEAR..=MAX_YEAR).contains(&year), "year out of range");
+        assert!((MIN_MONTH..=MAX_MONTH).contains(&month), "month out of range");
+        assert!((MIN_DAY..=MAX_DAY).contains(&day), "day out of range");
+        Self { year, month, day }
+    }
+
+    pub(crate) fn decode(dos_date: u16) -> Self {
+        let (year, month, day) = ((dos_date >> 9) + MIN_YEAR, (dos_date >> 5) & 0xF, dos_date & 0x1F);
+        Self { year, month, day }
+    }
+
+    pub(crate) fn encode(self) -> u16 {
+        ((self.year - MIN_YEAR) << 9) | (self.month << 5) | self.day
+    }
+}
+
+/// A DOS compatible time.
+///
+/// Used by `DirEntry` time-related methods.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
+pub struct Time {
+    /// Hours after midnight - [0, 23]
+    pub hour: u16,
+    /// Minutes after the hour - [0, 59]
+    pub min: u16,
+    /// Seconds after the minute - [0, 59]
+    pub sec: u16,
+    /// Milliseconds after the second - [0, 999]
+    pub millis: u16,
+}
+
+impl Time {
+    /// Creates a new `Time` instance.
+    ///
+    /// * `hour` - number of hours after midnight in the range [0, 23]
+    /// * `min` - number of minutes after the hour in the range [0, 59]
+    /// * `sec` - number of seconds after the minute in the range [0, 59]
+    /// * `millis` - number of milliseconds after the second in the range [0, 999]
+    ///
+    /// # Panics
+    ///
+    /// Panics if one of provided arguments is out of the supported range.
+    #[must_use]
+    pub fn new(hour: u16, min: u16, sec: u16, millis: u16) -> Self {
+        assert!(hour <= 23, "hour out of range");
+        assert!(min <= 59, "min out of range");
+        assert!(sec <= 59, "sec out of range");
+        assert!(millis <= 999, "millis out of range");
+        Self { hour, min, sec, millis }
+    }
+
+    pub(crate) fn decode(dos_time: u16, dos_time_hi_res: u8) -> Self {
+        let hour = dos_time >> 11;
+        let min = (dos_time >> 5) & 0x3F;
+        let sec = (dos_time & 0x1F) * 2 + u16::from(dos_time_hi_res / 100);
+        let millis = u16::from(dos_time_hi_res % 100) * 10;
+        Self { hour, min, sec, millis }
+    }
+
+    pub(crate) fn encode(self) -> (u16, u8) {
+        let dos_time = (self.hour << 11) | (self.min << 5) | (self.sec / 2);
+        let dos_time_hi_res = (self.millis / 10) + (self.sec % 2) * 100;
+        // safe cast: value in range [0, 199]
+        #[allow(clippy::cast_possible_truncation)]
+        (dos_time, dos_time_hi_res as u8)
+    }
+}
+
+/// A DOS compatible date and time.
+///
+/// Used by `DirEntry` time-related methods.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
+pub struct DateTime {
+    /// A date part
+    pub date: Date,
+    // A time part
+    pub time: Time,
+}
+
+impl DateTime {
+    #[must_use]
+    pub fn new(date: Date, time: Time) -> Self {
+        Self { date, time }
+    }
+
+    pub(crate) fn decode(dos_date: u16, dos_time: u16, dos_time_hi_res: u8) -> Self {
+        Self::new(Date::decode(dos_date), Time::decode(dos_time, dos_time_hi_res))
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<Date> for chrono::NaiveDate {
+    fn from(date: Date) -> Self {
+        chrono::NaiveDate::from_ymd_opt(i32::from(date.year), u32::from(date.month), u32::from(date.day)).unwrap()
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<DateTime> for chrono::NaiveDateTime {
+    fn from(date_time: DateTime) -> Self {
+        chrono::NaiveDate::from(date_time.date)
+            .and_hms_milli_opt(
+                u32::from(date_time.time.hour),
+                u32::from(date_time.time.min),
+                u32::from(date_time.time.sec),
+                u32::from(date_time.time.millis),
+            )
+            .unwrap()
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<chrono::NaiveDate> for Date {
+    fn from(date: chrono::NaiveDate) -> Self {
+        #[allow(clippy::cast_sign_loss)]
+        let year = u16::try_from(date.year()).unwrap(); // safe unwrap unless year is below 0 or above u16::MAX
+        assert!((MIN_YEAR..=MAX_YEAR).contains(&year), "year out of range");
+        Self {
+            year,
+            month: date.month() as u16, // safe cast: value in range [1, 12]
+            day: date.day() as u16,     // safe cast: value in range [1, 31]
+        }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<chrono::NaiveDateTime> for DateTime {
+    fn from(date_time: chrono::NaiveDateTime) -> Self {
+        let millis_leap = date_time.nanosecond() / 1_000_000; // value in the range [0, 1999] (> 999 if leap second)
+        let millis = millis_leap.min(999); // during leap second set milliseconds to 999
+        let date = Date::from(date_time.date());
+        #[allow(clippy::cast_possible_truncation)]
+        let time = Time {
+            hour: date_time.hour() as u16,  // safe cast: value in range [0, 23]
+            min: date_time.minute() as u16, // safe cast: value in range [0, 59]
+            sec: date_time.second() as u16, // safe cast: value in range [0, 59]
+            millis: millis as u16,          // safe cast: value in range [0, 999]
+        };
+        Self::new(date, time)
+    }
+}
+
+/// A current time and date provider.
+///
+/// Provides a custom implementation for a time resolution used when updating directory entry time fields.
+/// `TimeProvider` is specified by the `time_provider` property in `FsOptions` struct.
+pub trait TimeProvider: Debug {
+    fn get_current_date(&self) -> Date;
+    fn get_current_date_time(&self) -> DateTime;
+}
+
+/// `TimeProvider` implementation that returns current local time retrieved from `chrono` crate.
+#[cfg(feature = "chrono")]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ChronoTimeProvider {
+    _dummy: (),
+}
+
+#[cfg(feature = "chrono")]
+impl ChronoTimeProvider {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { _dummy: () }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TimeProvider for ChronoTimeProvider {
+    fn get_current_date(&self) -> Date {
+        Date::from(chrono::Local::now().date_naive())
+    }
+
+    fn get_current_date_time(&self) -> DateTime {
+        DateTime::from(chrono::Local::now().naive_local())
+    }
+}
+
+/// `TimeProvider` implementation that always returns DOS minimal date-time (1980-01-01 00:00:00).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NullTimeProvider {
+    _dummy: (),
+}
+
+impl NullTimeProvider {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { _dummy: () }
+    }
+}
+
+impl TimeProvider for NullTimeProvider {
+    fn get_current_date(&self) -> Date {
+        Date::decode(0)
+    }
+
+    fn get_current_date_time(&self) -> DateTime {
+        DateTime::decode(0, 0, 0)
+    }
+}
+
+/// Default time provider implementation.
+///
+/// Defined as `ChronoTimeProvider` if `chrono` feature is enabled. Otherwise defined as `NullTimeProvider`.
+#[cfg(feature = "chrono")]
+pub type DefaultTimeProvider = ChronoTimeProvider;
+#[cfg(not(feature = "chrono"))]
+pub type DefaultTimeProvider = NullTimeProvider;
+
+#[cfg(test)]
+mod tests {
+    use super::{Date, DateTime, Time};
+
+    #[test]
+    fn date_new_no_panic_1980() {
+        let _ = Date::new(1980, 1, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn date_new_panic_year_1979() {
+        let _ = Date::new(1979, 12, 31);
+    }
+
+    #[test]
+    fn date_new_no_panic_2107() {
+        let _ = Date::new(2107, 12, 31);
+    }
+
+    #[test]
+    #[should_panic]
+    fn date_new_panic_year_2108() {
+        let _ = Date::new(2108, 1, 1);
+    }
+
+    #[test]
+    fn date_encode_decode() {
+        let d = Date::new(2055, 7, 23);
+        let x = d.encode();
+        assert_eq!(x, 38647);
+        assert_eq!(d, Date::decode(x));
+    }
+
+    #[test]
+    fn time_encode_decode() {
+        let t1 = Time::new(15, 3, 29, 990);
+        let t2 = Time { sec: 18, ..t1 };
+        let t3 = Time { millis: 40, ..t1 };
+        let (x1, y1) = t1.encode();
+        let (x2, y2) = t2.encode();
+        let (x3, y3) = t3.encode();
+        assert_eq!((x1, y1), (30830, 199));
+        assert_eq!((x2, y2), (30825, 99));
+        assert_eq!((x3, y3), (30830, 104));
+        assert_eq!(t1, Time::decode(x1, y1));
+        assert_eq!(t2, Time::decode(x2, y2));
+        assert_eq!(t3, Time::decode(x3, y3));
+    }
+
+    #[test]
+    fn date_time_from_chrono_leap_second() {
+        let chrono_date_time = chrono::NaiveDate::from_ymd_opt(2016, 12, 31)
+            .unwrap()
+            .and_hms_milli_opt(23, 59, 59, 1999)
+            .unwrap();
+        let date_time = DateTime::from(chrono_date_time);
+        assert_eq!(
+            date_time,
+            DateTime::new(Date::new(2016, 12, 31), Time::new(23, 59, 59, 999))
+        );
+    }
+}

--- a/fatfs/tests/format.rs
+++ b/fatfs/tests/format.rs
@@ -1,0 +1,160 @@
+use std::io;
+use std::io::prelude::*;
+
+use fatfs::{FatType, StdIoWrapper};
+use fscommon::BufStream;
+
+const KB: u64 = 1024;
+const MB: u64 = KB * 1024;
+const TEST_STR: &str = "Hi there Rust programmer!\n";
+
+type FileSystem = fatfs::FileSystem<StdIoWrapper<BufStream<io::Cursor<Vec<u8>>>>>;
+
+fn init_logger() {
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
+fn format_fs(opts: fatfs::FormatVolumeOptions, total_bytes: u64) -> FileSystem {
+    init_logger();
+    // Init storage to 0xD1 bytes (value has been choosen to be parsed as normal file)
+    let storage_vec: Vec<u8> = vec![0xD1_u8; total_bytes as usize];
+    let storage_cur = io::Cursor::new(storage_vec);
+    let mut buffered_stream = fatfs::StdIoWrapper::from(BufStream::new(storage_cur));
+    fatfs::format_volume(&mut buffered_stream, opts).expect("format volume");
+    fatfs::FileSystem::new(buffered_stream, fatfs::FsOptions::new()).expect("open fs")
+}
+
+fn basic_fs_test(fs: &FileSystem) {
+    let stats = fs.stats().expect("stats");
+    if fs.fat_type() == fatfs::FatType::Fat32 {
+        // On FAT32 one cluster is allocated for root directory
+        assert_eq!(stats.total_clusters(), stats.free_clusters() + 1);
+    } else {
+        assert_eq!(stats.total_clusters(), stats.free_clusters());
+    }
+
+    let root_dir = fs.root_dir();
+    let entries = root_dir.iter().map(|r| r.unwrap()).collect::<Vec<_>>();
+    assert_eq!(entries.len(), 0);
+
+    let subdir1 = root_dir.create_dir("subdir1").expect("create_dir subdir1");
+    let subdir2 = root_dir
+        .create_dir("subdir1/subdir2 with long name")
+        .expect("create_dir subdir2");
+
+    let test_str = TEST_STR.repeat(1000);
+    {
+        let mut file = subdir2.create_file("test file name.txt").expect("create file");
+        file.truncate().expect("truncate file");
+        file.write_all(test_str.as_bytes()).expect("write file");
+    }
+
+    let mut file = root_dir
+        .open_file("subdir1/subdir2 with long name/test file name.txt")
+        .unwrap();
+    let mut content = String::new();
+    file.read_to_string(&mut content).expect("read_to_string");
+    assert_eq!(content, test_str);
+
+    let filenames = root_dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(filenames, ["subdir1"]);
+
+    let filenames = subdir2.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(filenames, [".", "..", "test file name.txt"]);
+
+    subdir1
+        .rename("subdir2 with long name/test file name.txt", &root_dir, "new-name.txt")
+        .expect("rename");
+
+    let filenames = subdir2.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(filenames, [".", ".."]);
+
+    let filenames = root_dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(filenames, ["subdir1", "new-name.txt"]);
+}
+
+fn test_format_fs(opts: fatfs::FormatVolumeOptions, total_bytes: u64) -> FileSystem {
+    let fs = format_fs(opts, total_bytes);
+    basic_fs_test(&fs);
+    fs
+}
+
+#[test]
+fn test_format_1mb() {
+    let total_bytes = MB;
+    let opts = fatfs::FormatVolumeOptions::new();
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.fat_type(), fatfs::FatType::Fat12);
+}
+
+#[test]
+fn test_format_8mb_1fat() {
+    let total_bytes = 8 * MB;
+    let opts = fatfs::FormatVolumeOptions::new().fats(1);
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.fat_type(), fatfs::FatType::Fat16);
+}
+
+#[test]
+fn test_format_50mb() {
+    let total_bytes = 50 * MB;
+    let opts = fatfs::FormatVolumeOptions::new();
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.fat_type(), fatfs::FatType::Fat16);
+}
+
+#[test]
+fn test_format_2gb_512sec() {
+    let total_bytes = 2 * 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new();
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.fat_type(), fatfs::FatType::Fat32);
+}
+
+#[test]
+fn test_format_1gb_4096sec() {
+    let total_bytes = 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new().bytes_per_sector(4096);
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.fat_type(), fatfs::FatType::Fat32);
+}
+
+#[test]
+fn test_format_empty_volume_label() {
+    let total_bytes = 2 * 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new();
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.volume_label(), "NO NAME");
+    assert_eq!(fs.read_volume_label_from_root_dir().unwrap(), None);
+}
+
+#[test]
+fn test_format_volume_label_and_id() {
+    let total_bytes = 2 * 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new()
+        .volume_id(1234)
+        .volume_label(*b"VOLUMELABEL");
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.volume_label(), "VOLUMELABEL");
+    assert_eq!(
+        fs.read_volume_label_from_root_dir().unwrap(),
+        Some("VOLUMELABEL".to_string())
+    );
+    assert_eq!(fs.volume_id(), 1234);
+}
+
+#[test]
+fn test_zero_root_dir_clusters() {
+    init_logger();
+    let total_bytes = 33 * MB;
+    let opts = fatfs::FormatVolumeOptions::new().fat_type(FatType::Fat32);
+    let fs = format_fs(opts, total_bytes);
+    let root_dir = fs.root_dir();
+
+    // create a bunch of files to force allocation of second root directory cluster (64 is combined size of LFN + SFN)
+    let files_to_create = fs.cluster_size() as usize / 64 + 1;
+    for i in 0..files_to_create {
+        root_dir.create_file(&format!("f{}", i)).unwrap();
+    }
+    assert_eq!(root_dir.iter().count(), files_to_create);
+}

--- a/fatfs/tests/fsck.rs
+++ b/fatfs/tests/fsck.rs
@@ -1,0 +1,48 @@
+#![cfg(target_os = "linux")]
+use fatfs::Write;
+
+const KB: u32 = 1024;
+const MB: u32 = KB * 1024;
+
+#[test]
+fn test_fsck_1mb() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut image = std::fs::OpenOptions::new()
+        .write(true)
+        .read(true)
+        .create(true)
+        .open("/tmp/test.img")
+        .expect("open temporary image file");
+    image.set_len(MB as u64).expect("set_len on temp file");
+
+    fatfs::format_volume(
+        &mut fatfs::StdIoWrapper::from(image.try_clone().expect("clone tempfile")),
+        fatfs::FormatVolumeOptions::new().total_sectors(MB / 512),
+    )
+    .expect("format volume");
+
+    let fs = fatfs::FileSystem::new(image, fatfs::FsOptions::new()).expect("open fs");
+    fs.root_dir().create_dir("dir1").expect("create dir1");
+    fs.root_dir()
+        .create_file("root file.bin")
+        .expect("create root file")
+        .write_all(&[0xab; (16 * KB) as usize])
+        .expect("root file write");
+    let dir2 = fs.root_dir().create_dir("dir2").expect("create dir2");
+    dir2.create_dir("subdir").expect("subdir");
+    dir2.create_file("file1")
+        .expect("file1")
+        .write_all(b"testing 1 2 1 2")
+        .expect("file 1 write");
+    core::mem::drop(dir2);
+    core::mem::drop(fs);
+
+    let fsck_status = std::process::Command::new("fsck.vfat")
+        .args(&["-n", "/tmp/test.img"])
+        .spawn()
+        .expect("spawn fsck")
+        .wait()
+        .expect("wait on fsck");
+    assert!(fsck_status.success(), "fsck was not successful ({fsck_status:?})");
+}

--- a/fatfs/tests/read.rs
+++ b/fatfs/tests/read.rs
@@ -1,0 +1,292 @@
+use std::fs;
+use std::io::prelude::*;
+use std::io::SeekFrom;
+use std::str;
+
+use fatfs::{FatType, FsOptions, StdIoWrapper};
+use fscommon::BufStream;
+
+const TEST_TEXT: &str = "Rust is cool!\n";
+const FAT12_IMG: &str = "resources/fat12.img";
+const FAT16_IMG: &str = "resources/fat16.img";
+const FAT32_IMG: &str = "resources/fat32.img";
+
+type FileSystem = fatfs::FileSystem<StdIoWrapper<BufStream<fs::File>>>;
+
+fn call_with_fs<F: Fn(FileSystem)>(f: F, filename: &str) {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let file = fs::File::open(filename).unwrap();
+    let buf_file = BufStream::new(file);
+    let fs = FileSystem::new(buf_file, FsOptions::new()).unwrap();
+    f(fs);
+}
+
+fn test_root_dir(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let entries = root_dir.iter().map(|r| r.unwrap()).collect::<Vec<_>>();
+    let short_names = entries.iter().map(|e| e.short_file_name()).collect::<Vec<String>>();
+    assert_eq!(short_names, ["LONG.TXT", "SHORT.TXT", "VERY", "VERY-L~1"]);
+    let names = entries.iter().map(|e| e.file_name()).collect::<Vec<String>>();
+    assert_eq!(names, ["long.txt", "short.txt", "very", "very-long-dir-name"]);
+    // Try read again
+    let names2 = root_dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names2, names);
+}
+
+#[test]
+fn test_root_dir_fat12() {
+    call_with_fs(test_root_dir, FAT12_IMG)
+}
+
+#[test]
+fn test_root_dir_fat16() {
+    call_with_fs(test_root_dir, FAT16_IMG)
+}
+
+#[test]
+fn test_root_dir_fat32() {
+    call_with_fs(test_root_dir, FAT32_IMG)
+}
+
+fn test_read_seek_short_file(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let mut short_file = root_dir.open_file("short.txt").unwrap();
+    let mut buf = Vec::new();
+    short_file.read_to_end(&mut buf).unwrap();
+    assert_eq!(str::from_utf8(&buf).unwrap(), TEST_TEXT);
+
+    assert_eq!(short_file.seek(SeekFrom::Start(5)).unwrap(), 5);
+    let mut buf2 = [0; 5];
+    short_file.read_exact(&mut buf2).unwrap();
+    assert_eq!(str::from_utf8(&buf2).unwrap(), &TEST_TEXT[5..10]);
+
+    assert_eq!(short_file.seek(SeekFrom::Start(1000)).unwrap(), TEST_TEXT.len() as u64);
+    let mut buf2 = [0; 5];
+    assert_eq!(short_file.read(&mut buf2).unwrap(), 0);
+}
+
+#[test]
+fn test_read_seek_short_file_fat12() {
+    call_with_fs(test_read_seek_short_file, FAT12_IMG)
+}
+
+#[test]
+fn test_read_seek_short_file_fat16() {
+    call_with_fs(test_read_seek_short_file, FAT16_IMG)
+}
+
+#[test]
+fn test_read_seek_short_file_fat32() {
+    call_with_fs(test_read_seek_short_file, FAT32_IMG)
+}
+
+fn test_read_long_file(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let mut long_file = root_dir.open_file("long.txt").unwrap();
+    let mut buf = Vec::new();
+    long_file.read_to_end(&mut buf).unwrap();
+    assert_eq!(str::from_utf8(&buf).unwrap(), TEST_TEXT.repeat(1000));
+
+    assert_eq!(long_file.seek(SeekFrom::Start(2017)).unwrap(), 2017);
+    buf.clear();
+    let mut buf2 = [0; 10];
+    long_file.read_exact(&mut buf2).unwrap();
+    assert_eq!(str::from_utf8(&buf2).unwrap(), &TEST_TEXT.repeat(1000)[2017..2027]);
+}
+
+#[test]
+fn test_read_long_file_fat12() {
+    call_with_fs(test_read_long_file, FAT12_IMG)
+}
+
+#[test]
+fn test_read_long_file_fat16() {
+    call_with_fs(test_read_long_file, FAT16_IMG)
+}
+
+#[test]
+fn test_read_long_file_fat32() {
+    call_with_fs(test_read_long_file, FAT32_IMG)
+}
+
+fn test_get_dir_by_path(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let dir = root_dir.open_dir("very/long/path/").unwrap();
+    let names = dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names, [".", "..", "test.txt"]);
+
+    let dir2 = root_dir.open_dir("very/long/path/././.").unwrap();
+    let names2 = dir2.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names2, [".", "..", "test.txt"]);
+
+    let root_dir2 = root_dir.open_dir("very/long/path/../../..").unwrap();
+    let root_names = root_dir2
+        .iter()
+        .map(|r| r.unwrap().file_name())
+        .collect::<Vec<String>>();
+    let root_names2 = root_dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(root_names, root_names2);
+
+    root_dir.open_dir("VERY-L~1").unwrap();
+}
+
+#[test]
+fn test_get_dir_by_path_fat12() {
+    call_with_fs(test_get_dir_by_path, FAT12_IMG)
+}
+
+#[test]
+fn test_get_dir_by_path_fat16() {
+    call_with_fs(test_get_dir_by_path, FAT16_IMG)
+}
+
+#[test]
+fn test_get_dir_by_path_fat32() {
+    call_with_fs(test_get_dir_by_path, FAT32_IMG)
+}
+
+fn test_get_file_by_path(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let mut file = root_dir.open_file("very/long/path/test.txt").unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+    assert_eq!(str::from_utf8(&buf).unwrap(), TEST_TEXT);
+
+    let mut file = root_dir
+        .open_file("very-long-dir-name/very-long-file-name.txt")
+        .unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+    assert_eq!(str::from_utf8(&buf).unwrap(), TEST_TEXT);
+
+    root_dir.open_file("VERY-L~1/VERY-L~1.TXT").unwrap();
+
+    // try opening dir as file
+    assert!(root_dir.open_file("very/long/path").is_err());
+    // try opening file as dir
+    assert!(root_dir.open_dir("very/long/path/test.txt").is_err());
+    // try using invalid path containing file as non-last component
+    assert!(root_dir.open_file("very/long/path/test.txt/abc").is_err());
+    assert!(root_dir.open_dir("very/long/path/test.txt/abc").is_err());
+}
+
+#[test]
+fn test_get_file_by_path_fat12() {
+    call_with_fs(test_get_file_by_path, FAT12_IMG)
+}
+
+#[test]
+fn test_get_file_by_path_fat16() {
+    call_with_fs(test_get_file_by_path, FAT16_IMG)
+}
+
+#[test]
+fn test_get_file_by_path_fat32() {
+    call_with_fs(test_get_file_by_path, FAT32_IMG)
+}
+
+fn test_volume_metadata(fs: FileSystem, fat_type: FatType) {
+    assert_eq!(fs.volume_id(), 0x1234_5678);
+    assert_eq!(fs.volume_label(), "Test!");
+    assert_eq!(&fs.read_volume_label_from_root_dir().unwrap().unwrap(), "Test!");
+    assert_eq!(fs.fat_type(), fat_type);
+}
+
+#[test]
+fn test_volume_metadata_fat12() {
+    call_with_fs(|fs| test_volume_metadata(fs, FatType::Fat12), FAT12_IMG)
+}
+
+#[test]
+fn test_volume_metadata_fat16() {
+    call_with_fs(|fs| test_volume_metadata(fs, FatType::Fat16), FAT16_IMG)
+}
+
+#[test]
+fn test_volume_metadata_fat32() {
+    call_with_fs(|fs| test_volume_metadata(fs, FatType::Fat32), FAT32_IMG)
+}
+
+fn test_status_flags(fs: FileSystem) {
+    let status_flags = fs.read_status_flags().unwrap();
+    assert!(!status_flags.dirty());
+    assert!(!status_flags.io_error());
+}
+
+#[test]
+fn test_status_flags_fat12() {
+    call_with_fs(test_status_flags, FAT12_IMG)
+}
+
+#[test]
+fn test_status_flags_fat16() {
+    call_with_fs(test_status_flags, FAT16_IMG)
+}
+
+#[test]
+fn test_status_flags_fat32() {
+    call_with_fs(test_status_flags, FAT32_IMG)
+}
+
+#[test]
+fn test_stats_fat12() {
+    call_with_fs(
+        |fs| {
+            let stats = fs.stats().unwrap();
+            assert_eq!(stats.cluster_size(), 512);
+            assert_eq!(stats.total_clusters(), 1955); // 1000 * 1024 / 512 = 2000
+            assert_eq!(stats.free_clusters(), 1920);
+        },
+        FAT12_IMG,
+    )
+}
+
+#[test]
+fn test_stats_fat16() {
+    call_with_fs(
+        |fs| {
+            let stats = fs.stats().unwrap();
+            assert_eq!(stats.cluster_size(), 512);
+            assert_eq!(stats.total_clusters(), 4927); // 2500 * 1024 / 512 = 5000
+            assert_eq!(stats.free_clusters(), 4892);
+        },
+        FAT16_IMG,
+    )
+}
+
+#[test]
+fn test_stats_fat32() {
+    call_with_fs(
+        |fs| {
+            let stats = fs.stats().unwrap();
+            assert_eq!(stats.cluster_size(), 512);
+            assert_eq!(stats.total_clusters(), 66922); // 34000 * 1024 / 512 = 68000
+            assert_eq!(stats.free_clusters(), 66886);
+        },
+        FAT32_IMG,
+    )
+}
+
+#[test]
+fn test_multi_thread() {
+    call_with_fs(
+        |fs| {
+            use std::sync::{Arc, Mutex};
+            use std::thread;
+            let shared_fs = Arc::new(Mutex::new(fs));
+            let mut handles = vec![];
+            for _ in 0..2 {
+                let shared_fs_cloned = Arc::clone(&shared_fs);
+                let handle = thread::spawn(move || {
+                    let fs2 = shared_fs_cloned.lock().unwrap();
+                    assert_eq!(fs2.fat_type(), FatType::Fat32);
+                });
+                handles.push(handle);
+            }
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        },
+        FAT32_IMG,
+    )
+}

--- a/fatfs/tests/write.rs
+++ b/fatfs/tests/write.rs
@@ -1,0 +1,402 @@
+use std::fs;
+use std::io;
+use std::io::prelude::*;
+use std::mem;
+use std::str;
+
+use fatfs::{FsOptions, StdIoWrapper};
+use fscommon::BufStream;
+
+const FAT12_IMG: &str = "fat12.img";
+const FAT16_IMG: &str = "fat16.img";
+const FAT32_IMG: &str = "fat32.img";
+const IMG_DIR: &str = "resources";
+const TMP_DIR: &str = "tmp";
+const TEST_STR: &str = "Hi there Rust programmer!\n";
+const TEST_STR2: &str = "Rust is cool!\n";
+
+type FileSystem = fatfs::FileSystem<StdIoWrapper<BufStream<fs::File>>>;
+
+fn call_with_tmp_img<F: Fn(&str)>(f: F, filename: &str, test_seq: u32) {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let img_path = format!("{}/{}", IMG_DIR, filename);
+    let tmp_path = format!("{}/{}-{}", TMP_DIR, test_seq, filename);
+    fs::create_dir(TMP_DIR).ok();
+    fs::copy(img_path, &tmp_path).unwrap();
+    f(tmp_path.as_str());
+    fs::remove_file(tmp_path).unwrap();
+}
+
+fn open_filesystem_rw(tmp_path: &str) -> FileSystem {
+    let file = fs::OpenOptions::new().read(true).write(true).open(tmp_path).unwrap();
+    let buf_file = BufStream::new(file);
+    let options = FsOptions::new().update_accessed_date(true);
+    FileSystem::new(buf_file, options).unwrap()
+}
+
+fn call_with_fs<F: Fn(FileSystem)>(f: F, filename: &str, test_seq: u32) {
+    let callback = |tmp_path: &str| {
+        let fs = open_filesystem_rw(tmp_path);
+        f(fs);
+    };
+    call_with_tmp_img(callback, filename, test_seq);
+}
+
+fn test_write_short_file(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let mut file = root_dir.open_file("short.txt").expect("open file");
+    file.truncate().unwrap();
+    file.write_all(TEST_STR.as_bytes()).unwrap();
+    file.seek(io::SeekFrom::Start(0)).unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+    assert_eq!(TEST_STR, str::from_utf8(&buf).unwrap());
+}
+
+#[test]
+fn test_write_file_fat12() {
+    call_with_fs(test_write_short_file, FAT12_IMG, 1)
+}
+
+#[test]
+fn test_write_file_fat16() {
+    call_with_fs(test_write_short_file, FAT16_IMG, 1)
+}
+
+#[test]
+fn test_write_file_fat32() {
+    call_with_fs(test_write_short_file, FAT32_IMG, 1)
+}
+
+fn test_write_long_file(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let mut file = root_dir.open_file("long.txt").expect("open file");
+    file.truncate().unwrap();
+    let test_str = TEST_STR.repeat(1000);
+    file.write_all(test_str.as_bytes()).unwrap();
+    file.seek(io::SeekFrom::Start(0)).unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+    assert_eq!(test_str, str::from_utf8(&buf).unwrap());
+    file.seek(io::SeekFrom::Start(1234)).unwrap();
+    file.truncate().unwrap();
+    file.seek(io::SeekFrom::Start(0)).unwrap();
+    buf.clear();
+    file.read_to_end(&mut buf).unwrap();
+    assert_eq!(&test_str[..1234], str::from_utf8(&buf).unwrap());
+}
+
+#[test]
+fn test_write_long_file_fat12() {
+    call_with_fs(test_write_long_file, FAT12_IMG, 2)
+}
+
+#[test]
+fn test_write_long_file_fat16() {
+    call_with_fs(test_write_long_file, FAT16_IMG, 2)
+}
+
+#[test]
+fn test_write_long_file_fat32() {
+    call_with_fs(test_write_long_file, FAT32_IMG, 2)
+}
+
+fn test_remove(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    assert!(root_dir.remove("very/long/path").is_err());
+    let dir = root_dir.open_dir("very/long/path").unwrap();
+    let mut names = dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names, [".", "..", "test.txt"]);
+    root_dir.remove("very/long/path/test.txt").unwrap();
+    names = dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names, [".", ".."]);
+    assert!(root_dir.remove("very/long/path").is_ok());
+
+    names = root_dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names, ["long.txt", "short.txt", "very", "very-long-dir-name"]);
+    root_dir.remove("long.txt").unwrap();
+    names = root_dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names, ["short.txt", "very", "very-long-dir-name"]);
+}
+
+#[test]
+fn test_remove_fat12() {
+    call_with_fs(test_remove, FAT12_IMG, 3)
+}
+
+#[test]
+fn test_remove_fat16() {
+    call_with_fs(test_remove, FAT16_IMG, 3)
+}
+
+#[test]
+fn test_remove_fat32() {
+    call_with_fs(test_remove, FAT32_IMG, 3)
+}
+
+fn test_create_file(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let dir = root_dir.open_dir("very/long/path").unwrap();
+    let mut names = dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names, [".", "..", "test.txt"]);
+    {
+        // test some invalid names
+        assert!(root_dir.create_file("very/long/path/:").is_err());
+        assert!(root_dir.create_file("very/long/path/\0").is_err());
+        // create file
+        let mut file = root_dir
+            .create_file("very/long/path/new-file-with-long-name.txt")
+            .unwrap();
+        file.write_all(TEST_STR.as_bytes()).unwrap();
+    }
+    // check for dir entry
+    names = dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names, [".", "..", "test.txt", "new-file-with-long-name.txt"]);
+    names = dir
+        .iter()
+        .map(|r| r.unwrap().short_file_name())
+        .collect::<Vec<String>>();
+    assert_eq!(names, [".", "..", "TEST.TXT", "NEW-FI~1.TXT"]);
+    {
+        // check contents
+        let mut file = root_dir
+            .open_file("very/long/path/new-file-with-long-name.txt")
+            .unwrap();
+        let mut content = String::new();
+        file.read_to_string(&mut content).unwrap();
+        assert_eq!(&content, &TEST_STR);
+    }
+    // Create enough entries to allocate next cluster
+    for i in 0..512 / 32 {
+        let name = format!("test{}", i);
+        dir.create_file(&name).unwrap();
+    }
+    names = dir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+    assert_eq!(names.len(), 4 + 512 / 32);
+    // check creating existing file opens it
+    {
+        let mut file = root_dir
+            .create_file("very/long/path/new-file-with-long-name.txt")
+            .unwrap();
+        let mut content = String::new();
+        file.read_to_string(&mut content).unwrap();
+        assert_eq!(&content, &TEST_STR);
+    }
+    // check using create_file with existing directory fails
+    assert!(root_dir.create_file("very").is_err());
+}
+
+#[test]
+fn test_create_file_fat12() {
+    call_with_fs(test_create_file, FAT12_IMG, 4)
+}
+
+#[test]
+fn test_create_file_fat16() {
+    call_with_fs(test_create_file, FAT16_IMG, 4)
+}
+
+#[test]
+fn test_create_file_fat32() {
+    call_with_fs(test_create_file, FAT32_IMG, 4)
+}
+
+fn test_create_dir(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let parent_dir = root_dir.open_dir("very/long/path").unwrap();
+    let mut names = parent_dir
+        .iter()
+        .map(|r| r.unwrap().file_name())
+        .collect::<Vec<String>>();
+    assert_eq!(names, [".", "..", "test.txt"]);
+    {
+        let subdir = root_dir.create_dir("very/long/path/new-dir-with-long-name").unwrap();
+        names = subdir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+        assert_eq!(names, [".", ".."]);
+    }
+    // check if new entry is visible in parent
+    names = parent_dir
+        .iter()
+        .map(|r| r.unwrap().file_name())
+        .collect::<Vec<String>>();
+    assert_eq!(names, [".", "..", "test.txt", "new-dir-with-long-name"]);
+    {
+        // Check if new directory can be opened and read
+        let subdir = root_dir.open_dir("very/long/path/new-dir-with-long-name").unwrap();
+        names = subdir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+        assert_eq!(names, [".", ".."]);
+    }
+    // Check if '.' is alias for new directory
+    {
+        let subdir = root_dir.open_dir("very/long/path/new-dir-with-long-name/.").unwrap();
+        names = subdir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+        assert_eq!(names, [".", ".."]);
+    }
+    // Check if '..' is alias for parent directory
+    {
+        let subdir = root_dir.open_dir("very/long/path/new-dir-with-long-name/..").unwrap();
+        names = subdir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+        assert_eq!(names, [".", "..", "test.txt", "new-dir-with-long-name"]);
+    }
+    // check if creating existing directory returns it
+    {
+        let subdir = root_dir.create_dir("very").unwrap();
+        names = subdir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
+        assert_eq!(names, [".", "..", "long"]);
+    }
+    // check short names validity after create_dir
+    {
+        let subdir = root_dir.create_dir("test").unwrap();
+        names = subdir
+            .iter()
+            .map(|r| r.unwrap().short_file_name())
+            .collect::<Vec<String>>();
+        assert_eq!(names, [".", ".."]);
+    }
+
+    // check using create_dir with existing file fails
+    assert!(root_dir.create_dir("very/long/path/test.txt").is_err());
+}
+
+#[test]
+fn test_create_dir_fat12() {
+    call_with_fs(test_create_dir, FAT12_IMG, 5)
+}
+
+#[test]
+fn test_create_dir_fat16() {
+    call_with_fs(test_create_dir, FAT16_IMG, 5)
+}
+
+#[test]
+fn test_create_dir_fat32() {
+    call_with_fs(test_create_dir, FAT32_IMG, 5)
+}
+
+fn test_rename_file(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let parent_dir = root_dir.open_dir("very/long/path").unwrap();
+    let entries = parent_dir.iter().map(|r| r.unwrap()).collect::<Vec<_>>();
+    let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
+    assert_eq!(names, [".", "..", "test.txt"]);
+    assert_eq!(entries[2].len(), 14);
+    let stats = fs.stats().unwrap();
+
+    parent_dir.rename("test.txt", &parent_dir, "new-long-name.txt").unwrap();
+    let entries = parent_dir.iter().map(|r| r.unwrap()).collect::<Vec<_>>();
+    let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
+    assert_eq!(names, [".", "..", "new-long-name.txt"]);
+    assert_eq!(entries[2].len(), TEST_STR2.len() as u64);
+    let mut file = parent_dir.open_file("new-long-name.txt").unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+    assert_eq!(str::from_utf8(&buf).unwrap(), TEST_STR2);
+
+    parent_dir
+        .rename("new-long-name.txt", &root_dir, "moved-file.txt")
+        .unwrap();
+    let entries = root_dir.iter().map(|r| r.unwrap()).collect::<Vec<_>>();
+    let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        ["long.txt", "short.txt", "very", "very-long-dir-name", "moved-file.txt"]
+    );
+    assert_eq!(entries[4].len(), TEST_STR2.len() as u64);
+    let mut file = root_dir.open_file("moved-file.txt").unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+    assert_eq!(str::from_utf8(&buf).unwrap(), TEST_STR2);
+
+    assert!(root_dir.rename("moved-file.txt", &root_dir, "short.txt").is_err());
+    let entries = root_dir.iter().map(|r| r.unwrap()).collect::<Vec<_>>();
+    let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        ["long.txt", "short.txt", "very", "very-long-dir-name", "moved-file.txt"]
+    );
+
+    assert!(root_dir.rename("moved-file.txt", &root_dir, "moved-file.txt").is_ok());
+
+    let new_stats = fs.stats().unwrap();
+    assert_eq!(new_stats.free_clusters(), stats.free_clusters());
+}
+
+#[test]
+fn test_rename_file_fat12() {
+    call_with_fs(test_rename_file, FAT12_IMG, 6)
+}
+
+#[test]
+fn test_rename_file_fat16() {
+    call_with_fs(test_rename_file, FAT16_IMG, 6)
+}
+
+#[test]
+fn test_rename_file_fat32() {
+    call_with_fs(test_rename_file, FAT32_IMG, 6)
+}
+
+fn test_dirty_flag(tmp_path: &str) {
+    // Open filesystem, make change, and forget it - should become dirty
+    let fs = open_filesystem_rw(tmp_path);
+    let status_flags = fs.read_status_flags().unwrap();
+    assert!(!status_flags.dirty());
+    assert!(!status_flags.io_error());
+    fs.root_dir().create_file("abc.txt").unwrap();
+    mem::forget(fs);
+    // Check if volume is dirty now
+    let fs = open_filesystem_rw(tmp_path);
+    let status_flags = fs.read_status_flags().unwrap();
+    assert!(status_flags.dirty());
+    assert!(!status_flags.io_error());
+    fs.unmount().unwrap();
+    // Make sure remounting does not clear the dirty flag
+    let fs = open_filesystem_rw(tmp_path);
+    let status_flags = fs.read_status_flags().unwrap();
+    assert!(status_flags.dirty());
+    assert!(!status_flags.io_error());
+}
+
+#[test]
+fn test_dirty_flag_fat12() {
+    call_with_tmp_img(test_dirty_flag, FAT12_IMG, 7)
+}
+
+#[test]
+fn test_dirty_flag_fat16() {
+    call_with_tmp_img(test_dirty_flag, FAT16_IMG, 7)
+}
+
+#[test]
+fn test_dirty_flag_fat32() {
+    call_with_tmp_img(test_dirty_flag, FAT32_IMG, 7)
+}
+
+fn test_multiple_files_in_directory(fs: FileSystem) {
+    let dir = fs.root_dir().create_dir("/TMP").unwrap();
+    for i in 0..8 {
+        let name = format!("T{}.TXT", i);
+        let mut file = dir.create_file(&name).unwrap();
+        file.write_all(TEST_STR.as_bytes()).unwrap();
+        file.flush().unwrap();
+
+        let file = dir.iter().map(|r| r.unwrap()).find(|e| e.file_name() == name).unwrap();
+
+        assert_eq!(TEST_STR.len() as u64, file.len(), "Wrong file len on iteration {}", i);
+    }
+}
+
+#[test]
+fn test_multiple_files_in_directory_fat12() {
+    call_with_fs(test_multiple_files_in_directory, FAT12_IMG, 8)
+}
+
+#[test]
+fn test_multiple_files_in_directory_fat16() {
+    call_with_fs(test_multiple_files_in_directory, FAT16_IMG, 8)
+}
+
+#[test]
+fn test_multiple_files_in_directory_fat32() {
+    call_with_fs(test_multiple_files_in_directory, FAT32_IMG, 8)
+}


### PR DESCRIPTION
## Description
To introduce a file system into awkernel, we will first integrate the existing [rust-fatfs](https://github.com/rafalh/rust-fatfs) crate (MIT License). In a subsequent PR, we will modify this fatfs for a multithreaded environment, and then implement a file system service in awkernel. Following that, we will proceed to support other file systems.

## Related links

## How was this PR tested?

## Notes for reviewers
