### PR TITLE
feat: add preemption logic into PrioritizedFIFOScheduler

### DIFF
--- a/awkernel_async_lib/src/scheduler/prioritized_fifo.rs
+++ b/awkernel_async_lib/src/scheduler/prioritized_fifo.rs
@@ -1,8 +1,11 @@
 //! A prioritized FIFO scheduler.
 
 use super::{Scheduler, SchedulerType, Task};
+use crate::task::{get_scheduler_type_by_task_id, get_tasks_running, set_need_preemption};
 use crate::{scheduler::get_priority, task::State};
 use alloc::sync::Arc;
+use alloc::vec::Vec;
+use awkernel_lib::cpu::num_cpu;
 use awkernel_lib::priority_queue::PriorityQueue;
 use awkernel_lib::sync::mutex::{MCSNode, Mutex};
 
@@ -30,40 +33,27 @@ impl PrioritizedFIFOData {
 
 impl Scheduler for PrioritizedFIFOScheduler {
     fn wake_task(&self, task: Arc<Task>) {
+        let priority = {
+            let mut node = MCSNode::new();
+            let info = task.info.lock(&mut node);
+            match info.scheduler_type {
+                SchedulerType::PrioritizedFIFO(p) => p,
+                _ => unreachable!(),
+            }
+        };
+
         let mut node = MCSNode::new();
         let mut data = self.data.lock(&mut node);
+        let internal_data = data.get_or_insert_with(PrioritizedFIFOData::new);
+        internal_data.queue.push(
+            priority as u32,
+            PrioritizedFIFOTask {
+                task: task.clone(),
+                _priority: priority,
+            },
+        );
 
-        if let Some(data) = data.as_mut() {
-            let mut node = MCSNode::new();
-            let info = task.info.lock(&mut node);
-            let SchedulerType::PrioritizedFIFO(priority) = info.scheduler_type else {
-                return;
-            };
-
-            data.queue.push(
-                priority as u32,
-                PrioritizedFIFOTask {
-                    task: task.clone(),
-                    _priority: priority,
-                },
-            );
-        } else {
-            let mut prioritized_fifo_data = PrioritizedFIFOData::new();
-            let mut node = MCSNode::new();
-            let info = task.info.lock(&mut node);
-            let SchedulerType::PrioritizedFIFO(priority) = info.scheduler_type else {
-                return;
-            };
-
-            prioritized_fifo_data.queue.push(
-                priority as u32,
-                PrioritizedFIFOTask {
-                    task: task.clone(),
-                    _priority: priority,
-                },
-            );
-            *data = Some(prioritized_fifo_data);
-        }
+        self.invoke_preemption(priority);
     }
 
     fn get_next(&self) -> Option<Arc<Task>> {
@@ -105,6 +95,40 @@ impl Scheduler for PrioritizedFIFOScheduler {
 
     fn priority(&self) -> u8 {
         self.priority
+    }
+}
+
+impl PrioritizedFIFOScheduler {
+    fn invoke_preemption(&self, priority: u8) {
+        let tasks_running = get_tasks_running()
+            .into_iter()
+            .filter(|task| task.task_id != 0)
+            .collect::<Vec<_>>();
+
+        // If the number of running tasks is less than the number of non-primary CPUs, preempt is not required.
+        if tasks_running.len() < num_cpu() - 1 {
+            return;
+        }
+
+        let lowest_priority_running_task = tasks_running
+            .iter()
+            .filter_map(|task| {
+                get_scheduler_type_by_task_id(task.task_id).and_then(|scheduler_type| {
+                    match scheduler_type {
+                        SchedulerType::PrioritizedFIFO(p) => Some((task, p)),
+                        _ => None, // TODO: Inter-scheduler preemption is not supported yet.
+                    }
+                })
+            })
+            .max_by_key(|(_, p)| *p);
+
+        if let Some((task, lowest_priority)) = lowest_priority_running_task {
+            if priority < lowest_priority {
+                let preempt_irq = awkernel_lib::interrupt::get_preempt_irq();
+                set_need_preemption(task.task_id, task.cpu_id);
+                awkernel_lib::interrupt::send_ipi(preempt_irq, task.cpu_id as u32);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This adds the preemption logic into `PrioritizedFIFOScheduler`.

## Related links

[Why is this needed?](https://star4.slack.com/archives/C054R6DL5KL/p1748324432416939)

## How was this PR tested?

## Notes for reviewers

As shown in [this PR](https://github.com/tier4/awkernel/pull/457), the current implementation includes the priority inversion.
