### PR TITLE
fix(awkernel_lib): fix clippy warnings

### DIFF
--- a/awkernel_lib/src/select/kqueue.rs
+++ b/awkernel_lib/src/select/kqueue.rs
@@ -157,24 +157,26 @@ pub(super) fn wait(timeout: Duration) {
             let raw_fd = event.ident as RawFd;
             disable_event(raw_fd, EventType::Read);
 
-            {
+            if let Some(waker) = {
                 let mut node = MCSNode::new();
                 let mut map = super::FD_TO_WAKER.lock(&mut node);
                 map.remove(&(raw_fd, EventType::Read))
+            } {
+                waker.wake()
             }
-            .map(|waker| waker.wake());
         }
 
         if event.filter == libc::EVFILT_WRITE {
             let raw_fd = event.ident as RawFd;
             disable_event(raw_fd, EventType::Write);
 
-            {
+            if let Some(waker) = {
                 let mut node = MCSNode::new();
                 let mut map = super::FD_TO_WAKER.lock(&mut node);
                 map.remove(&(raw_fd, EventType::Write))
+            } {
+                waker.wake()
             }
-            .map(|waker| waker.wake());
         }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes `clippy_std` warning
```
warning: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> awkernel_lib/src/select/kqueue.rs:160:13
    |
160 | /             {
161 | |                 let mut node = MCSNode::new();
162 | |                 let mut map = super::FD_TO_WAKER.lock(&mut node);
163 | |                 map.remove(&(raw_fd, EventType::Read))
164 | |             }
165 | |             .map(|waker| waker.wake());
    | |______________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_map_unit_fn
    = note: `#[warn(clippy::option_map_unit_fn)]` on by default
help: try
    |
160 ~             if let Some(waker) = {
161 +                 let mut node = MCSNode::new();
162 +                 let mut map = super::FD_TO_WAKER.lock(&mut node);
163 +                 map.remove(&(raw_fd, EventType::Read))
164 +             } { waker.wake() }
```

## Related links

## How was this PR tested?

## Notes for reviewers

It happens on my Macbook environment below, but I have no idea why GitHub CI is quiet.
```
$ rustc --version
rustc 1.89.0-nightly (bf64d66bd 2025-05-21)

$ rustup --version
rustup 1.28.2 (e4f3ad6f8 2025-04-28)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.89.0-nightly (bf64d66bd 2025-05-21)`

$ rustup toolchain list
stable-aarch64-apple-darwin
nightly-aarch64-apple-darwin
nightly-2025-05-22-aarch64-apple-darwin (active, default)
```