### PR TITLE
feat(igc): implement `igc_is_valid_ether_addr()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -541,7 +541,17 @@ fn igc_attach_and_hw_control(
 
     ops.read_mac_addr(info, hw).or(Err(InitFailure))?;
 
+    if !igc_is_valid_ether_addr(&hw.mac.addr) {
+        log::error!("igc: Invalid MAC address read from EEPROM");
+        return Err(PCIeDeviceErr::InitFailure);
+    }
+
     // TODO: continue initialization
 
     Ok(())
+}
+
+fn igc_is_valid_ether_addr(addr: &[u8; 6]) -> bool {
+    // Check if the address is a multicast address or a zero address.
+    !(addr[0] & 1 != 0 || addr.iter().all(|&x| x == 0))
 }


### PR DESCRIPTION
## Description

Implement `igc_is_valid_ether_addr()`.

## Related links

- OpenBSD's `igc_is_valid_ether_addr()`:
  - https://github.com/openbsd/src/blob/98b1dda24a5c7b993c17411213a62602e028390b/sys/dev/pci/if_igc.c#L2487
  - https://github.com/openbsd/src/blob/98b1dda24a5c7b993c17411213a62602e028390b/sys/dev/pci/if_igc.c#L270

## How was this PR tested?

## Notes for reviewers
