### PR TITLE
feat(virtio): enable VIRTIO_NET_F_MRG_RXBUF

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -258,7 +258,9 @@ impl Virtq {
             let header = unsafe { &*(header.as_ptr() as *const VirtioNetHdr) };
 
             if header.num_buffers > 1 {
-                log::error!("virtio-net: num_buffers > 1. Receipt of large packets is not supported");
+                log::error!(
+                    "virtio-net: num_buffers > 1. Receipt of large packets is not supported"
+                );
                 break;
             }
 
@@ -554,7 +556,9 @@ impl VirtioNetInner {
 
         self.active_features = negotiated_features;
 
-        if negotiated_features & VIRTIO_F_VERSION_1 == 0 || negotiated_features & VIRTIO_NET_F_MRG_RXBUF == 0 {
+        if negotiated_features & VIRTIO_F_VERSION_1 == 0
+            || negotiated_features & VIRTIO_NET_F_MRG_RXBUF == 0
+        {
             self.common_cfg
                 .virtio_set_device_status(VIRTIO_CONFIG_DEVICE_STATUS_FAILED)?;
             return Err(VirtioDriverErr::InitFailure);


### PR DESCRIPTION
## Description

Enabled `VIRTIO_NET_F_MRG_RXBUF` in virtio-net.
This feature enables drivers to merge receive buffers, which allows receipt of large packets without having to allocate large buffers: a packet that does not fit in a single buffer can flow over to the next buffer, and so on.

This is enabled to avoid KVM bug which is written in OpenBSD when `VIRTIO_NET_F_MRG_RXBUF` is not negotiated
https://github.com/openbsd/src/blob/bc55f572b2c558c1ee20e64f8adf89f596386136/sys/dev/pv/if_vio.c#L1431
```
                if (mrg_rxbuf) {
			virtio_enqueue(vq, slot, vioq->viq_rxdmamaps[slot], 0);
		} else {
			/*
			 * Buggy kvm wants a buffer of exactly the size of
			 * the header in this case, so we have to split in
			 * two.
			 */
			virtio_enqueue_p(vq, slot, vioq->viq_rxdmamaps[slot],
			    0, sc->sc_hdr_size, 0);
			virtio_enqueue_p(vq, slot, vioq->viq_rxdmamaps[slot],
			    sc->sc_hdr_size,
			    sc->sc_rx_mbuf_size - sc->sc_hdr_size, 0);
		}
```

## Related links

VirtIO Specification
https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html

OpenBSD
https://github.com/openbsd/src/blob/master/sys/dev/pv/if_vio.c

## How was this PR tested?

Tested network sample application on qemu-x86.
Not tested on kvm/qemu.

## Notes for reviewers
