### PR TITLE
fix(filesystem): added trait bound for IoError

### DIFF
--- a/awkernel_lib/src/file/error.rs
+++ b/awkernel_lib/src/file/error.rs
@@ -1,5 +1,5 @@
 /// Trait that should be implemented by errors returned from the user supplied storage.
-pub trait IoError: core::fmt::Debug {
+pub trait IoError: core::fmt::Debug + Clone + Send + Sync + 'static {
     fn is_interrupted(&self) -> bool;
     fn new_unexpected_eof_error() -> Self;
     fn new_write_zero_error() -> Self;

--- a/awkernel_lib/src/file/memfs.rs
+++ b/awkernel_lib/src/file/memfs.rs
@@ -70,7 +70,7 @@ impl Seek for InMemoryDisk {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum InMemoryDiskError {
     OutOfBounds,
     WriteZero,


### PR DESCRIPTION
## Description
Added trait bound of Clone, Sync, Send, and 'static for IoError.
Since the Error type that implements this IoError trait will be used in async func, each of the Error type has to live until the Future is completed.

## Related links
#511 

## How was this PR tested?

## Notes for reviewers
