### PR TITLE
feat(dag): verify duplicate topic subscriptions and publications from the same reactor

### DIFF
--- a/awkernel_async_lib/src/dag.rs
+++ b/awkernel_async_lib/src/dag.rs
@@ -670,7 +670,7 @@ pub async fn finish_create_dags(dags: &[Arc<Dag>]) -> Result<(), Vec<DagError>> 
             errors.extend(arg_errors.into_iter());
         } else if let Err(dag_validation_error) = validate_dag(dag) {
             errors.push(dag_validation_error);
-        } else if let Err(pubsub_duplicate_errors) = chec_for_pubsub_duplicate(dag.id) {
+        } else if let Err(pubsub_duplicate_errors) = check_for_pubsub_duplicate(dag.id) {
             errors.extend(pubsub_duplicate_errors);
         }
     }


### PR DESCRIPTION
## Description
Implementation of the functionality to validate that a single reactor subscribes or publishes the same topic multiple times.

## Related links
#500 

## How was this PR tested?


## Notes for reviewers

- I noticed that the comment for `check_for_arity_mismatches()` is not a proper doc comment. I'll submit a PR to fix it shortly."
- I removed the comment on the `DagError` tuple because it makes more sense when you look at the `Display` trait.