### PR TITLE
feat(dag): validate argument mismatch

### DIFF
--- a/awkernel_async_lib/src/dag.rs
+++ b/awkernel_async_lib/src/dag.rs
@@ -509,7 +509,6 @@ fn check_for_arity_mismatches(dag_id: u32) -> Result<(), Vec<DagError>> {
     };
 
     if errors.is_empty() {
-        log::debug!("OK");
         Ok(())
     } else {
         Err(errors)


### PR DESCRIPTION
## Description
This adds a feature to detect and report "arity mismatches" that occur during DAG reactor registration. An arity mismatch happens when the number of arguments indicated by the type signature does not match the number of topic names actually passed.

This includes the following changes:
- Addition of the `ArityMismatchError` enum.
- Introduction of the `TupleSize` trait.
- Checking for and recording of arity mismatches.
- Collection and reporting of errors.

## Related links

## How was this PR tested?
I checked test_dag by making it run.

Example：
```
    dag.register_sink_reactor::<_, (i32, i32)>(
        "reactor_node4".into(),
        |(a, b): (i32, i32)| {
            let value = a + b;
            if LOG_ENABLE {
                log::debug!("value={value} in reactor_node4");
            }
        },
        vec![
            Cow::from("topic3"),
            Cow::from("topic4"),
            Cow::from("topic_a"),
        ],
        SchedulerType::FIFO,
        Duration::from_secs(1),
    )
    .await;
```
```
[         5096 ERROR] /home/yutarokobayashi/awkernel/applications/tests/test_dag/src/lib.rs:103: Failed to create DAGs
[         5096 ERROR] /home/yutarokobayashi/awkernel/applications/tests/test_dag/src/lib.rs:105: - DAG#1 Node#4: Mismatch in subscribed topics and arguments
[         5097 ERROR] /home/yutarokobayashi/awkernel/applications/tests/test_dag/src/lib.rs:105: - DAG#1 Node#3: Mismatch in published topics and return values
```

## Notes for reviewers 1
Ideally, this validation would be performed within the `impl_tuple_to_pub_sub` macro in `pubsub.rs`. However, that approach only allows for post-creation validation, which would make the logic for cleaning up the related DAG data and other reactors very complex.

Another alternative is to immediately `panic` or return a `Result` from the `register_xxx` functions, but both have significant downsides:

Panicking risks leaving orphaned data in an inconsistent state, as a full cleanup within the thread is not guaranteed.
Returning a Result would make the registration API cumbersome, forcing users to handle errors on every single call.
Also, the `finish_create_dags()` function assumes all DAGs in its arguments are present. Therefore, if a target DAG is removed, it will `panic` at an `assert` rather than handling it gracefully.
Furthermore, if the user fails to implement error handling, the program will continue as if nothing is wrong, leading to a silent failure.

## Notes for reviewers 2
The `impl_tuple_size` macro is used because the operation is simple (returning the number of tuple elements) and this approach allows for easy extension to support larger tuples.