### PR TITLE
feat(net): prepare the polling task for network interfaces

### DIFF
--- a/awkernel_lib/src/net.rs
+++ b/awkernel_lib/src/net.rs
@@ -604,11 +604,14 @@ pub fn poll_interface(interface_id: u64) -> bool {
 ///
 /// 1. `NetManager.read()`
 /// 2. `POLL_WAKERS.lock()`
-pub fn poll() {
+pub fn poll() -> usize {
     let net_manager = NET_MANAGER.read();
+
+    let mut n = 0;
 
     for (interface_id, if_net) in net_manager.interfaces.iter() {
         if if_net.is_poll_mode && if_net.net_device.poll() {
+            n += 1;
             let mut node = MCSNode::new();
             let mut w = POLL_WAKERS.lock(&mut node);
 
@@ -628,6 +631,8 @@ pub fn poll() {
             }
         }
     }
+
+    n
 }
 
 /// If some packets are processed, true is returned.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -81,7 +81,6 @@ fn main<Info: Debug>(kernel_info: KernelInfo<Info>) {
             }
 
             let dur = wake_task(); // Wake executable tasks periodically.
-            awkernel_lib::net::poll(); // Poll network devices.
 
             #[cfg(feature = "std")]
             {


### PR DESCRIPTION
## Description

Previously, network interfaces were polled only by the primary core. However, polling may not occur if the primary core enters a sleep state.
This PR introduces a dedicated polling task to ensure that network interfaces are consistently polled, even when the primary core is sleeping.

Current primary core:
```
loop {
   poll_network_interfaces();
   sleep(); // wait interrupts forever, may not poll network interfaces.
}
```

## Related links

## How was this PR tested?

## Notes for reviewers
