### PR TITLE
feat(igc): implement `igc_enable_intr()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -888,6 +888,8 @@ fn igc_enable_intr(
     write_reg(info, IGC_EIAM, mask)?;
     write_reg(info, IGC_EIMS, mask)?;
     write_reg(info, IGC_IMS, IGC_IMS_LSC)?;
+    write_flush(info)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description

implement `igc_enable_intr()`.

## Related links

- OpenBSD's `igc_enable_intr()`: https://github.com/openbsd/src/blob/46c686c36300616c9603e4e05f394b76d7949207/sys/dev/pci/if_igc.c#L1767
-  issue #335 

## How was this PR tested?

## Notes for reviewers
