### PR TITLE
fix(igc): call `igc_setup_copper_link_generic()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc/i225.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/i225.rs
@@ -4,8 +4,8 @@ use crate::pcie::{
     intel::igc::{
         igc_mac::igc_config_fc_after_link_up_generic,
         igc_phy::{
-            igc_check_downshift_generic, igc_phy_has_link_generic, IGC_I225_PHPM,
-            IGC_I225_PHPM_GO_LINKD,
+            igc_check_downshift_generic, igc_phy_has_link_generic, igc_setup_copper_link_generic,
+            IGC_I225_PHPM, IGC_I225_PHPM_GO_LINKD,
         },
     },
     PCIeInfo,
@@ -867,5 +867,5 @@ fn igc_setup_copper_link_i225(
     phpm_reg &= !IGC_I225_PHPM_GO_LINKD; // Clear the go link down bit
     write_reg(info, IGC_I225_PHPM, phpm_reg)?;
 
-    igc_setup_link_generic(ops, info, hw)
+    igc_setup_copper_link_generic(ops, info, hw)
 }

--- a/awkernel_drivers/src/pcie/intel/igc/igc_phy.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_phy.rs
@@ -585,7 +585,7 @@ fn igc_wait_autoneg(
 /// speed and duplex.  Then we check for link, once link is established calls
 /// to configure collision distance and flow control are called.  If link is
 /// not established, we return -IGC_ERR_PHY (-2).
-fn igc_setup_copper_link_generic(
+pub(super) fn igc_setup_copper_link_generic(
     ops: &dyn IgcOperations,
     info: &mut PCIeInfo,
     hw: &mut IgcHw,


### PR DESCRIPTION
## Description

`igc_setup_copper_link_generic()` must be called instead of `igc_setup_link_generic()` in `igc_setup_copper_link_i225()`.

## Related links

- OpenBSD's `igc_setup_copper_link_i225()`: https://github.com/openbsd/src/blob/45ccd79b6758f50ac1edfdaac64135aa43e06183/sys/dev/pci/igc_i225.c#L362
- issue #335 

## How was this PR tested?

## Notes for reviewers
