### PR TITLE
feat(virtio): add VIRTIO_F_EVENT_IDX

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -1145,13 +1145,11 @@ impl NetDevice for VirtioNet {
             tx.vio_start(&data);
         }
 
-        {
-            let mut inner = self.inner.write();
-            let tx_vq_index = (que_id * 2 + 1) as u16;
-            inner
-                .virtio_notify(tx_vq_index)
-                .or(Err(NetDevError::DeviceError))?;
-        }
+        let tx_vq_index = (que_id * 2 + 1) as u16;
+        let mut inner = self.inner.write();
+        inner
+            .virtio_notify(tx_vq_index)
+            .or(Err(NetDevError::DeviceError))?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Enabled `VIRTIO_F_EVENT_IDX` feature.
This feature enables the `used_event` and the `avail_event` fields and suppresses user buffer notifications.

To smartly suppress the notifications between device/driver, the following new functions are added
- virtio_postpone_intr
- virtio_postpone_intr_smart
- virtio_postpone_intr_far
- virtio_notify

## Related links

VirtIO Specification `2.7.7 Used Buffer Notification Suppression`
https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-510007:~:text=to%20%E2%80%9Cunexpose%E2%80%9D%20buffers).-,2.7.7%20Used%20Buffer%20Notification%20Suppression

OpenBSD `virtio_postpone_intr`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/virtio.c#L908

OpenBSD `virtio_postpone_intr_smart`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/virtio.c#L932

OpenBSD `virtio_postpone_intr_far`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/virtio.c#L946C1-L946C25

OpenBSD `virtio_stop_vq_intr`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/virtio.c#L960C1-L960C20

OpenBSD `virtio_start_vq_intr`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/virtio.c#L980C1-L980C21

OpenBSD `virtio_enqueue_commit` is the base for `virtio_notify`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/virtio.c#L755-L776

OpenBSD `vio_attach`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/if_vio.c#L767-L770

OpenBSD `vio_start`
https://github.com/openbsd/src/blob/8ba5287a9170ba4c6e701a63af5bd28c0b4e0dcf/sys/dev/pv/if_vio.c#L1223-L1226

## How was this PR tested?

qemu-x86_64

## Notes for reviewers

The feature name used to be `VIRTIO_F_RING_EVENT_IDX`.
OpenBSD still use it, but the latest specification use `VIRTIO_F_EVENT_IDX` and I followed it.