### PR TITLE
fix(scheduler): solve inter-scheduler priority inversion

### DIFF
--- a/applications/tests/test_multi_prioritized_scheduler/Cargo.toml
+++ b/applications/tests/test_multi_prioritized_scheduler/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_multi_prioritized_scheduler"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+log = "0.4"
+
+[dependencies.awkernel_async_lib]
+path = "../../../awkernel_async_lib"
+default-features = false
+
+[dependencies.awkernel_lib]
+path = "../../../awkernel_lib"
+default-features = false

--- a/applications/tests/test_multi_prioritized_scheduler/src/lib.rs
+++ b/applications/tests/test_multi_prioritized_scheduler/src/lib.rs
@@ -1,0 +1,51 @@
+#![no_std]
+
+extern crate alloc;
+
+use awkernel_async_lib::{scheduler::SchedulerType, spawn};
+use awkernel_lib::{cpu::num_cpu, delay::wait_millisec};
+
+pub async fn run() {
+    wait_millisec(1000);
+    for i in 1..num_cpu() {
+        let sched_type = if i % 3 == 0 {
+            SchedulerType::PrioritizedFIFO(0)
+        } else if i % 3 == 1 {
+            SchedulerType::PrioritizedRR(0)
+        } else {
+            SchedulerType::GEDF(1000)
+        };
+
+        spawn(
+            "low_priority".into(),
+            async move {
+                log::debug!("low priority task {i} started. sched_type = {sched_type:?}");
+                wait_millisec(500);
+                log::debug!("low priority task {i} finished. sched_type = {sched_type:?}");
+            },
+            sched_type,
+        )
+        .await;
+    }
+
+    for i in 1..num_cpu() {
+        let sched_type = if i % 3 == 0 {
+            SchedulerType::PrioritizedFIFO(1)
+        } else if i % 3 == 1 {
+            SchedulerType::PrioritizedRR(1)
+        } else {
+            SchedulerType::GEDF(500)
+        };
+
+        spawn(
+            "high_priority".into(),
+            async move {
+                log::debug!("high priority task {i} started. sched_type = {sched_type:?}");
+                wait_millisec(100);
+                log::debug!("high priority task {i} finished. sched_type = {sched_type:?}");
+            },
+            sched_type,
+        )
+        .await;
+    }
+}

--- a/awkernel_async_lib/src/scheduler.rs
+++ b/awkernel_async_lib/src/scheduler.rs
@@ -116,6 +116,11 @@ static PRIORITY_LIST: [SchedulerType; 4] = [
     SchedulerType::Panicked,
 ];
 
+/// For exclusion execution of `wake_task` and `get_next` across all schedulers.
+/// In order to resolve priority inversion in multiple priority-based schedulers,
+/// the decision to preempt, dequeuing, enqueuing, and updating of RUNNING must be executed exclusively.
+static GLOBAL_WAKE_GET_MUTEX: Mutex<()> = Mutex::new(());
+
 pub(crate) trait Scheduler {
     /// Enqueue an executable task.
     /// The enqueued task will be taken by `get_next()`.

--- a/awkernel_async_lib/src/scheduler/prioritized_rr.rs
+++ b/awkernel_async_lib/src/scheduler/prioritized_rr.rs
@@ -4,7 +4,10 @@ use core::cmp::max;
 
 use super::{Scheduler, SchedulerType, Task};
 use crate::{
-    scheduler::{get_next_task, get_priority, peek_preemption_pending, push_preemption_pending},
+    scheduler::{
+        get_next_task, get_priority, peek_preemption_pending, push_preemption_pending,
+        GLOBAL_WAKE_GET_MUTEX,
+    },
     task::{
         get_last_executed_by_task_id, get_task, get_tasks_running, set_current_task,
         set_need_preemption, State,
@@ -40,12 +43,6 @@ impl PrioritizedRRData {
 
 impl Scheduler for PrioritizedRRScheduler {
     fn wake_task(&self, task: Arc<Task>) {
-        let mut node = MCSNode::new();
-        // The reason for acquiring this lock before invoke_preemption() is to prevent priority inversion from occurring
-        // when invoke_preemption() is executed between the time the next task is determined and the RUNNING is updated
-        // within the scheduler's get_next().
-        let mut data = self.data.lock(&mut node);
-        let internal_data = data.get_or_insert_with(PrioritizedRRData::new);
         let priority = {
             let mut node_inner = MCSNode::new();
             let info = task.info.lock(&mut node_inner);
@@ -55,7 +52,12 @@ impl Scheduler for PrioritizedRRScheduler {
             }
         };
 
+        let mut node = MCSNode::new();
+        GLOBAL_WAKE_GET_MUTEX.lock(&mut node);
         if !self.invoke_preemption_wake(task.clone()) {
+            let mut node_inner = MCSNode::new();
+            let mut data = self.data.lock(&mut node_inner);
+            let internal_data = data.get_or_insert_with(PrioritizedRRData::new);
             internal_data.queue.push(
                 priority,
                 PrioritizedRRTask {
@@ -68,7 +70,10 @@ impl Scheduler for PrioritizedRRScheduler {
 
     fn get_next(&self, execution_ensured: bool) -> Option<Arc<Task>> {
         let mut node = MCSNode::new();
-        let mut guard = self.data.lock(&mut node);
+        GLOBAL_WAKE_GET_MUTEX.lock(&mut node);
+
+        let mut node_inner = MCSNode::new();
+        let mut guard = self.data.lock(&mut node_inner);
 
         #[allow(clippy::question_mark)]
         let data = match guard.as_mut() {

--- a/specification/awkernel_async_lib/src/task/preemptive_spin/data_structure.pml
+++ b/specification/awkernel_async_lib/src/task/preemptive_spin/data_structure.pml
@@ -35,5 +35,6 @@ chan queue[SCHEDULER_TYPE_NUM] = [TASK_NUM] of { byte }// task_ids in ascending 
 #include "mutex.pml"
 Mutex lock_info[TASK_NUM]
 Mutex lock_queue[SCHEDULER_TYPE_NUM]
+Mutex lock_global_wake_get_mutex
 
 #define BYTE_MAX 255

--- a/specification/awkernel_async_lib/src/task/preemptive_spin/for_verification.pml
+++ b/specification/awkernel_async_lib/src/task/preemptive_spin/for_verification.pml
@@ -34,7 +34,7 @@ inline update_running_lowest_priority() {
 	}
 }
 
-#define MAX_CONSECUTIVE_RUN_MAIN_LOOP 5
+#define MAX_CONSECUTIVE_RUN_MAIN_LOOP 2
 byte consecutive_run_main_loop[WORKER_NUM] = 0
 bool wait_for_weak_fairness[WORKER_NUM] = false
 chan resume_requests = [WORKER_NUM] of { byte }// tid that requested to resume execution.

--- a/userland/Cargo.toml
+++ b/userland/Cargo.toml
@@ -38,6 +38,10 @@ optional = true
 path = "../applications/tests/test_prioritized_fifo"
 optional = true
 
+[dependencies.test_multi_prioritized_scheduler]
+path = "../applications/tests/test_multi_prioritized_scheduler"
+optional = true
+
 [dependencies.test_prioritized_rr]
 path = "../applications/tests/test_prioritized_rr"
 optional = true

--- a/userland/src/lib.rs
+++ b/userland/src/lib.rs
@@ -25,6 +25,9 @@ pub async fn main() -> Result<(), Cow<'static, str>> {
     #[cfg(feature = "test_prioritized_fifo")]
     test_prioritized_fifo::run().await; // test for prioritized_fifo
 
+    #[cfg(feature = "test_multi_prioritized_scheduler")]
+    test_multi_prioritized_scheduler::run().await; // test for multi prioritized scheduler
+
     #[cfg(feature = "test_prioritized_rr")]
     test_prioritized_rr::run().await; // test for prioritized_rr
 


### PR DESCRIPTION
## Description

This solves the inter-scheduler priority inversion. This also changes the promela model and verifies it.

## Related links

## How was this PR tested?

- [x] Model checking. Please see `README.md` for detail.
- [x] Test application. The log is as follows.

```
[         5682 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 1 started. sched_type = PrioritizedRR(0)
[         5730 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 2 started. sched_type = GEDF(1000)
[         5778 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 3 started. sched_type = PrioritizedFIFO(0)
[         6162 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 6 started. sched_type = PrioritizedFIFO(0)
[         6258 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 8 started. sched_type = GEDF(1000)
[         6306 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 5 started. sched_type = GEDF(1000)
[         6466 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 11 started. sched_type = GEDF(1000)
[         6561 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 2 finished. sched_type = GEDF(1000)
[         6785 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 8 finished. sched_type = GEDF(1000)
[         6833 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 12 started. sched_type = PrioritizedFIFO(0)
[         6865 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 5 finished. sched_type = GEDF(1000)
[         6929 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 14 started. sched_type = GEDF(1000)
[         7025 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 15 started. sched_type = PrioritizedFIFO(0)
[         7297 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 11 finished. sched_type = GEDF(1000)
[         7521 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 3 started. sched_type = PrioritizedFIFO(1)
[         7537 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 2 started. sched_type = GEDF(500)
[         7569 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 14 finished. sched_type = GEDF(1000)
[         7633 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 5 started. sched_type = GEDF(500)
[         7633 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 6 started. sched_type = PrioritizedFIFO(1)
[         7729 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 2 finished. sched_type = GEDF(500)
[         7745 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 5 finished. sched_type = GEDF(500)
[         7761 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 3 finished. sched_type = PrioritizedFIFO(1)
[         7777 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 6 finished. sched_type = PrioritizedFIFO(1)
[         7793 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 9 started. sched_type = PrioritizedFIFO(1)
[         7809 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 8 started. sched_type = GEDF(500)
[         7905 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 11 started. sched_type = GEDF(500)
[         7905 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 9 finished. sched_type = PrioritizedFIFO(1)
[         7969 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 8 finished. sched_type = GEDF(500)
[         8017 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 12 started. sched_type = PrioritizedFIFO(1)
[         8017 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 11 finished. sched_type = GEDF(500)
[         8017 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 9 started. sched_type = PrioritizedFIFO(0)
[         8081 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 14 started. sched_type = GEDF(500)
[         8113 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 15 started. sched_type = PrioritizedFIFO(1)
[         8161 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 12 finished. sched_type = PrioritizedFIFO(1)
[         8241 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 12 finished. sched_type = PrioritizedFIFO(0)
[         8257 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 14 finished. sched_type = GEDF(500)
[         8257 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 15 finished. sched_type = PrioritizedFIFO(1)
[         8257 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 15 finished. sched_type = PrioritizedFIFO(0)
[         8257 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 3 finished. sched_type = PrioritizedFIFO(0)
[         8467 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 6 finished. sched_type = PrioritizedFIFO(0)
[         8594 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 9 finished. sched_type = PrioritizedFIFO(0)
[         8674 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 1 started. sched_type = PrioritizedRR(1)
[         8850 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 1 finished. sched_type = PrioritizedRR(1)
[         8898 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 4 started. sched_type = PrioritizedRR(1)
[         9026 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 4 finished. sched_type = PrioritizedRR(1)
[         9026 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 7 started. sched_type = PrioritizedRR(1)
[         9186 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 10 started. sched_type = PrioritizedRR(1)
[         9298 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 10 finished. sched_type = PrioritizedRR(1)
[         9298 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:43: high priority task 13 started. sched_type = PrioritizedRR(1)
[         9446 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 13 finished. sched_type = PrioritizedRR(1)
[         9511 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:45: high priority task 7 finished. sched_type = PrioritizedRR(1)
[         9737 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 4 started. sched_type = PrioritizedRR(0)
[        10297 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 4 finished. sched_type = PrioritizedRR(0)
[        10329 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 7 started. sched_type = PrioritizedRR(0)
[        10858 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 7 finished. sched_type = PrioritizedRR(0)
[        11001 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 10 started. sched_type = PrioritizedRR(0)
[        11354 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:22: low priority task 13 started. sched_type = PrioritizedRR(0)
[        11626 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 1 finished. sched_type = PrioritizedRR(0)
[        11931 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 10 finished. sched_type = PrioritizedRR(0)
[        12075 DEBUG] /home/atsushi/awkernel/applications/tests/test_multi_prioritized_scheduler/src/lib.rs:24: low priority task 13 finished. sched_type = PrioritizedRR(0)
```

## Notes for reviewers

The `Mutex` for each scheduler's `data` is unnecessary for now, such as

```rust
pub static SCHEDULER: PrioritizedFIFOScheduler = PrioritizedFIFOScheduler {
    data: Mutex::new(None),  // <- this
    priority: get_priority(SchedulerType::PrioritizedFIFO(0)),
};
```
However, `RefCell` cannot be used for a field in a static object. Therefore, it remains. I would appreciate your comments on this if you have a better idea.