### PR TITLE
feat(nvme): add allocate_msix related method

### DIFF
--- a/awkernel_drivers/src/pcie/nvme.rs
+++ b/awkernel_drivers/src/pcie/nvme.rs
@@ -721,13 +721,8 @@ impl NvmeInner {
         let mut rv = false;
 
         if let Some(ccbs) = self.ccbs.as_mut() {
-            rv = io_q.complete(&self.info, ccbs)?;
-        }
-
-        if let Some(ccbs) = self.ccbs.as_mut() {
-            if admin_q.complete(&self.info, ccbs)? {
-                rv = true;
-            }
+            rv |= io_q.complete(&self.info, ccbs)?;
+            rv |= admin_q.complete(&self.info, ccbs)?;
         }
 
         Ok(rv)


### PR DESCRIPTION
## Description
Add allocate_msix related method for nvme.
NVMe device specific interrupt function is register as a interrupt_handler for now, but it will be a generic storage interrupt handler in the future as commented.

## Related links
nvme_intr
https://github.com/openbsd/src/blob/f27f14072d0d9ed1a84afd679d3fef0ac483f421/sys/dev/ic/nvme.c#L1580

## How was this PR tested?

## Notes for reviewers
