### PR TITLE
feat(igc): implement `igc_initialize_transmit_unit()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -986,6 +986,7 @@ fn igc_initialize_transmit_unit(info: &PCIeInfo, queues: &[Queue]) -> Result<(),
         txdctl |= 0x1f; // PTHRESH
         txdctl |= 1 << 8; // HTHREASH
         txdctl |= 1 << 16; // WTHREASH
+        txdctl |= 1 << 22; // Reserved bit 22 must always be 1
         txdctl |= IGC_TXDCTL_GRAN;
         txdctl |= 1 << 25; // LWTHREASH
 


### PR DESCRIPTION
## Description

Implement `igc_initialize_transmit_unit()`.

## Related links

- OpenBSD's `igc_initialize_transmit_unit()`: https://github.com/openbsd/src/blob/31f40ba0014770901f856e06fc0a9f52cd8bb19b/sys/dev/pci/if_igc.c#L1928
- issue #335 

## How was this PR tested?

## Notes for reviewers

Variables for timers, `watchdog_timer` and `if_timer` , are not needed by Awkernel