### PR TITLE
feat(filesystem): add async filesystem trait

### DIFF
--- a/awkernel_async_lib/src/file/filesystem.rs
+++ b/awkernel_async_lib/src/file/filesystem.rs
@@ -4,7 +4,7 @@ use crate::time::Time;
 use alloc::{boxed::Box, string::String};
 use async_trait::async_trait;
 use awkernel_lib::file::{
-    error::{Error, IoError},
+    error::IoError,
     io::SeekFrom,
     vfs::error::{VfsError, VfsErrorKind, VfsResult},
     vfs::path::VfsMetadata,
@@ -28,6 +28,8 @@ pub trait AsyncSeekAndRead<E: IoError>: Send + Unpin {
                 Err(e) => return Err(e),
             }
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description
Provide async filesystem trait for no_std environment. 

Since async Read, Write, Seek trait cannot be used in no_std environment, I've defined these traits myself in this file: AsyncSeekAndRead, AsyncSeekAndWrite. This may be replaced with embedded_io_async::{Read, Write, Seek} traits but since there will be a lot to fix, and since embedded-io-async doesn't seem stable yet, I've defined these myself for now. (I've already tried using embedded_io_async and it seems working. It will be merged in the near future.)

## Related links
PR #511 

## How was this PR tested?

## Notes for reviewers
