### PR TITLE
feat(virtio): introduce barriers

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -294,6 +294,7 @@ impl Virtq {
         // set the new event index: avail_ring->used_event = idx
         self.vq_dma.as_mut().avail.used_event = idx;
         membar_sync();
+
         // number of slots in the used ring available to be supplied to the avail ring.
         let nused = self.vq_dma.as_ref().used.idx - self.vq_used_idx;
         debug_assert!(nused < self.vq_num as u16);


### PR DESCRIPTION
## Description

Introduced barriers to virtio-net.

## Related links

OpenBSD virtio membarriers
https://github.com/openbsd/src/blob/788294299689adc0a6c392611e2b1f3c1288bdd5/sys/arch/amd64/include/atomic.h#L284-L287

where `virtio_membar_consumer()` is used
https://github.com/openbsd/src/blob/788294299689adc0a6c392611e2b1f3c1288bdd5/sys/dev/pv/virtio.c#L858

where `virtio_membar_producer()` is used
https://github.com/openbsd/src/blob/788294299689adc0a6c392611e2b1f3c1288bdd5/sys/dev/pv/virtio.c#L731

where `virtio_membar_sync()` is used
https://github.com/openbsd/src/blob/788294299689adc0a6c392611e2b1f3c1288bdd5/sys/dev/pv/virtio.c#L916
https://github.com/openbsd/src/blob/788294299689adc0a6c392611e2b1f3c1288bdd5/sys/dev/pv/virtio.c#L995
https://github.com/openbsd/src/blob/788294299689adc0a6c392611e2b1f3c1288bdd5/sys/dev/pv/virtio.c#L757-L775

## How was this PR tested?

## Notes for reviewers
