### PR TITLE
feat(dag): add validation for single publisher per topic

### DIFF
--- a/awkernel_async_lib/src/dag.rs
+++ b/awkernel_async_lib/src/dag.rs
@@ -160,7 +160,6 @@ struct NodeInfo {
     relative_deadline: Option<Duration>,
 }
 
-#[allow(dead_code)] // TODO: remove this later
 struct EdgeInfo {
     topic_name: Cow<'static, str>,
 }


### PR DESCRIPTION
## Description
A `validate_single_publisher_per_topic` function has been added to check if a topic has been published by more than one publisher.

## Related links
#500 

## How was this PR tested?
I checked `test_dag` by making it run.

## Notes for reviewers
Design Choice: The "one publisher per topic" rule is an intentional design choice for now to keep the system simple. As noted in the code comments, we may need to relax this restriction in the future to support use cases like multiple reactors publishing to a common diagnostics topic. 