### PR TITLE
feat(pcie): add `get_table_size()` method to `Msix`

### DIFF
--- a/awkernel_drivers/src/pcie/capability/msix.rs
+++ b/awkernel_drivers/src/pcie/capability/msix.rs
@@ -119,6 +119,8 @@ impl Msix {
     }
 
     /// Returns the size of the MSI-X table.
+    /// Because the table size in the config space represents the number of entries minus one,
+    /// this method returns `table_size + 1`.
     pub fn get_table_size(&self) -> u16 {
         self.table_size + 1
     }


### PR DESCRIPTION
## Description

Add `get_table_size()` method to `Msix`.

## Related links

## How was this PR tested?

## Notes for reviewers

Note that PCIe's MSI-X's `table_size` represents N - 1, where N is an actual table size.
So, this method returns `table_size + 1`.

https://www.intel.com/content/www/us/en/docs/programmable/683686/20-4/msi-x-capability-structure.html

> MSI-X Capability ID, Capability Pointer and Mask Register
>
> Bits [26:16]: Size of the MSI-X Table. The value in this field is 1 less than the size of the table set up for this function. The maximum value is 0x7FF, or 4096 interrupt vectors. 