### PR TITLE
feat(igc): implement `igc_rxfill()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -86,7 +86,7 @@ pub enum IgcDriverErr {
     Param,
     Phy,
     Config,
-    DMAPool,
+    DmaPoolAlloc,
 }
 
 type RxRing = [IgcAdvRxDesc; IGC_DEFAULT_RXD];
@@ -1045,7 +1045,7 @@ impl Rx {
             info.segment_group as usize,
             core::mem::size_of::<RxBuffer>() / PAGESIZE,
         )
-        .ok_or(IgcDriverErr::DMAPool)?;
+        .ok_or(IgcDriverErr::DmaPoolAlloc)?;
         self.read_buf = Some(read_buf);
 
         Ok(())
@@ -1056,7 +1056,7 @@ impl Rx {
         let mut post = false;
 
         let Some(read_buf) = self.read_buf.as_mut() else {
-            return Err(IgcDriverErr::DMAPool);
+            return Err(IgcDriverErr::DmaPoolAlloc);
         };
 
         while self.slots > 0 {


### PR DESCRIPTION
## Description

Implement `igc_rxfill()` to initialize RX descriptors.
To receive Ethernet frames, this PR also introduce `read_buf: Option<DMAPool<RxBuffer>>` in `Rx` strucutre.

This code is based on OpenBSD's `igc_rxfil()`, but it is not completely same as the original.

Important fields:

- `Rx::slots`: the number of uninitialized RX descriptors
- `Rx::rx_desc_ring`: receive buffer
- `Rx::last_desc_filled`: the index of the last initialized RX descriptor

## Related links

- OpenBSD's `igc_rxfill()`: https://github.com/openbsd/src/blob/0c66559787bc10823c8332a71a95f4d121c539c4/sys/dev/pci/if_igc.c#L1248
- issue #335 

## How was this PR tested?

## Notes for reviewers
