### PR TITLE
fix(dag): spawn_periodic_reactor

### DIFF
--- a/awkernel_async_lib/src/dag.rs
+++ b/awkernel_async_lib/src/dag.rs
@@ -895,14 +895,17 @@ where
         );
 
         let mut interval = interval(period);
+        // Consume the first tick here to start the loop's main body without an initial delay.
+        interval.tick().await;
 
         loop {
-            interval.tick().await;
             let results = f();
             publishers.send_all(results).await;
 
             #[cfg(feature = "perf")]
             periodic_measure();
+
+            interval.tick().await;
         }
     };
 


### PR DESCRIPTION
## Description
Moves the `interval.tick()` from the beginning of the loop to the end. This will ensure the wake time is correct.

## Related links

## How was this PR tested?

## Notes for reviewers
