### PR TITLE
feat(virtio): add virtio_pci_setup_queue

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/config/virtio_common_config.rs
+++ b/awkernel_drivers/src/pcie/virtio/config/virtio_common_config.rs
@@ -159,7 +159,8 @@ impl VirtioCommonConfig {
     }
 
     pub fn virtio_set_queue_enable(&mut self, enable: u16) -> Result<(), VirtioDriverErr> {
-        self.bar.write16(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_ENABLE, enable);
+        self.bar
+            .write16(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_ENABLE, enable);
 
         Ok(())
     }
@@ -179,8 +180,10 @@ impl VirtioCommonConfig {
 
         self.bar
             .write32(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DESC, addr_low);
-        self.bar
-            .write32(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DESC + 4, addr_high);
+        self.bar.write32(
+            self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DESC + 4,
+            addr_high,
+        );
 
         Ok(())
     }
@@ -192,8 +195,10 @@ impl VirtioCommonConfig {
 
         self.bar
             .write32(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DRIVER, addr_low);
-        self.bar
-            .write32(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DRIVER + 4, addr_high);
+        self.bar.write32(
+            self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DRIVER + 4,
+            addr_high,
+        );
 
         Ok(())
     }
@@ -205,8 +210,10 @@ impl VirtioCommonConfig {
 
         self.bar
             .write32(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DEVICE, addr_low);
-        self.bar
-            .write32(self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DEVICE + 4, addr_high);
+        self.bar.write32(
+            self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_DEVICE + 4,
+            addr_high,
+        );
 
         Ok(())
     }

--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -347,9 +347,10 @@ impl VirtioNetInner {
             self.common_cfg.virtio_set_queue_used(0)?;
         } else {
             let avail_offset = 4096; // TODO: offset of _avail in VirtqDMA
-            let used_offset = 8192;  // TODO: offset of _used in VirtqDMA
+            let used_offset = 8192; // TODO: offset of _used in VirtqDMA
             self.common_cfg.virtio_set_queue_desc(addr)?;
-            self.common_cfg.virtio_set_queue_avail(addr + avail_offset)?;
+            self.common_cfg
+                .virtio_set_queue_avail(addr + avail_offset)?;
             self.common_cfg.virtio_set_queue_used(addr + used_offset)?;
             self.common_cfg.virtio_set_queue_enable(1)?;
         }


### PR DESCRIPTION
## Description

Added `virtio_pci_setup_queue` function.

Also, to implement it, following 4 functions are added to `VirtioCommonConfig`
- `virtio_set_queue_enable`
- `virtio_set_queue_desc`
- `virtio_set_queue_avail`
- `virtio_set_queue_used`

## Related links

VirtIO Specification `4.1.4.3 Common configuration structure layout`
https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-270006:~:text=4.1.4.3%20Common%20configuration%20structure%20layout

OpenBSD `virtio_pci_setup_queue`
https://github.com/openbsd/src/blob/690e03dbc85956fb4adc22ce984aaad6764d5ae3/sys/dev/pci/virtio_pci.c#L259

## How was this PR tested?

## Notes for reviewers
