### PR TITLE
feat(igc): implement `igc_set_eee_i225()`

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc/i225.rs
+++ b/awkernel_drivers/src/pcie/intel/igc/i225.rs
@@ -912,7 +912,7 @@ fn igc_set_eee_i225(
             ipcnfg &= !IGC_IPCNFG_EEE_2_5G_AN;
         }
 
-        eeer |= (IGC_EEER_TX_LPI_EN | IGC_EEER_RX_LPI_EN | IGC_EEER_LPI_FC);
+        eeer |= IGC_EEER_TX_LPI_EN | IGC_EEER_RX_LPI_EN | IGC_EEER_LPI_FC;
 
         // This bit should not be set in normal operation.
         if eee_su & IGC_EEE_SU_LPI_CLK_STP != 0 {


### PR DESCRIPTION
## Description

Implement `igc_set_eee_i225()`.

## Related links

- OpenBSD's `igc_set_eee_i225()`: https://github.com/openbsd/src/blob/6cb1de419d8c8f0fb2c1135406d00d0dad3a5d78/sys/dev/pci/igc_i225.c#L1111
- issue #335 

## How was this PR tested?

## Notes for reviewers
