### PR TITLE
feat(nvme): add ccbs_free method and fix ccbs_alloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,6 @@ QEMU_X86_ARGS+= -numa node,memdev=m0,cpus=0-3,nodeid=0
 QEMU_X86_ARGS+= -numa node,memdev=m1,cpus=4-7,nodeid=1
 QEMU_X86_ARGS+= -numa node,memdev=m2,cpus=8-11,nodeid=2
 QEMU_X86_ARGS+= -numa node,memdev=m3,cpus=12-15,nodeid=3
-QEMU_X86_ARGS+= -drive file=nvme_disk.img,if=none,id=nvme0,format=raw
-QEMU_X86_ARGS+= -device nvme,drive=nvme0,serial=deadbeef
-QEMU_X86_ARGS+= -nographic
 # QEMU_X86_ARGS+= -d int # debug interrupt
 # QEMU_X86_ARGS+= --trace apic_mem_writel # debug APIC
 # QEMU_X86_ARGS+= --trace "e1000e_irq_*" --trace "pci_cfg_*" # debug e1000e and PCI


### PR DESCRIPTION
## Description
Add ccbs_free method and fix ccbs_alloc to initialize prpl field.

## Related links
nvme_ccbs_free
https://github.com/openbsd/src/blob/f27f14072d0d9ed1a84afd679d3fef0ac483f421/sys/dev/ic/nvme.c#L1483

nvme_ccbs_alloc
https://github.com/openbsd/src/blob/f27f14072d0d9ed1a84afd679d3fef0ac483f421/sys/dev/ic/nvme.c#L1410

corresponding part of nvme_attach
https://github.com/openbsd/src/blob/f27f14072d0d9ed1a84afd679d3fef0ac483f421/sys/dev/ic/nvme.c#L373-L385
## How was this PR tested?

## Notes for reviewers
