### PR TITLE
feat(virtio): dump virtqueue info

### DIFF
--- a/awkernel_drivers/src/pcie/virtio/virtio_net.rs
+++ b/awkernel_drivers/src/pcie/virtio/virtio_net.rs
@@ -408,6 +408,29 @@ impl Virtq {
         self.vq_dma.as_mut().avail.idx = self.vq_avail_idx;
     }
 
+    fn virtio_vq_dump(&self) {
+        // Common fields
+        log::info!(" vq_num: {}", self.vq_num);
+        log::info!(" vq_mask: {}", self.vq_mask);
+        log::info!(" vq_index: {}", self.vq_index);
+        log::info!(" vq_used_idx: {}", self.vq_used_idx);
+        log::info!(" vq_avail_idx: {}", self.vq_avail_idx);
+
+        // Avail ring fields
+        let flags = self.vq_dma.as_ref().avail.flags;
+        let idx = self.vq_dma.as_ref().avail.idx;
+        let used_event = self.vq_dma.as_ref().avail.used_event;
+        log::info!(" avail: flags:{flags}, idx:{idx}, used_event:{used_event}",);
+
+        // Used ring fields
+        let flags = self.vq_dma.as_ref().used.flags;
+        let idx = self.vq_dma.as_ref().used.idx;
+        let avail_event = self.vq_dma.as_ref().used.avail_event;
+        log::info!(" used: flags:{flags}, idx:{idx}, avail_event:{avail_event}",);
+
+        log::info!(" +++++++++++++++++++++++++++");
+    }
+
     /// add mbufs for all the empty receive slots
     fn vio_populate_rx_mbufs(&mut self) -> bool {
         let mut should_notify = false;
@@ -1134,6 +1157,24 @@ impl VirtioNetInner {
         self.virtio_reinit_end()?;
 
         Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn vio_dump(&self) {
+        for i in 0..self.virtqueues.len() {
+            {
+                let mut node = MCSNode::new();
+                let tx = self.virtqueues[i].tx.lock(&mut node);
+                log::info!("{i}: TX virtqueue:");
+                tx.virtio_vq_dump();
+            }
+            {
+                let mut node = MCSNode::new();
+                let rx = self.virtqueues[i].rx.lock(&mut node);
+                log::info!("{i}: RX virtqueue:");
+                rx.virtio_vq_dump();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Implemented dump functions.
These are not called by default.

## Related links

OpenBSD `virtio_vq_dump`
https://github.com/openbsd/src/blob/8dff66dede28b464d54c9159461236885cc49254/sys/dev/pv/virtio.c#L1030

OpenBSD `vio_dump`
https://github.com/openbsd/src/blob/8dff66dede28b464d54c9159461236885cc49254/sys/dev/pv/if_vio.c#L1246

## How was this PR tested?

QEMU x86_64

## Notes for reviewers

When called, it looks like the following:

```
[         5113 INFO] 0: TX virtqueue:
[         5113 INFO]  vq_num: 256
[         5113 INFO]  vq_mask: 255
[         5113 INFO]  vq_index: 1
[         5113 INFO]  vq_used_idx: 3
[         5113 INFO]  vq_avail_idx: 3
[         5113 INFO]  avail: flags:0, idx:3, used_event:32771
[         5113 INFO]  used: flags:0, idx:3, avail_event:3
[         5113 INFO]  +++++++++++++++++++++++++++
[         5113 INFO] 0: RX virtqueue:
[         5113 INFO]  vq_num: 256
[         5113 INFO]  vq_mask: 255
[         5113 INFO]  vq_index: 0
[         5113 INFO]  vq_used_idx: 3
[         5113 INFO]  vq_avail_idx: 259
[         5113 INFO]  avail: flags:0, idx:259, used_event:0
[         5113 INFO]  used: flags:0, idx:3, avail_event:0
[         5113 INFO]  +++++++++++++++++++++++++++
```