### PR TITLE
feat(filesystem): Add InMemoryDisk struct

### DIFF
--- a/awkernel_lib/src/file.rs
+++ b/awkernel_lib/src/file.rs
@@ -1,3 +1,4 @@
 pub mod error;
 pub mod fatfs;
 pub mod io;
+pub mod memfs;


### PR DESCRIPTION
## Description
Added InMemoryStruct for later use in PR #483.

To use the fatfs library, it's necessary to provide a data structure that implements the Read, Write, and Seek traits. Typically, a device driver for a storage device would fulfill this role. However, to use the filesystem in memory for now, we will implement these traits on an InMemoryDisk struct that simply wraps a Vec.
## Related links
#483 

## How was this PR tested?

## Notes for reviewers
