### PR TITLE
feat(igc): handle the link status change event

### DIFF
--- a/awkernel_lib/src/interrupt.rs
+++ b/awkernel_lib/src/interrupt.rs
@@ -65,7 +65,7 @@ pub trait InterruptController: Sync + Send {
     }
 }
 
-type NameAndCallback = (Cow<'static, str>, Box<dyn FnMut(u16) + Send>);
+type NameAndCallback = (Cow<'static, str>, Box<dyn Fn(u16) + Send>);
 
 static INTERRUPT_CONTROLLER: RwLock<Option<Box<dyn InterruptController>>> = RwLock::new(None);
 static IRQ_HANDLERS: RwLock<BTreeMap<u16, NameAndCallback>> = RwLock::new(BTreeMap::new());


### PR DESCRIPTION
## Description

This PR handles the link status change event of igc.
As this PR, link up/down will be detected.

## Related links

- https://github.com/openbsd/src/blob/01075e58a8ba32f90406c663dd5c28d9688777ba/sys/dev/pci/if_igc.c#L1792
- Issue #335 

## How was this PR tested?

It works on a physical x86_64 machine equipped with igc.

## Notes for reviewers

Interrupts are not cause by using MSI-X on a mini PC.
I will try to fix the problem by using this PR.