### PR TITLE
feat(dmamap): add DmaMap struct

### DIFF
--- a/awkernel_lib/src/dma_map.rs
+++ b/awkernel_lib/src/dma_map.rs
@@ -1,0 +1,240 @@
+//! DMA Mapping API
+//!
+//! This DMA mapping layer expects that transfers passed to it are already
+//! limited to the device's Maximum Data Transfer Size (MDTS, stored in
+//! DmaTag::maxsize). If a transfer exceeds maxsize, this layer will return
+//! DmaError::SizeTooLarge rather than attempting to split it.
+//!
+//! In OpenBSD, the physio() layer calls minphys() to limit transfer sizes
+//! before they reach device drivers. AWKernel currently lacks an equivalent
+//! physio layer, so upper layers (storage, filesystem) are responsible for
+//! ensuring transfers do not exceed device limits.
+//!
+//! For transfers within MDTS but requiring too many segments (exceeding
+//! DmaTag::nsegments), this layer WILL automatically use bounce buffers
+//! to consolidate segments.
+
+use crate::{
+    addr::{phy_addr::PhyAddr, virt_addr::VirtAddr, Addr},
+    dma_pool::DMAPool,
+    paging::{self, PAGESIZE},
+};
+use alloc::vec::Vec;
+
+/// DMA constraints for a device
+#[derive(Debug, Clone, Copy)]
+pub struct DmaTag {
+    pub boundary: u64,
+    pub maxsegsz: usize,
+    pub nsegments: usize,
+    pub maxsize: usize,
+    pub alignment: usize,
+}
+
+impl Default for DmaTag {
+    /// Create a default DMA tag for 64-bit devices
+    fn default() -> Self {
+        Self {
+            boundary: 0,
+            maxsegsz: PAGESIZE,
+            nsegments: 1,
+            maxsize: usize::MAX,
+            alignment: 1,
+        }
+    }
+}
+
+/// DMA segment descriptor
+///
+/// NOTE: OpenBSD tracks _ds_va and _ds_bounce_va per segment for copying data
+/// between original and bounce buffers. AWKernel doesn't need these because:
+/// 1. We store virtual addresses at the map level (orig_vaddr, owned_memory)
+/// 2. Bounce buffer is a single contiguous segment - we copy the entire range at once
+#[derive(Debug, Clone, Copy)]
+pub struct DmaSegment {
+    pub ds_addr: PhyAddr,
+    pub ds_len: usize,
+}
+
+/// DMA map structure
+pub struct DmaMap {
+    tag: DmaTag,
+    segments: Vec<DmaSegment>,
+    /// Memory owned by this map (either bounce buffer or pre-allocated DMA pool)
+    owned_memory: Option<DMAPool<u8>>,
+    /// Original virtual address (for sync operations)
+    orig_vaddr: Option<VirtAddr>,
+    mapsize: usize,
+    numa_id: usize,
+}
+
+/// DMA synchronization operations
+#[derive(Debug, Clone, Copy)]
+pub enum DmaSyncOp {
+    PreRead,
+    PostRead,
+    PreWrite,
+    PostWrite,
+}
+
+/// Errors that can occur during DMA operations
+#[derive(Debug)]
+pub enum DmaError {
+    AddressTooHigh,
+    SizeTooLarge,
+    TooManySegments,
+    BadAlignment,
+    OutOfMemory,
+    NotLoaded,
+    InvalidAddress,
+}
+
+impl DmaMap {
+    /// Create a new DMA map
+    pub fn new(tag: DmaTag, numa_id: usize) -> Result<Self, DmaError> {
+        Ok(Self {
+            tag,
+            segments: Vec::new(),
+            owned_memory: None,
+            orig_vaddr: None,
+            mapsize: 0,
+            numa_id,
+        })
+    }
+
+    pub fn mapsize(&self) -> usize {
+        self.mapsize
+    }
+
+    /// Load a buffer into the DMA map
+    /// Based on OpenBSD's _bus_dmamap_load_buffer (sys/arch/amd64/amd64/bus_dma.c:722-823)
+    pub fn load(&mut self, vaddr: VirtAddr, size: usize) -> Result<(), DmaError> {
+        if size > self.tag.maxsize {
+            return Err(DmaError::SizeTooLarge);
+        }
+
+        if vaddr.as_usize() & (self.tag.alignment - 1) != 0 {
+            return Err(DmaError::BadAlignment);
+        }
+
+        self.segments.clear();
+
+        let mut lastaddr = PhyAddr::new(0);
+        let bmask = if self.tag.boundary > 0 {
+            !(self.tag.boundary - 1)
+        } else {
+            0 // No masking needed when boundary = 0
+        };
+
+        let mut buflen = size;
+        let mut vaddr_current = vaddr.as_usize();
+        let mut seg = 0usize;
+        let mut first = true;
+
+        while buflen > 0 {
+            // Get the physical address for this segment
+            let curaddr = match paging::vm_to_phy(VirtAddr::new(vaddr_current)) {
+                Some(paddr) => paddr,
+                None => {
+                    return Err(DmaError::InvalidAddress);
+                }
+            };
+
+            // TODO: Skipping check for PCIeDevice with 32bit addressing.
+
+            // NOTE: OpenBSD has a check here for pre-allocated bounce
+            // buffers in SEV guest mode. AWKernel skips this because:
+            // 1. No SEV support yet
+            // 2. We use dynamic bounce buffer allocation instead
+
+            // Compute the segment size, and adjust counts.
+            let mut sgsize = PAGESIZE - (vaddr_current & (PAGESIZE - 1));
+            if buflen < sgsize {
+                sgsize = buflen;
+            }
+
+            // Make sure we don't cross any boundaries
+            if self.tag.boundary > 0 {
+                let baddr = (curaddr.as_usize() as u64 + self.tag.boundary) & bmask;
+                let max_size = baddr - curaddr.as_usize() as u64;
+                if sgsize > max_size as usize {
+                    sgsize = max_size as usize;
+                }
+            }
+
+            // Insert chunk into a segment, coalescing with
+            // previous segment if possible
+            if first {
+                self.segments.push(DmaSegment {
+                    ds_addr: curaddr,
+                    ds_len: sgsize,
+                });
+                first = false;
+            } else {
+                let can_coalesce = curaddr.as_usize() == lastaddr.as_usize()
+                    && (self.segments[seg].ds_len + sgsize) <= self.tag.maxsegsz
+                    && (self.tag.boundary == 0
+                        || (self.segments[seg].ds_addr.as_usize() as u64 & bmask)
+                            == (curaddr.as_usize() as u64 & bmask));
+
+                if can_coalesce {
+                    self.segments[seg].ds_len += sgsize;
+                } else {
+                    seg += 1;
+                    if seg >= self.tag.nsegments {
+                        return self.load_with_bounce(vaddr, size);
+                    }
+                    self.segments.push(DmaSegment {
+                        ds_addr: curaddr,
+                        ds_len: sgsize,
+                    });
+                }
+            }
+
+            lastaddr = PhyAddr::new(curaddr.as_usize() + sgsize);
+            vaddr_current += sgsize;
+            buflen -= sgsize;
+        }
+
+        self.orig_vaddr = Some(vaddr);
+        self.mapsize = size;
+        Ok(())
+    }
+
+    /// Load buffer using bounce buffer
+    fn load_with_bounce(&mut self, vaddr: VirtAddr, size: usize) -> Result<(), DmaError> {
+        let pages = size.div_ceil(PAGESIZE);
+        log::warn!(
+            "Allocating bounce buffer: size={} bytes, pages={}",
+            size,
+            pages
+        );
+
+        let bounce = DMAPool::<u8>::new(self.numa_id, pages).ok_or(DmaError::OutOfMemory)?;
+
+        let bounce_paddr = bounce.get_phy_addr();
+
+        // NOTE: Data copying happens in sync(), not here!
+        // This matches OpenBSD's design where load only sets up mappings
+
+        self.segments.clear();
+        self.segments.push(DmaSegment {
+            ds_addr: bounce_paddr,
+            ds_len: size,
+        });
+
+        self.owned_memory = Some(bounce);
+        self.orig_vaddr = Some(vaddr);
+        self.mapsize = size;
+
+        Ok(())
+    }
+
+    /// Unload the DMA map
+    pub fn unload(&mut self) {
+        self.segments.clear();
+        self.owned_memory = None;
+        self.orig_vaddr = None;
+        self.mapsize = 0;
+    }
+}

--- a/awkernel_lib/src/lib.rs
+++ b/awkernel_lib/src/lib.rs
@@ -44,6 +44,9 @@ pub mod heap;
 pub mod dma_pool;
 
 #[cfg(not(feature = "std"))]
+pub mod dma_map;
+
+#[cfg(not(feature = "std"))]
 pub mod context;
 
 pub mod paging;


### PR DESCRIPTION
## Description
  Add DMA mapping layer based on OpenBSD's bus_dma(9) framework

  ### Summary
  This PR introduces a new DMA mapping API (`dma_map.rs`) that provides a robust abstraction for managing DMA transfers between devices and memory. The implementation is based on OpenBSD's proven bus_dma(9)
   framework, adapted for AWKernel's architecture.

  ### Key Features
  - **DMA constraint management** via `DmaTag` structure (boundary, segment size/count limits, alignment)
  - **Automatic scatter-gather list generation** from virtual addresses
  - **Bounce buffer support** for transfers exceeding device segment limits
  - **Architecture-aware memory barriers** for DMA coherency
  - **Zero-copy operation** when device constraints are met

  ### Implementation Details

  #### Core Components:
  - `DmaTag`: Defines device-specific DMA constraints (max segment size, count, boundary, alignment)
  - `DmaMap`: Manages the mapping between virtual and physical addresses for DMA
  - `DmaSegment`: Represents a physically contiguous memory segment
  - `DmaSyncOp`: Synchronization operations (PreRead/PostRead/PreWrite/PostWrite)

  ### Design Decisions

  1. **Transfer size validation without splitting**: 
     Similar to OpenBSD's approach, we expect transfers to be limited before reaching the DMA layer. OpenBSD uses physio() with minphys() to enforce these limits. AWKernel hasn't implemented an equivalent 
  physio layer yet, so this responsibility temporarily falls on upper layers. When a transfer exceeds `DmaTag::maxsize`, we return `DmaError::SizeTooLarge` rather than attempting to split it. This matches 
  the philosophy that the DMA layer should map what it's given, not make policy decisions about transfer sizes.

  2. **Dynamic bounce buffer as fallback (not recommended)**: 
     The dynamic bounce buffer allocation using `DMAPool::new()` is implemented as a safety net to prevent failures, but it's not the intended path. The warning log alerts developers that their device 
  driver should pre-allocate DMA memory to avoid unpredictable runtime overhead. For example, USB drivers with large segment requirements should use `DmaMap::from_dma_pool()` with pre-allocated buffers 
  rather than relying on dynamic allocation. This design ensures the system won't fail while making it clear that proper DMA memory management requires upfront allocation. The dynamic path exists primarily 
  for unexpected fragmentation scenarios that shouldn't occur with well-designed drivers.

  3. **Simplified segment tracking**: 
     OpenBSD tracks per-segment virtual addresses (`_ds_va` and `_ds_bounce_va`) to enable fine-grained copying between original and bounce buffers. AWKernel stores virtual addresses only at the map level
  (`orig_vaddr`, `owned_memory`) because we always allocate bounce buffers as single contiguous segments. This simplification works because when we need a bounce buffer, we allocate one large buffer rather
  than multiple smaller ones.

## Related links

## How was this PR tested?

## Notes for reviewers
