### PR TITLE
fix(igc): enable MSIX

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -977,6 +977,14 @@ fn igc_allocate_pci_resources(info: &mut PCIeInfo) -> Result<(Vec<IRQ>, IRQ), PC
         .or(Err(PCIeDeviceErr::InitFailure))?;
     irq_other.enable();
 
+    if let Some(msi) = info.get_msi_mut() {
+        msi.disable();
+    }
+    info.disable_legacy_interrupt();
+
+    let msix = info.get_msix_mut().unwrap();
+    msix.enable();
+
     Ok((irqs_queues, irq_other))
 }
 


### PR DESCRIPTION
## Description

As igb, MSIX is enabled when initializting MSIX.

## Related links

- Awkernel's igb: https://github.com/tier4/awkernel/blob/f927461aeae516778382824e87a081413ef6dc51/awkernel_drivers/src/pcie/intel/igb.rs#L1824-L1830
- #335 

## How was this PR tested?

## Notes for reviewers
