### PR TITLE
feat(igc): implement `igc_stop()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -628,10 +628,10 @@ impl IgcInner {
         self.if_flags.remove(NetFlags::RUNNING);
 
         // Disable interrupts.
-        igc_disable_intr(&mut self.info, &mut self.hw)?;
+        igc_disable_intr(&mut self.info)?;
 
         self.ops.reset_hw(&mut self.info, &mut self.hw)?;
-        write_reg(&mut self.info, IGC_WUC, 0)?;
+        write_reg(&self.info, IGC_WUC, 0)?;
 
         // TODO: Free transmit and receive structures.
 
@@ -874,7 +874,7 @@ fn igc_set_queues(
     Ok(())
 }
 
-fn igc_disable_intr(info: &mut PCIeInfo, hw: &mut IgcHw) -> Result<(), IgcDriverErr> {
+fn igc_disable_intr(info: &mut PCIeInfo) -> Result<(), IgcDriverErr> {
     use igc_regs::*;
 
     write_reg(info, IGC_EIMC, 0xffffffff)?;


### PR DESCRIPTION
## Description

Implement `igc_stop()` and `igc_disable_intr()` to stop an igc device.

Note that OpenBSD removes and waits threads to handle interrupts as follows, but Awkenel does not need to it because Awkernel acquires mutual exclusion when handling IRQs and stopping the device.

https://github.com/openbsd/src/blob/b38eaba60654ec6b523c64ac5243d89896ee0b6c/sys/dev/pci/if_igc.c#L1148-L1157

```c
	intr_barrier(sc->tag);
        for (i = 0; i < sc->sc_nqueues; i++) {
                struct ifqueue *ifq = ifp->if_ifqs[i];
                ifq_barrier(ifq);
                ifq_clr_oactive(ifq);

                if (sc->queues[i].tag != NULL)
                        intr_barrier(sc->queues[i].tag);
                timeout_del(&sc->rx_rings[i].rx_refill);
        }
```

## Related links

- OpenBSD's `igc_stop()`: https://github.com/openbsd/src/blob/b38eaba60654ec6b523c64ac5243d89896ee0b6c/sys/dev/pci/if_igc.c#L1135
- OpenBSD's `igc_disable_intr()`: https://github.com/openbsd/src/blob/b38eaba60654ec6b523c64ac5243d89896ee0b6c/sys/dev/pci/if_igc.c#L1781
- isssu #335 

## How was this PR tested?

## Notes for reviewers
