### PR TITLE
fix(nvme): comment out the attachment of nvme

### DIFF
--- a/awkernel_drivers/src/pcie.rs
+++ b/awkernel_drivers/src/pcie.rs
@@ -1013,6 +1013,8 @@ impl PCIeInfo {
                 return virtio::attach(self);
             }
             _ => {
+                // TODO: After the issue with the actual device is reolved,
+                // we will enable the NVMe support.
                 //if let PCIeClass::MassStorageController(pcie_class::PCIeStorageSubClass::Nvm(
                 //pcie_class::PCIeStorageNvmProgrammingInterface::NvmExpressIOController,
                 //)) = self.get_class()


### PR DESCRIPTION
## Description
Comment out the attachment of nvme for now since nvme device get panic at q_complete method with the actual device. Will be validate after the issue is solved.

## Related links
[TIER IV Internal Slack
](https://star4.slack.com/archives/C054R6DL5KL/p1753853994964889?thread_ts=1753852711.981579&cid=C054R6DL5KL)
## How was this PR tested?

## Notes for reviewers
