### PR TITLE
feat: validate connent edge

### DIFF
--- a/awkernel_async_lib/src/dag.rs
+++ b/awkernel_async_lib/src/dag.rs
@@ -47,7 +47,7 @@ use alloc::{
     vec::Vec,
 };
 use awkernel_lib::sync::mutex::{MCSNode, Mutex};
-use core::{cmp::Ordering, future::Future, pin::Pin, time::Duration};
+use core::{future::Future, pin::Pin, time::Duration};
 
 #[cfg(feature = "perf")]
 use performance::ResponseInfo;
@@ -77,10 +77,10 @@ impl core::fmt::Display for DagError {
             DagError::MultipleSourceNodes(id) => write!(f, "DAG#{id} has multiple source nodes"),
             DagError::MultipleSinkNodes(id) => write!(f, "DAG#{id} has multiple sink nodes"),
             DagError::NoPublisherFound(dag_id, node_id) => {
-                write!(f, "DAG #{} Node #{}: One or more subscribed topics have no corresponding publisher", dag_id, node_id)
+                write!(f, "DAG#{dag_id} Node#{node_id}: One or more subscribed topics have no corresponding publisher")
             }
             DagError::NoSubscriberFound(dag_id, node_id) => {
-                write!(f, "DAG #{} Node #{}: One or more published topics have no corresponding subscriber", dag_id, node_id)
+                write!(f, "DAG#{dag_id} Node#{node_id}: One or more published topics have no corresponding subscriber")
             }
         }
     }


### PR DESCRIPTION
## Description
This function detects inconsistencies that exist between the DAG structure and the actual connection.

1. A situation where a reactor publishes data on a topic, but there is no reactor to subscribe to it. Computational resources are wasted and messages are lost.
2. A state in which a Reactor subscribes to a topic, but no Reactor exists to publish data to that topic. Reactors will be forever waiting for data that never arrives.


## Related links

## How was this PR tested?
I checked `test_dag` by making it run.

## Notes for reviewers
