### PR TITLE
feat(igc): implement `igc_set_queues()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -747,7 +747,6 @@ fn igc_set_queues(
                 ivar &= 0x00FFFFFF;
                 ivar |= (vector | igc_defines::IGC_IVAR_VALID) << 24;
             } else {
-                // Rx even
                 ivar &= 0xFFFF00FF;
                 ivar |= (vector | igc_defines::IGC_IVAR_VALID) << 8;
             }


### PR DESCRIPTION
## Description

Implement `igc_set_queues()`.

## Related links

- OpenBSD's `igc_set_queues()`: https://github.com/openbsd/src/blob/c8a32696b4e4595ecb6be82f64a8437903e801c2/sys/dev/pci/if_igc.c#L1733
- FreeBSD's `igc_configure_queues()`: https://github.com/freebsd/freebsd-src/blob/1873f2a5fd4111476cf1fb03654c9a95df98f1b5/sys/dev/igc/if_igc.c#L1610-L1639
- issue #335 

## How was this PR tested?

## Notes for reviewers

The IVARx registers specify the MSI-X interrupt entries. These registers contain the following information. For example, if `IVAR0 = 0b00000000_00000000_00000000_00000010`, the interrupt for RXQ0 is mapped to entry No. 2 in the MSI-X table.

### IVAR0

| bits | description | queue
|-- | -- | --
|6:0 | Vector (Tx Queue 0) | RXQ0
|7 | Are 6:0 bits valid/enabled? |
|14:8 | Vector (Rx Queue 0) | TXQ0
|15 | Are 14:8 bits valid/enabled? |
|22:16 | Vector (Tx Queue 1) | RXQ1
|23 | Are 22:16 bits valid/enabled? |
|30:24 | Vector (Rx Queue 1) | TXQ1
|31 | Are 30:24 bits valid/enabled? |

### IVAR1

| bits | description | queue
|-- | -- | --
|6:0 | Vector (Tx Queue 2) | RXQ2
|7 | Are 6:0 bits valid/enabled? |
|14:8 | Vector (Rx Queue 2) | TXQ2
|15 | Are 14:8 bits valid/enabled? |
|22:16 | Vector (Tx Queue 3) | RXQ3
|23 | Are 22:16 bits valid/enabled? |
|30:24 | Vector (Rx Queue 3) | TXQ3
|31 | Are 30:24 bits valid/enabled? |

IVAR3 and IVAR4 are same as IVAR0 and IVAR1.

</body></html>