### PR TITLE
feat(virtio): get speed and duplex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ QEMU_X86_NET_ARGS+= -netdev user,id=net0,hostfwd=udp::4445-:2000
 QEMU_X86_NET_ARGS+= -device e1000e,netdev=net0,mac=12:34:56:11:22:33
 QEMU_X86_NET_ARGS+= -object filter-dump,id=net0,netdev=net0,file=packets_net0.pcap
 QEMU_X86_NET_ARGS+= -netdev user,id=net1,hostfwd=udp::4446-:2001
-QEMU_X86_NET_ARGS+= -device virtio-net-pci,netdev=net1,mac=12:34:56:11:22:34,disable-legacy=on,disable-modern=off
+QEMU_X86_NET_ARGS+= -device virtio-net-pci,netdev=net1,mac=12:34:56:11:22:34,disable-legacy=on,disable-modern=off,speed=1000,duplex=full
 QEMU_X86_NET_ARGS+= -object filter-dump,id=net1,netdev=net1,file=packets_net1.pcap
 
 tcp-dump:

--- a/awkernel_drivers/src/pcie/virtio/config/virtio_net_config.rs
+++ b/awkernel_drivers/src/pcie/virtio/config/virtio_net_config.rs
@@ -17,6 +17,8 @@ use crate::pcie::{capability::virtio::VirtioCap, virtio::VirtioDriverErr, BaseAd
 
 const VIRTIO_NET_CONFIG_MAC: usize = 0x00;
 const VIRTIO_NET_CONFIG_STATUS: usize = 0x06;
+const VIRTIO_NET_CONFIG_SPEED: usize = 0x0C;
+const VIRTIO_NET_CONFIG_DUPLEX: usize = 0x10;
 
 pub struct VirtioNetConfig {
     bar: BaseAddress,
@@ -66,5 +68,23 @@ impl VirtioNetConfig {
             .ok_or(VirtioDriverErr::ReadFailure)?;
 
         Ok(status)
+    }
+
+    pub fn virtio_get_speed(&self) -> Result<u32, VirtioDriverErr> {
+        let speed = self
+            .bar
+            .read32(self.offset + VIRTIO_NET_CONFIG_SPEED)
+            .ok_or(VirtioDriverErr::ReadFailure)?;
+
+        Ok(speed)
+    }
+
+    pub fn virtio_get_duplex(&self) -> Result<u8, VirtioDriverErr> {
+        let duplex = self
+            .bar
+            .read8(self.offset + VIRTIO_NET_CONFIG_DUPLEX)
+            .ok_or(VirtioDriverErr::ReadFailure)?;
+
+        Ok(duplex)
     }
 }


### PR DESCRIPTION
## Description

Added `speed=1000,duplex=full` in `QEMU_X86_NET_ARGS` so that virtio-net driver can get speed and duplex infomation from net-config space.
Changed `link_speed()` and `link_speed()` to get the actual values from configuration spaces.

## Related links

ViotIO Specification `5.1.4 Device configuration layout`
https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1220001:~:text=The%20following%20two%20fields,for%20unknown%20duplex%20state.

OpenBSD does not have similar functionality.
FreeBSD have one, but not completely the same: https://github.com/freebsd/freebsd-src/blob/6039cd1b45eb847ef5bbe6c58341b8b92fff8a74/sys/dev/virtio/network/if_vtnet.c#L3934

## How was this PR tested?

Tested in https://github.com/tier4/awkernel/pull/465
```
> (ifconfig)
[1] virtio-net:
    IPv4 address: 10.0.2.64/24
    IPv4 gateway: None
    MAC address: 12:34:56:11:22:34
    Link status: Up (Full Duplex), Link speed: 1000 Mbps
    Capabilities: 
    IRQs: [65, 66, 67]
    Poll mode: false
```

## Notes for reviewers

I am not sure what to return when speed/duplex could not obtained.