### PR TITLE
feat(igc): define structs of Tx/Rx descriptors

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc/igc_base.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_base.rs
@@ -11,6 +11,107 @@ use super::{
 
 pub(super) const IGC_RAR_ENTRIES_BASE: u16 = 16;
 
+/// Transmit Descriptor - Advanced
+union IgcAdvTxDesc {
+    read: TxDescRead,
+    wb: TxDescWb,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct TxDescRead {
+    buffer_addr: u64, // Address of descriptor's data buf
+    cmd_type_len: u32,
+    olinfo_status: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct TxDescWb {
+    rsvd: u64, // Reserved
+    nxtseq_seed: u32,
+    status: u32,
+}
+
+/// Context descriptors
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct IgcAdvTxContextDesc {
+    vlan_macip_lens: u32,
+    ts: TxContextTS,
+    type_tucmd_mlhl: u32,
+    mss_l4len_idx: u32,
+}
+
+#[derive(Clone, Copy)]
+union TxContextTS {
+    launch_time: u32, // Launch time
+    seqnum_seed: u32, // Sequence number seed
+}
+
+/// Receive Descriptor - Advanced
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct IgcAdvRxDesc {
+    read: RxRead,
+    wb: RxWb, // writeback
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct RxRead {
+    pkt_addr: u64, // Packet buffer address
+    hdr_addr: u64, // Header buffer address
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct RxHsRss {
+    pkt_info: u16, // Packet type
+    hdr_info: u16, // Split Header, header buffer len
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct RxCsumIp {
+    ip_id: u16, // IP id
+    csum: u16,  // Packet checksum
+}
+
+#[derive(Clone, Copy)]
+union RxLoDword {
+    data: u32,
+    hs_rss: RxHsRss,
+}
+
+#[derive(Clone, Copy)]
+union RxHiDword {
+    rss: u32, // RSS hash
+    csum_ip: RxCsumIp,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct RxLower {
+    lo_dword: RxLoDword,
+    hi_dword: RxHiDword,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct RxUpper {
+    status_error: u32, // ext status/error
+    length: u16,       // Packet length
+    vlan: u16,         // VLAN tag
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct RxWb {
+    lower: RxLower,
+    upper: RxUpper,
+}
+
 /// Acquire access rights to the correct PHY.
 pub(super) fn igc_acquire_phy_base(
     ops: &dyn IgcOperations,


### PR DESCRIPTION
## Description

Define structs and unions of Tx/Rx descriptors for igc.

## Related links

-  OpenBSD's `igc_adv_tx_desc`: https://github.com/openbsd/src/blob/64a3b7d296b25e5611725cba80414db980040864/sys/dev/pci/igc_base.h#L22-L33
- OpenBSD's `igc_adv_tx_context_desc`: https://github.com/openbsd/src/blob/64a3b7d296b25e5611725cba80414db980040864/sys/dev/pci/igc_base.h#L36-L44
- OpenBSD's `igc_adv_rx_desc`: https://github.com/openbsd/src/blob/64a3b7d296b25e5611725cba80414db980040864/sys/dev/pci/igc_base.h#L93
- issue #335 

## How was this PR tested?

## Notes for reviewers
