### PR TITLE
feat(virtio): add msix vector setters

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/config/virtio_common_config.rs
+++ b/awkernel_drivers/src/pcie/virtio/config/virtio_common_config.rs
@@ -33,9 +33,11 @@ const VIRTIO_PCI_COMMON_CFG_DEVICE_FEATURE_SELECT: usize = 0x00;
 const VIRTIO_PCI_COMMON_CFG_DEVICE_FEATURE: usize = 0x04;
 const VIRTIO_PCI_COMMON_CFG_DRIVER_FEATURE_SELECT: usize = 0x08;
 const VIRTIO_PCI_COMMON_CFG_DRIVER_FEATURE: usize = 0x0c;
+const VIRTIO_PCI_COMMON_CFG_CONFIG_MSIX_VECTOR: usize = 0x10;
 const VIRTIO_PCI_COMMON_CFG_DEVICE_STATUS: usize = 0x14;
 const VIRTIO_PCI_COMMON_CFG_QUEUE_SELECT: usize = 0x16;
 const VIRTIO_PCI_COMMON_CFG_QUEUE_SIZE: usize = 0x18;
+const VIRTIO_PCI_COMMON_CFG_QUEUE_MSIX_VECTOR: usize = 0x1a;
 const VIRTIO_PCI_COMMON_CFG_QUEUE_ENABLE: usize = 0x1c;
 const VIRTIO_PCI_COMMON_CFG_QUEUE_NOTIFY_OFF: usize = 0x1e;
 const VIRTIO_PCI_COMMON_CFG_QUEUE_DESC: usize = 0x20;
@@ -122,6 +124,15 @@ impl VirtioCommonConfig {
             .write32(self.offset + VIRTIO_PCI_COMMON_CFG_DRIVER_FEATURE, high);
     }
 
+    pub fn virtio_set_config_msix_vector(&mut self, vector: u16) -> Result<(), VirtioDriverErr> {
+        self.bar.write16(
+            self.offset + VIRTIO_PCI_COMMON_CFG_CONFIG_MSIX_VECTOR,
+            vector,
+        );
+
+        Ok(())
+    }
+
     pub fn virtio_get_device_status(&self) -> Result<u8, VirtioDriverErr> {
         let status = self
             .bar
@@ -156,6 +167,15 @@ impl VirtioCommonConfig {
             .ok_or(VirtioDriverErr::ReadFailure)?;
 
         Ok(size)
+    }
+
+    pub fn virtio_set_queue_msix_vector(&mut self, vector: u16) -> Result<(), VirtioDriverErr> {
+        self.bar.write16(
+            self.offset + VIRTIO_PCI_COMMON_CFG_QUEUE_MSIX_VECTOR,
+            vector,
+        );
+
+        Ok(())
     }
 
     pub fn virtio_set_queue_enable(&mut self, enable: u16) -> Result<(), VirtioDriverErr> {

--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -368,6 +368,19 @@ impl VirtioNetInner {
         self.common_cfg.virtio_get_queue_size()
     }
 
+    fn _virtio_pci_set_msix_config_vector(&mut self, vector: u16) -> Result<(), VirtioDriverErr> {
+        self.common_cfg.virtio_set_config_msix_vector(vector)
+    }
+
+    fn _virtio_pci_set_msix_queue_vector(
+        &mut self,
+        idx: u16,
+        vector: u16,
+    ) -> Result<(), VirtioDriverErr> {
+        self.common_cfg.virtio_set_queue_select(idx)?;
+        self.common_cfg.virtio_set_queue_msix_vector(vector)
+    }
+
     fn _virtio_pci_kick(&mut self, idx: u16) -> Result<(), VirtioDriverErr> {
         let offset = self.common_cfg.virtio_get_queue_notify_off()? as usize
             * self.notify_cap.virtio_get_notify_off_multiplier()? as usize;


### PR DESCRIPTION
## Description

Added
- `virtio_pci_set_msix_config_vector`
- `virtio_pci_set_msix_queue_vector`

## Related links

OpenBSD `virtio_pci_set_msix_config_vector`
https://github.com/openbsd/src/blob/42cfcc5e5a44b4af2928048b3d88f2fbe7f51f28/sys/dev/pci/virtio_pci.c#L1018

OpenBSD `virtio_pci_set_msix_queue_vector`
https://github.com/openbsd/src/blob/42cfcc5e5a44b4af2928048b3d88f2fbe7f51f28/sys/dev/pci/virtio_pci.c#L1004

## How was this PR tested?

## Notes for reviewers
