### PR TITLE
feat(nvme): add complete method

### DIFF
--- a/awkernel_drivers/src/pcie/nvme.rs
+++ b/awkernel_drivers/src/pcie/nvme.rs
@@ -104,6 +104,8 @@ impl Queue {
 
             if let Some(done_fn) = ccb._done {
                 done_fn(ccb, cqe);
+            } else {
+                return Err(NvmeDriverErr::NoCallback);
             }
 
             head += 1;
@@ -426,6 +428,7 @@ pub enum NvmeDriverErr {
     CommandFailed,
     NoCcb,
     IncompatiblePageSize,
+    NoCallback,
 }
 
 impl From<NvmeDriverErr> for PCIeDeviceErr {
@@ -443,6 +446,7 @@ impl From<NvmeDriverErr> for PCIeDeviceErr {
             NvmeDriverErr::CommandFailed => PCIeDeviceErr::InitFailure,
             NvmeDriverErr::NoCcb => PCIeDeviceErr::InitFailure,
             NvmeDriverErr::IncompatiblePageSize => PCIeDeviceErr::InitFailure,
+            NvmeDriverErr::NoCallback => PCIeDeviceErr::CommandFailure,
         }
     }
 }


### PR DESCRIPTION
## Description
Add complete method for nvme.

## Related links
nvme_q_complete
https://github.com/openbsd/src/blob/f27f14072d0d9ed1a84afd679d3fef0ac483f421/sys/dev/ic/nvme.c#L1205

sc->sc_ops->op_cq_done(sc, q, ccb); ( = nvme_op_cq_done)
https://github.com/openbsd/src/blob/f27f14072d0d9ed1a84afd679d3fef0ac483f421/sys/dev/ic/nvme.c#L1198


## How was this PR tested?

## Notes for reviewers
