### PR TITLE
fix(igb): fix lock of queue of igb

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igb.rs
+++ b/awkernel_drivers/src/pcie/intel/igb.rs
@@ -283,14 +283,6 @@ struct IgbInner {
 
 /// Intel Gigabit Ethernet Controller driver
 pub struct Igb {
-    // The order of lock acquisition must be as follows:
-    //
-    // 1. `IgbInner`'s lock
-    // 2. `Queue`'s lock
-    // 3. `Queue`'s unlock
-    // 4. `IgbInner`'s unlock
-    //
-    // Otherwise, a deadlock will occur.
     inner: RwLock<IgbInner>,
 }
 


### PR DESCRIPTION
## Description

In the interrupt handler of `igb.rs`, it checks whether the device is in the `Running` state before calling `rx_recv()`. To check the status, it locks `IgbInner` and releases it before calling `rx_recv()`, as shown below.

https://github.com/tier4/awkernel/blob/c7e3d061cba7a8871a86002c1e34c94706518c1f/awkernel_drivers/src/pcie/intel/igb.rs#L1555-L1557

In `rx_recv()`, the lock is immediately acquired again.

https://github.com/tier4/awkernel/blob/c7e3d061cba7a8871a86002c1e34c94706518c1f/awkernel_drivers/src/pcie/intel/igb.rs#L1192-L1193

However, the state may be updated between releasing and reacquiring the lock.

To fix this, this PR updates the design so that `IgbInner` holds the `Queue` instead of `Igb`.

## Related links

## How was this PR tested?

## Notes for reviewers
