### PR TITLE
fix(igc): link down is not error

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc/igc_phy.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/igc_phy.rs
@@ -604,8 +604,8 @@ pub(super) fn igc_setup_copper_link_generic(
 
     if link {
         ops.config_collision_dist(info, hw)?;
-        igc_config_fc_after_link_up_generic(ops, info, hw)
-    } else {
-        Err(IgcDriverErr::Phy)
+        igc_config_fc_after_link_up_generic(ops, info, hw)?;
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Description

When an IGC link goes down, the previous implementation returned an error; however, link down is not considered an error.

## Related links

- OpenBSD's `igc_setup_copper_link_generic`: https://github.com/openbsd/src/blob/1652017d6445239d16d30595e2f912b7e1d23fcc/sys/dev/pci/igc_phy.c#L560-L567
- issue #335 

## How was this PR tested?

## Notes for reviewers
