### PR TITLE
fix(GEDFScheduler): solve intra-scheduler priority inversion

### DIFF
--- a/awkernel_async_lib/src/task.rs
+++ b/awkernel_async_lib/src/task.rs
@@ -943,18 +943,6 @@ pub fn get_scheduler_type_by_task_id(task_id: u32) -> Option<SchedulerType> {
 }
 
 #[inline(always)]
-pub fn get_absolute_deadline_by_task_id(task_id: u32) -> Option<u64> {
-    let mut node = MCSNode::new();
-    let tasks = TASKS.lock(&mut node);
-
-    tasks.id_to_task.get(&task_id).and_then(|task| {
-        let mut node = MCSNode::new();
-        let info = task.info.lock(&mut node);
-        info.get_absolute_deadline()
-    })
-}
-
-#[inline(always)]
 pub fn set_need_preemption(task_id: u32, cpu_id: usize) {
     let mut node = MCSNode::new();
     let tasks = TASKS.lock(&mut node);


### PR DESCRIPTION
## Description

This solves the intra-GEDFScheduler priority inversion same as [PrioritizedFIFOScheduler](https://github.com/tier4/awkernel/blob/main/awkernel_async_lib/src/scheduler/prioritized_fifo.rs).

## Related links

- [Design Document](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3830874138/PriotitizedFIFOScheduler)

## How was this PR tested?

`test_gedf`

```
> [         4845 INFO] spawn heavy_1: 4844978
[         4875 INFO] spawn task_1: 4874090
[         4905 INFO] spawn light_1: 4890306
[         5833 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 2, start_time: 4922256, end_time: 5833339
[         6937 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 2, start_time: 6026127, end_time: 6937584
[         7961 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 1, start_time: 7050024, end_time: 7961075
[         9112 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 3, start_time: 8200799, end_time: 9112339
[        10167 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 6, start_time: 9256489, end_time: 10167835
[        11862 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 4, start_time: 10951141, end_time: 11862481
[        13413 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 3, start_time: 12502227, end_time: 13413656
[        14468 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: heavy_1, cpu_id: 1, start_time: 4860165, end_time: 14468906
[        14628 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 2, start_time: 13701739, end_time: 14628871
[        14708 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: task_1, cpu_id: 5, start_time: 4905842, end_time: 14708900
[        16115 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 9, start_time: 15204520, end_time: 16115831
[        17427 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 2, start_time: 16435610, end_time: 17427113
[        19393 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 4, start_time: 18434579, end_time: 19393864
[        25023 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: task_1, cpu_id: 3, start_time: 15220556, end_time: 25023368
[        25039 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: heavy_1, cpu_id: 8, start_time: 15220494, end_time: 25039241
[        36158 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 8, start_time: 35151120, end_time: 36158233
[        39134 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 12, start_time: 38045559, end_time: 39134591
[        45002 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: task_1, cpu_id: 5, start_time: 35199060, end_time: 45002989
[        45946 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: heavy_1, cpu_id: 4, start_time: 36302318, end_time: 45946120
[        53271 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 8, start_time: 52280423, end_time: 53271730
[        62002 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: heavy_1, cpu_id: 5, start_time: 52392226, end_time: 62002146
[        62002 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: task_1, cpu_id: 6, start_time: 52184358, end_time: 62002236
[        78463 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 6, start_time: 77520299, end_time: 78463757
[        87195 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: heavy_1, cpu_id: 3, start_time: 77568406, end_time: 87195129
[        87371 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: task_1, cpu_id: 2, start_time: 77520571, end_time: 87371177
[       121295 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: light_1, cpu_id: 15, start_time: 120096540, end_time: 121295790
[       130412 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: task_1, cpu_id: 14, start_time: 120192535, end_time: 130412106
[       130955 DEBUG] /home/atsushi/awkernel/applications/tests/test_gedf/src/lib.rs:44: task_name: heavy_1, cpu_id: 4, start_time: 121167836, end_time: 130955569
```

## Notes for reviewers
