### PR TITLE
feat(igc): implement `up()` and `flags()`

### DIFF
--- a/kernel/src/arch/x86_64/config.rs
+++ b/kernel/src/arch/x86_64/config.rs
@@ -8,4 +8,4 @@ pub const HEAP_START: usize = 0x41000000000;
 pub const PREEMPT_IRQ: u16 = 255;
 pub const WAKEUP_IRQ: u16 = 254;
 
-pub const DMA_SIZE: usize = 64 * 1024 * 1024; // 64MiB
+pub const DMA_SIZE: usize = 128 * 1024 * 1024; // 128MiB


### PR DESCRIPTION
This PR implements the `up()` and `flags()` methods for igc.
Additionally, it fixes a bug in the calculation of `IGC_RDT(i)` and increases the `DMA_SIZE` for x86_64, as the previous size was too small for a PC equipped with two `igc` interfaces.

## Description

## Related links

- Awkernel igb's `up()`: https://github.com/tier4/awkernel/blob/8755a883b626ee682737438692e6b580ae421903/awkernel_drivers/src/pcie/intel/igb.rs#L2100-L2118
- OpenBSD's `IGC_RDT(i)`: https://github.com/openbsd/src/blob/21c4aba0978e79954813a357eb47aba44ddb5c81/sys/dev/pci/if_igc.c#L928
- Issue #335 

## How was this PR tested?

## Notes for reviewers
