### PR TITLE
fix(virtio): set speed and duplex properly

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -881,36 +881,15 @@ impl NetDevice for VirtioNet {
             }
         }
 
-        let duplex = inner.net_cfg.virtio_get_duplex();
-        match duplex {
+        match inner.net_cfg.virtio_get_duplex() {
             Ok(0x00) => LinkStatus::UpHalfDuplex,
-            Ok(0x01) => LinkStatus::UpFullDuplex,
-            Ok(0xff) => {
-                log::warn!("virtio-net: duplex is unknown");
-                LinkStatus::Unknown
-            }
-            _ => {
-                log::warn!("virtio-net: cannot get duplex");
-                LinkStatus::Down
-            }
+            _ => LinkStatus::UpFullDuplex,
         }
     }
 
     fn link_speed(&self) -> u64 {
         let inner = self.inner.read();
-        let speed = inner.net_cfg.virtio_get_speed();
-
-        match speed {
-            Ok(0xffffffff) => {
-                log::warn!("virtio-net: speed is unknown");
-                0
-            }
-            Ok(speed) => speed as u64,
-            _ => {
-                log::warn!("virtio-net: cannot get speed");
-                0
-            }
-        }
+        inner.net_cfg.virtio_get_speed().unwrap_or(0) as u64
     }
 
     fn mac_address(&self) -> [u8; 6] {


### PR DESCRIPTION
## Description

I fount that KVM does not offer `VIRTIO_NET_F_SPEED_DUPLEX`, which means the driver cannot report speed and duplex.
So, I changed it to work without errors even when `VIRTIO_NET_F_SPEED_DUPLEX` is not negotiated.

## Related links

VirtIO Specification `5.1.4.2 Driver Requirements: Device configuration layout`
https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-1220001:~:text=5.1.4.2%20Driver%20Requirements%3A%20Device%20configuration%20layout

There is no corresponding code in OpenBSD.

## How was this PR tested?

QEMU x86_64

## Notes for reviewers
