### PR TITLE
feat(RV64): implement dynamic memory/cpu decider

### DIFF
--- a/awkernel_lib/Cargo.toml
+++ b/awkernel_lib/Cargo.toml
@@ -15,6 +15,7 @@ embedded-graphics = "0.8"
 chrono = { version = "0.4", default-features = false, features = [
     "clock",
 ], optional = true }
+fdt = { version = "0.1", optional = true }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 wf_alloc = { version = "0.1.2", default-features = false, optional = true }
@@ -94,7 +95,7 @@ x86 = [
 ]
 aarch64 = ["dep:awkernel_aarch64", "awkernel_sync/aarch64"]
 rv32 = ["dep:riscv", "awkernel_sync/rv32"]
-rv64 = ["awkernel_sync/rv64"]
+rv64 = ["awkernel_sync/rv64", "dep:fdt"]
 std = ["dep:libc", "dep:socket2", "awkernel_sync/std"]
 spinlock = ["awkernel_sync/spinlock"]
 # LFN (Long File Name) support

--- a/awkernel_lib/src/arch/rv64.rs
+++ b/awkernel_lib/src/arch/rv64.rs
@@ -3,15 +3,34 @@ pub mod barrier;
 pub(super) mod cpu;
 pub(super) mod delay;
 pub(super) mod dvfs;
+pub(super) mod fdt;
 pub(super) mod frame_allocator;
 pub(super) mod interrupt;
 pub(super) mod page_table;
 pub(super) mod paging;
 pub(super) mod vm;
 
+use core::sync::atomic::{AtomicUsize, Ordering};
+
 pub struct RV64;
 
 impl super::Arch for RV64 {}
+
+/// # Safety
+///
+/// This function must be called at initialization,
+/// and called by the primary CPU.
+pub unsafe fn init_primary() {
+    delay::init_primary();
+}
+
+/// # Safety
+///
+/// This function must be called at initialization,
+/// and called by non-primary CPUs.
+pub unsafe fn init_non_primary() {
+    delay::init_non_primary();
+}
 
 pub fn init_page_allocator() {
     frame_allocator::init_page_allocator();
@@ -37,5 +56,130 @@ pub fn translate_kernel_address(vpn: address::VirtPageNum) -> Option<page_table:
         space.translate(vpn)
     } else {
         None
+    }
+}
+
+pub fn get_heap_size() -> usize {
+    vm::get_heap_size()
+}
+
+static BOOT_DTB_PTR: AtomicUsize = AtomicUsize::new(0);
+
+/// Record the DTB pointer supplied by firmware/bootloader.
+pub fn set_boot_dtb_ptr(addr: usize) {
+    BOOT_DTB_PTR.store(addr, Ordering::Relaxed);
+}
+
+fn boot_dtb_ptr() -> Option<usize> {
+    match BOOT_DTB_PTR.load(Ordering::Relaxed) {
+        0 => None,
+        addr => Some(addr),
+    }
+}
+
+/// Detect memory size from device tree or by probing
+///
+/// Returns the detected memory size in bytes, or None if detection fails
+pub fn detect_memory_size() -> Option<u64> {
+    unsafe {
+        if let Some(dtb_addr) = boot_dtb_ptr() {
+            if let Some(region) = fdt::detect_memory_from_dtb(dtb_addr) {
+                unsafe_puts("Memory detected from boot DTB pointer at 0x");
+                crate::console::unsafe_print_hex_u32((dtb_addr >> 16) as u32);
+                crate::console::unsafe_print_hex_u32(dtb_addr as u32);
+                unsafe_puts("\r\n");
+                return Some(region.size);
+            } else {
+                unsafe_puts("Boot DTB pointer invalid, falling back to probe\r\n");
+            }
+        }
+
+        // First, try to find DTB at common locations
+        if let Some(dtb_addr) = fdt::probe_dtb_locations() {
+            if let Some(region) = fdt::detect_memory_from_dtb(dtb_addr) {
+                unsafe_puts("Memory detected from DTB at 0x");
+                crate::console::unsafe_print_hex_u32((dtb_addr >> 16) as u32);
+                crate::console::unsafe_print_hex_u32(dtb_addr as u32);
+                unsafe_puts("\r\n");
+                return Some(region.size);
+            }
+        }
+
+        // Fallback: Try memory probing
+        if let Some(size) = fdt::probe_memory_size() {
+            use crate::console::unsafe_puts;
+            unsafe_puts("Memory detected by probing\r\n");
+            return Some(size);
+        }
+    }
+    None
+}
+
+use crate::console::unsafe_puts;
+
+/// Get the memory end address based on detected or default memory size
+///
+/// This function attempts to detect the actual available RAM and returns
+/// an appropriate MEMORY_END value. Falls back to a safe default if detection fails.
+pub fn get_memory_end() -> u64 {
+    const DEFAULT_MEMORY_END: u64 = 0xB0000000; // 768MB default
+    const DRAM_BASE: u64 = 0x80000000;
+
+    if let Some(detected_size) = detect_memory_size() {
+        // Use detected size, but cap it at reasonable limits
+        let max_memory_end = DRAM_BASE + detected_size;
+
+        // Don't exceed 2GB to be safe
+        let memory_end = max_memory_end.min(DRAM_BASE + 0x80000000);
+
+        // Log the detection
+        unsafe {
+            use crate::console::unsafe_puts;
+            unsafe_puts("Detected RAM size: 0x");
+            crate::console::unsafe_print_hex_u32((detected_size >> 32) as u32);
+            crate::console::unsafe_print_hex_u32(detected_size as u32);
+            unsafe_puts("\r\n");
+        }
+
+        memory_end
+    } else {
+        // Fall back to default
+        unsafe {
+            use crate::console::unsafe_puts;
+            unsafe_puts("Using default MEMORY_END (DTB not found)\r\n");
+        }
+        DEFAULT_MEMORY_END
+    }
+}
+
+/// Detect CPU count from device tree or return default
+///
+/// Returns the detected number of CPUs, or a safe default if detection fails
+pub fn detect_cpu_count() -> usize {
+    const DEFAULT_CPU_COUNT: usize = 4;
+
+    unsafe {
+        if let Some(dtb_addr) = boot_dtb_ptr() {
+            if let Some(count) = fdt::detect_cpu_count_from_dtb(dtb_addr) {
+                unsafe_puts("Detected ");
+                crate::console::unsafe_print_hex_u32(count as u32);
+                unsafe_puts(" CPUs from boot DTB\r\n");
+                return count;
+            }
+        }
+
+        // Try to find DTB at common locations
+        if let Some(dtb_addr) = fdt::probe_dtb_locations() {
+            if let Some(count) = fdt::detect_cpu_count_from_dtb(dtb_addr) {
+                unsafe_puts("Detected ");
+                crate::console::unsafe_print_hex_u32(count as u32);
+                unsafe_puts(" CPUs from probed DTB\r\n");
+                return count;
+            }
+        }
+
+        // Fall back to default
+        unsafe_puts("Using default CPU count\r\n");
+        DEFAULT_CPU_COUNT
     }
 }

--- a/awkernel_lib/src/arch/rv64.rs
+++ b/awkernel_lib/src/arch/rv64.rs
@@ -32,12 +32,17 @@ pub unsafe fn init_non_primary() {
     delay::init_non_primary();
 }
 
-pub fn init_page_allocator() {
-    frame_allocator::init_page_allocator();
+/// Initialise the frame allocator over `[start, end)`.
+/// This range must be reserved exclusively for page table frames —
+/// it must not overlap with the heap region passed to `init_kernel_space`.
+pub fn init_page_allocator(start: usize, end: usize) {
+    frame_allocator::init_page_allocator(start, end);
 }
 
-pub fn init_kernel_space() {
-    vm::init_kernel_space();
+/// Build the kernel page table and identity-map the heap region `[heap_start, memory_end)`.
+/// Must be called after `init_page_allocator` and after the global heap is initialised.
+pub fn init_kernel_space(heap_start: usize, memory_end: usize) {
+    vm::init_kernel_space(heap_start, memory_end);
 }
 
 pub fn activate_kernel_space() {

--- a/awkernel_lib/src/arch/rv64.rs
+++ b/awkernel_lib/src/arch/rv64.rs
@@ -90,7 +90,7 @@ pub fn detect_memory_size() -> Option<u64> {
         if let Some(dtb_addr) = boot_dtb_ptr() {
             if let Some(region) = fdt::detect_memory_from_dtb(dtb_addr) {
                 unsafe_puts("Memory detected from boot DTB pointer at 0x");
-                crate::console::unsafe_print_hex_u32((dtb_addr >> 16) as u32);
+                crate::console::unsafe_print_hex_u32((dtb_addr >> 32) as u32);
                 crate::console::unsafe_print_hex_u32(dtb_addr as u32);
                 unsafe_puts("\r\n");
                 return Some(region.size);
@@ -103,7 +103,7 @@ pub fn detect_memory_size() -> Option<u64> {
         if let Some(dtb_addr) = fdt::probe_dtb_locations() {
             if let Some(region) = fdt::detect_memory_from_dtb(dtb_addr) {
                 unsafe_puts("Memory detected from DTB at 0x");
-                crate::console::unsafe_print_hex_u32((dtb_addr >> 16) as u32);
+                crate::console::unsafe_print_hex_u32((dtb_addr >> 32) as u32);
                 crate::console::unsafe_print_hex_u32(dtb_addr as u32);
                 unsafe_puts("\r\n");
                 return Some(region.size);

--- a/awkernel_lib/src/arch/rv64.rs
+++ b/awkernel_lib/src/arch/rv64.rs
@@ -39,10 +39,11 @@ pub fn init_page_allocator(start: usize, end: usize) {
     frame_allocator::init_page_allocator(start, end);
 }
 
-/// Build the kernel page table and identity-map the heap region `[heap_start, memory_end)`.
+/// Build the kernel page table and identity-map the page-table-frame region
+/// `[pt_start, heap_start)` and the heap region `[heap_start, memory_end)`.
 /// Must be called after `init_page_allocator` and after the global heap is initialised.
-pub fn init_kernel_space(heap_start: usize, memory_end: usize) {
-    vm::init_kernel_space(heap_start, memory_end);
+pub fn init_kernel_space(pt_start: usize, heap_start: usize, memory_end: usize) {
+    vm::init_kernel_space(pt_start, heap_start, memory_end);
 }
 
 pub fn activate_kernel_space() {

--- a/awkernel_lib/src/arch/rv64/address.rs
+++ b/awkernel_lib/src/arch/rv64/address.rs
@@ -8,7 +8,11 @@ use core::{
 pub const PAGE_SIZE: usize = 0x1000; // 4 KiB
 pub const PAGE_OFFSET: usize = 0xc; // 12 bits
 
-pub const MEMORY_END: u64 = 0x8080_0000;
+// Memory end for QEMU virt with 1GB RAM (-m 1G)
+// QEMU provides 1GB at 0x80000000 - 0xC0000000
+// Using 0xC0000000 directly may be too aggressive,
+// so we use 0xB0000000 (768MB from start) for safety
+pub const MEMORY_END: u64 = 0xB0000000;
 
 /// Design abstraction struct:
 /// PhysAddr, VirtAddr, PhysPageNum, VirtPageNum

--- a/awkernel_lib/src/arch/rv64/address.rs
+++ b/awkernel_lib/src/arch/rv64/address.rs
@@ -8,12 +8,6 @@ use core::{
 pub const PAGE_SIZE: usize = 0x1000; // 4 KiB
 pub const PAGE_OFFSET: usize = 0xc; // 12 bits
 
-// Memory end for QEMU virt with 1GB RAM (-m 1G)
-// QEMU provides 1GB at 0x80000000 - 0xC0000000
-// Using 0xC0000000 directly may be too aggressive,
-// so we use 0xB0000000 (768MB from start) for safety
-pub const MEMORY_END: u64 = 0xB0000000;
-
 /// Design abstraction struct:
 /// PhysAddr, VirtAddr, PhysPageNum, VirtPageNum
 /// to guarantee memory safety by borrow check in compilation

--- a/awkernel_lib/src/arch/rv64/cpu.rs
+++ b/awkernel_lib/src/arch/rv64/cpu.rs
@@ -4,7 +4,9 @@ impl CPU for super::RV64 {
     fn cpu_id() -> usize {
         let hartid: usize;
         unsafe {
-            core::arch::asm!("csrr {}, mhartid", out(reg) hartid);
+            // In M-mode, read from tp register (set during boot)
+            // This avoids repeatedly accessing mhartid CSR
+            core::arch::asm!("mv {}, tp", out(reg) hartid);
         }
         hartid
     }

--- a/awkernel_lib/src/arch/rv64/fdt.rs
+++ b/awkernel_lib/src/arch/rv64/fdt.rs
@@ -1,0 +1,163 @@
+//! Simple Flattened Device Tree (FDT) helpers for memory detection
+//!
+//! This module now leverages the `fdt` crate to extract memory information
+//! while keeping a small, RV64-centric surface for the rest of the kernel.
+
+use fdt::Fdt;
+
+/// FDT Magic number (0xd00dfeed in big-endian)
+const FDT_MAGIC: u32 = 0xd00dfeed;
+
+const RISCV_DRAM_BASE: u64 = 0x8000_0000;
+const RISCV_DRAM_MAX_BASE: u64 = 0x9000_0000;
+const MAX_REASONABLE_REGION_SIZE: u64 = 0x1_0000_0000; // 4GB
+
+/// Convert big-endian u32 to native endian
+#[inline]
+fn be32_to_cpu(val: u32) -> u32 {
+    u32::from_be(val)
+}
+
+/// Memory region information
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryRegion {
+    pub base: u64,
+    pub size: u64,
+}
+
+/// Detect memory size from device tree blob
+///
+/// # Safety
+///
+/// This function reads from the DTB address which must point to valid memory.
+pub unsafe fn detect_memory_from_dtb(dtb_addr: usize) -> Option<MemoryRegion> {
+    // Check if DTB address looks valid (aligned and non-zero)
+    if dtb_addr == 0 || dtb_addr & 0x3 != 0 {
+        return None;
+    }
+
+    let fdt = unsafe { Fdt::from_ptr(dtb_addr as *const u8).ok()? };
+    let memory = fdt.memory();
+    let mut regions = memory.regions().filter_map(convert_region);
+
+    regions.find(is_reasonable_region)
+}
+
+fn convert_region(region: fdt::standard_nodes::MemoryRegion) -> Option<MemoryRegion> {
+    let size = region.size? as u64;
+    if size == 0 {
+        return None;
+    }
+
+    Some(MemoryRegion {
+        base: region.starting_address as usize as u64,
+        size,
+    })
+}
+
+fn is_reasonable_region(region: &MemoryRegion) -> bool {
+    region.base >= RISCV_DRAM_BASE
+        && region.base < RISCV_DRAM_MAX_BASE
+        && region.size > 0
+        && region.size < MAX_REASONABLE_REGION_SIZE
+}
+
+/// Probe common DTB locations used by QEMU and firmware
+pub unsafe fn probe_dtb_locations() -> Option<usize> {
+    // Common DTB locations for RISC-V:
+    // 1. 0x82000000 - QEMU often places DTB here
+    // 2. 0x88000000 - Alternative location
+    // 3. 0x87000000 - Another common location
+    // 4. 0xBFE00000 - End of 1GB RAM (QEMU default for some modes)
+
+    let locations = [
+        0xBFE00000, // Try end of 1GB first (QEMU -bios none)
+        0x82000000, 0x88000000, 0x87000000, 0xBFF00000, // Alternative end location
+    ];
+
+    for &addr in &locations {
+        // Check if this looks like a valid DTB
+        let magic_ptr = addr as *const u32;
+        if let Some(magic) = unsafe { magic_ptr.as_ref() } {
+            if be32_to_cpu(*magic) == FDT_MAGIC {
+                return Some(addr);
+            }
+        }
+    }
+
+    None
+}
+
+/// Probe available memory by checking if addresses are accessible
+///
+/// This is a fallback when DTB is not available. We probe memory
+/// in chunks to find where RAM ends.
+pub unsafe fn probe_memory_size() -> Option<u64> {
+    const DRAM_BASE: usize = 0x80000000;
+    const PROBE_STEP: usize = 64 * 1024 * 1024; // 64MB chunks
+    const MAX_PROBE: usize = 2 * 1024 * 1024 * 1024; // Don't probe beyond 2GB
+
+    let mut current = DRAM_BASE + PROBE_STEP;
+    let mut last_valid = DRAM_BASE;
+
+    while current < DRAM_BASE + MAX_PROBE {
+        // Use read-write-verify test pattern for reliable memory detection
+        // This is the standard approach to distinguish valid RAM from MMIO/ROM/unmapped regions
+        let test_addr = current as *mut u32;
+
+        if let Some(ptr) = test_addr.as_mut() {
+            // Save the original value
+            let original = core::ptr::read_volatile(ptr);
+
+            // Write alternating bit pattern (industry standard memory test pattern)
+            core::ptr::write_volatile(ptr, 0xA5A5A5A5);
+
+            // Read back and verify
+            let test_read = core::ptr::read_volatile(ptr);
+
+            // Restore original value to avoid corrupting memory
+            core::ptr::write_volatile(ptr, original);
+
+            // If write was successful, this is valid writable RAM
+            if test_read == 0xA5A5A5A5 {
+                last_valid = current;
+            } else {
+                // Write failed - likely MMIO, ROM, or invalid address
+                break;
+            }
+        } else {
+            break;
+        }
+
+        current += PROBE_STEP;
+    }
+
+    if last_valid > DRAM_BASE {
+        Some((last_valid - DRAM_BASE) as u64)
+    } else {
+        None
+    }
+}
+
+/// Detect the number of CPUs from the device tree blob
+///
+/// # Safety
+///
+/// This function reads from the DTB address which must point to valid memory.
+pub unsafe fn detect_cpu_count_from_dtb(dtb_addr: usize) -> Option<usize> {
+    // Check if DTB address looks valid (aligned and non-zero)
+    if dtb_addr == 0 || dtb_addr & 0x3 != 0 {
+        return None;
+    }
+
+    let fdt = unsafe { Fdt::from_ptr(dtb_addr as *const u8).ok()? };
+
+    // Count CPUs by iterating through /cpus node
+    let cpu_count = fdt.cpus().count();
+
+    if cpu_count > 0 {
+        Some(cpu_count)
+    } else {
+        None
+    }
+}

--- a/awkernel_lib/src/arch/rv64/fdt.rs
+++ b/awkernel_lib/src/arch/rv64/fdt.rs
@@ -12,12 +12,6 @@ const RISCV_DRAM_BASE: u64 = 0x8000_0000;
 const RISCV_DRAM_MAX_BASE: u64 = 0x9000_0000;
 const MAX_REASONABLE_REGION_SIZE: u64 = 0x1_0000_0000; // 4GB
 
-/// Convert big-endian u32 to native endian
-#[inline]
-fn be32_to_cpu(val: u32) -> u32 {
-    u32::from_be(val)
-}
-
 /// Memory region information
 #[derive(Debug, Clone, Copy)]
 pub struct MemoryRegion {
@@ -79,7 +73,7 @@ pub unsafe fn probe_dtb_locations() -> Option<usize> {
         // Check if this looks like a valid DTB
         let magic_ptr = addr as *const u32;
         if let Some(magic) = unsafe { magic_ptr.as_ref() } {
-            if be32_to_cpu(*magic) == FDT_MAGIC {
+            if u32::from_be(*magic) == FDT_MAGIC {
                 return Some(addr);
             }
         }

--- a/awkernel_lib/src/arch/rv64/fdt.rs
+++ b/awkernel_lib/src/arch/rv64/fdt.rs
@@ -127,7 +127,9 @@ pub unsafe fn probe_memory_size() -> Option<u64> {
     }
 
     if last_valid > DRAM_BASE {
-        Some((last_valid - DRAM_BASE) as u64)
+        // `last_valid` is the start of the last successfully probed PROBE_STEP block,
+        // so the detected RAM end is last_valid + PROBE_STEP.
+        Some((last_valid + PROBE_STEP - DRAM_BASE) as u64)
     } else {
         None
     }

--- a/awkernel_lib/src/arch/rv64/frame_allocator.rs
+++ b/awkernel_lib/src/arch/rv64/frame_allocator.rs
@@ -1,4 +1,4 @@
-use super::address::{PhysPageNum, MEMORY_END};
+use super::address::PhysPageNum;
 use crate::addr::{phy_addr::PhyAddr, Addr};
 use crate::sync::mcs::MCSNode;
 use alloc::vec::Vec;
@@ -33,10 +33,9 @@ pub fn frame_dealloc(ppn: PhysPageNum) {
     }
 }
 
-pub fn init_page_allocator() {
-    extern "C" {
-        fn ekernel();
-    }
+/// Initialize the frame allocator over `[start, end)`.
+/// This range must not overlap with the heap region.
+pub fn init_page_allocator(start: usize, end: usize) {
     let mut node = MCSNode::new();
     let mut allocator = FRAME_ALLOCATOR.lock(&mut node);
     if allocator.is_none() {
@@ -44,8 +43,8 @@ pub fn init_page_allocator() {
     }
     if let Some(allocator_ref) = allocator.as_mut() {
         allocator_ref.init(
-            PhyAddr::from_usize(ekernel as *const () as usize).ceil(),
-            PhyAddr::from_usize(MEMORY_END as usize).floor(),
+            PhyAddr::from_usize(start).ceil(),
+            PhyAddr::from_usize(end).floor(),
         );
     } else {
         panic!("[Error] Failed to initialize FrameAllocator!");

--- a/awkernel_lib/src/arch/rv64/frame_allocator.rs
+++ b/awkernel_lib/src/arch/rv64/frame_allocator.rs
@@ -108,7 +108,7 @@ impl FrameAllocator for PageAllocator {
     }
 
     fn alloc_more(&mut self, pages: usize) -> Option<Vec<PhysPageNum>> {
-        if self.current + pages >= self.end {
+        if self.current + pages > self.end {
             None
         } else {
             self.current += pages;

--- a/awkernel_lib/src/arch/rv64/interrupt.rs
+++ b/awkernel_lib/src/arch/rv64/interrupt.rs
@@ -1,5 +1,7 @@
 use crate::interrupt::Interrupt;
 
+// RV64 runs in M-mode without OpenSBI, so we use mstatus
+// MIE (Machine Interrupt Enable) is bit 3 (0x08) in mstatus
 impl Interrupt for super::RV64 {
     fn get_flag() -> usize {
         let x: usize;

--- a/awkernel_lib/src/arch/rv64/vm.rs
+++ b/awkernel_lib/src/arch/rv64/vm.rs
@@ -155,16 +155,6 @@ impl MemorySet {
         }
     }
 
-    pub fn get_heap_size(&self) -> Option<usize> {
-        // Return heap size if calculated during init_kernel_heap
-        let size = HEAP_SIZE.load(core::sync::atomic::Ordering::Relaxed);
-        if size == 0 {
-            None
-        } else {
-            Some(size)
-        }
-    }
-
     #[allow(dead_code)]
     pub fn token(&self) -> usize {
         self.page_table.token()
@@ -307,77 +297,51 @@ use crate::sync::mutex::Mutex;
 pub static KERNEL_SPACE: Mutex<Option<MemorySet>> = Mutex::new(None);
 static HEAP_SIZE: AtomicUsize = AtomicUsize::new(0);
 
-pub fn init_kernel_space() {
+/// Initialize the kernel page table.
+///
+/// `heap_start` and `memory_end` are the physical bounds of the heap region.
+/// They must not overlap with the frame allocator's region.
+pub fn init_kernel_space(heap_start: usize, memory_end: usize) {
     let mut node = MCSNode::new();
     let mut kernel_space = KERNEL_SPACE.lock(&mut node);
     let mut memory_set = MemorySet::new_kernel();
 
-    // Calculate dynamic heap size after kernel mapping
-    let heap_size = calculate_dynamic_heap_size(&mut memory_set);
-    HEAP_SIZE.store(heap_size, Ordering::Relaxed);
+    map_heap_region(&mut memory_set, heap_start, memory_end);
+    HEAP_SIZE.store(memory_end - heap_start, Ordering::Relaxed);
 
     *kernel_space = Some(memory_set);
 }
 
-fn calculate_dynamic_heap_size(memory_set: &mut MemorySet) -> usize {
-    extern "C" {
-        fn ekernel();
+/// Map the heap physical region `[heap_start, memory_end)` into the kernel page table.
+///
+/// Uses identity mapping so physical addresses equal virtual addresses (M-mode compatible).
+/// Page table node frames come from the frame allocator, which must be initialised over a
+/// *separate* region before this is called — that is the guarantee that prevents overlap.
+fn map_heap_region(memory_set: &mut MemorySet, heap_start: usize, memory_end: usize) {
+    if memory_end <= heap_start {
+        unsafe { unsafe_puts("Warning: No memory available for heap\r\n") };
+        return;
     }
-    use crate::addr::{phy_addr::PhyAddr, Addr};
-
-    // Get dynamically detected memory end
-    let memory_end_addr = super::get_memory_end();
-
-    // Calculate available memory after kernel
-    let kernel_end = PhyAddr::from_usize(ekernel as *const () as usize);
-    let memory_end = PhyAddr::from_usize(memory_end_addr as usize);
-
-    // Start heap mapping after kernel, aligned to page boundary
-    let heap_start_phy =
-        PhyAddr::from_usize((kernel_end.as_usize() + PAGESIZE - 1) & !(PAGESIZE - 1));
-
-    if memory_end <= heap_start_phy {
-        unsafe {
-            unsafe_puts("Warning: No memory available for heap\r\n");
-        }
-        return 0;
-    }
-
-    // Calculate heap region
-    let heap_start = heap_start_phy.as_usize();
-    let heap_end = memory_end.as_usize();
-    let heap_size = heap_end - heap_start;
 
     unsafe {
-        unsafe_puts("Dynamic heap calculation:\r\n");
-        unsafe_puts("  Kernel end: 0x");
-        crate::console::unsafe_print_hex_u64(kernel_end.as_usize() as u64);
-        unsafe_puts("\r\n  Heap start: 0x");
+        unsafe_puts("Heap mapping:\r\n  start: 0x");
         crate::console::unsafe_print_hex_u64(heap_start as u64);
-        unsafe_puts("\r\n  Heap end: 0x");
-        crate::console::unsafe_print_hex_u64(heap_end as u64);
-        unsafe_puts("\r\n  Heap size: 0x");
-        crate::console::unsafe_print_hex_u64(heap_size as u64);
+        unsafe_puts("\r\n  end:   0x");
+        crate::console::unsafe_print_hex_u64(memory_end as u64);
+        unsafe_puts("\r\n  size:  0x");
+        crate::console::unsafe_print_hex_u64((memory_end - heap_start) as u64);
         unsafe_puts("\r\n");
-        unsafe_puts("Creating dedicated heap mapping...\r\n");
     }
 
-    // Create dedicated heap mapping using memory_set
     memory_set.push(
         MapArea::new(
             VirtAddr::from_usize(heap_start),
-            VirtAddr::from_usize(heap_end),
+            VirtAddr::from_usize(memory_end),
             MapType::Identical,
             MapPermission::R | MapPermission::W,
         ),
         None,
     );
-
-    unsafe {
-        unsafe_puts("Heap mapping created successfully\r\n");
-    }
-
-    heap_size
 }
 
 pub fn activate_kernel_space() {
@@ -399,35 +363,5 @@ pub fn kernel_token() -> usize {
 }
 
 pub fn get_heap_size() -> usize {
-    // Try to get heap size from kernel space MemorySet first
-    let mut node = MCSNode::new();
-    let kernel_space = KERNEL_SPACE.lock(&mut node);
-    if let Some(ref space) = *kernel_space {
-        if let Some(size) = space.get_heap_size() {
-            return size;
-        }
-    }
-
-    // Fallback: read from HEAP_SIZE atomic if not in MemorySet
-    let heap_size = HEAP_SIZE.load(Ordering::Relaxed);
-    if heap_size == 0 {
-        // Last resort: calculate from memory end
-        extern "C" {
-            fn ekernel();
-        }
-        use crate::addr::{phy_addr::PhyAddr, Addr};
-
-        let memory_end_addr = super::get_memory_end();
-
-        let kernel_end = PhyAddr::from_usize(ekernel as *const () as usize);
-        let memory_end = PhyAddr::from_usize(memory_end_addr as usize);
-
-        if memory_end > kernel_end {
-            memory_end.as_usize() - kernel_end.as_usize()
-        } else {
-            0
-        }
-    } else {
-        heap_size
-    }
+    HEAP_SIZE.load(Ordering::Relaxed)
 }

--- a/awkernel_lib/src/arch/rv64/vm.rs
+++ b/awkernel_lib/src/arch/rv64/vm.rs
@@ -5,6 +5,7 @@ use crate::addr::{virt_addr::VirtAddr, Addr};
 use crate::{console::unsafe_puts, paging::PAGESIZE};
 use alloc::vec::Vec;
 use core::arch::asm;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 extern "C" {
     fn stext();
@@ -154,6 +155,17 @@ impl MemorySet {
     }
 
     #[allow(dead_code)]
+    pub fn get_heap_size(&self) -> Option<usize> {
+        // Return heap size if calculated during init_kernel_heap
+        let size = HEAP_SIZE.load(core::sync::atomic::Ordering::Relaxed);
+        if size == 0 {
+            None
+        } else {
+            Some(size)
+        }
+    }
+
+    #[allow(dead_code)]
     pub fn token(&self) -> usize {
         self.page_table.token()
     }
@@ -194,6 +206,9 @@ impl MemorySet {
 
     pub fn new_kernel() -> Self {
         let mut memory_set = Self::new_bare();
+
+        // Detect actual memory end dynamically
+        let memory_end = super::get_memory_end();
 
         // Map kernel sections
         unsafe {
@@ -250,11 +265,18 @@ impl MemorySet {
 
         unsafe {
             unsafe_puts("Mapping physical memory...\r\n");
+            unsafe_puts("  from ekernel: 0x");
+            crate::console::unsafe_print_hex_u64(ekernel as usize as u64);
+            unsafe_puts("\r\n  to MEMORY_END: 0x");
+            crate::console::unsafe_print_hex_u64(memory_end as usize as u64);
+            unsafe_puts(" (dynamic)\r\n");
         }
+        // Map physical memory range for kernel use
+        // This creates an identity mapping for available RAM
         memory_set.push(
             MapArea::new(
                 VirtAddr::from_usize(ekernel as *const () as usize),
-                VirtAddr::from_usize(super::address::MEMORY_END as usize),
+                VirtAddr::from_usize(memory_end as usize),
                 MapType::Identical,
                 MapPermission::R | MapPermission::W,
             ),
@@ -300,16 +322,66 @@ impl MapArea {
     }
 }
 
-// Static kernel memory set
+// Static kernel memory set and heap size tracking
 use crate::sync::mcs::MCSNode;
 use crate::sync::mutex::Mutex;
 
 pub static KERNEL_SPACE: Mutex<Option<MemorySet>> = Mutex::new(None);
+static HEAP_SIZE: AtomicUsize = AtomicUsize::new(0);
 
 pub fn init_kernel_space() {
     let mut node = MCSNode::new();
     let mut kernel_space = KERNEL_SPACE.lock(&mut node);
-    *kernel_space = Some(MemorySet::new_kernel());
+    let mut memory_set = MemorySet::new_kernel();
+
+    // Calculate dynamic heap size after kernel mapping
+    let heap_size = calculate_dynamic_heap_size(&mut memory_set);
+    HEAP_SIZE.store(heap_size, Ordering::Relaxed);
+
+    *kernel_space = Some(memory_set);
+}
+
+fn calculate_dynamic_heap_size(_memory_set: &mut MemorySet) -> usize {
+    extern "C" {
+        fn ekernel();
+    }
+    use crate::addr::{phy_addr::PhyAddr, Addr};
+
+    // Get dynamically detected memory end
+    let memory_end_addr = super::get_memory_end();
+
+    // Calculate available memory after kernel
+    let kernel_end = PhyAddr::from_usize(ekernel as usize);
+    let memory_end = PhyAddr::from_usize(memory_end_addr as usize);
+
+    // Start heap mapping after kernel, aligned to page boundary
+    let heap_start_phy =
+        PhyAddr::from_usize((kernel_end.as_usize() + PAGESIZE - 1) & !(PAGESIZE - 1));
+
+    if memory_end <= heap_start_phy {
+        unsafe {
+            unsafe_puts("Warning: No memory available for heap\r\n");
+        }
+        return 0;
+    }
+
+    // Calculate maximum possible heap size
+    let max_heap_size = memory_end.as_usize() - heap_start_phy.as_usize();
+
+    unsafe {
+        unsafe_puts("Dynamic heap calculation:\r\n");
+        unsafe_puts("  Kernel end: 0x");
+        crate::console::unsafe_print_hex_u64(kernel_end.as_usize() as u64);
+        unsafe_puts("\r\n  Heap start: 0x");
+        crate::console::unsafe_print_hex_u64(heap_start_phy.as_usize() as u64);
+        unsafe_puts("\r\n  Memory end: 0x");
+        crate::console::unsafe_print_hex_u64(memory_end.as_usize() as u64);
+        unsafe_puts("\r\n  Max heap size: 0x");
+        crate::console::unsafe_print_hex_u64(max_heap_size as u64);
+        unsafe_puts("\r\n");
+    }
+
+    max_heap_size
 }
 
 pub fn activate_kernel_space() {
@@ -327,5 +399,29 @@ pub fn kernel_token() -> usize {
         space.page_table.token()
     } else {
         panic!("Kernel space not initialized")
+    }
+}
+
+pub fn get_heap_size() -> usize {
+    let heap_size = HEAP_SIZE.load(Ordering::Relaxed);
+    if heap_size == 0 {
+        // Fallback calculation if not initialized yet
+        extern "C" {
+            fn ekernel();
+        }
+        use crate::addr::{phy_addr::PhyAddr, Addr};
+
+        let memory_end_addr = super::get_memory_end();
+
+        let kernel_end = PhyAddr::from_usize(ekernel as usize);
+        let memory_end = PhyAddr::from_usize(memory_end_addr as usize);
+
+        if memory_end > kernel_end {
+            memory_end.as_usize() - kernel_end.as_usize()
+        } else {
+            0
+        }
+    } else {
+        heap_size
     }
 }

--- a/awkernel_lib/src/arch/rv64/vm.rs
+++ b/awkernel_lib/src/arch/rv64/vm.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 use core::arch::asm;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+#[allow(dead_code)]
 extern "C" {
     fn stext();
     fn etext();
@@ -154,7 +155,6 @@ impl MemorySet {
         }
     }
 
-    #[allow(dead_code)]
     pub fn get_heap_size(&self) -> Option<usize> {
         // Return heap size if calculated during init_kernel_heap
         let size = HEAP_SIZE.load(core::sync::atomic::Ordering::Relaxed);
@@ -206,9 +206,6 @@ impl MemorySet {
 
     pub fn new_kernel() -> Self {
         let mut memory_set = Self::new_bare();
-
-        // Detect actual memory end dynamically
-        let memory_end = super::get_memory_end();
 
         // Map kernel sections
         unsafe {
@@ -263,26 +260,7 @@ impl MemorySet {
             None,
         );
 
-        unsafe {
-            unsafe_puts("Mapping physical memory...\r\n");
-            unsafe_puts("  from ekernel: 0x");
-            crate::console::unsafe_print_hex_u64(ekernel as usize as u64);
-            unsafe_puts("\r\n  to MEMORY_END: 0x");
-            crate::console::unsafe_print_hex_u64(memory_end as usize as u64);
-            unsafe_puts(" (dynamic)\r\n");
-        }
-        // Map physical memory range for kernel use
-        // This creates an identity mapping for available RAM
-        memory_set.push(
-            MapArea::new(
-                VirtAddr::from_usize(ekernel as *const () as usize),
-                VirtAddr::from_usize(memory_end as usize),
-                MapType::Identical,
-                MapPermission::R | MapPermission::W,
-            ),
-            None,
-        );
-
+        // Note: Heap mapping is created separately in calculate_dynamic_heap_size()
         memory_set
     }
 
@@ -293,7 +271,7 @@ impl MemorySet {
             asm!("sfence.vma");
         }
     }
-    #[allow(dead_code)]
+
     pub fn translate(&mut self, vpn: VirtPageNum) -> Option<PageTableEntry> {
         self.page_table.translate(vpn)
     }
@@ -341,7 +319,7 @@ pub fn init_kernel_space() {
     *kernel_space = Some(memory_set);
 }
 
-fn calculate_dynamic_heap_size(_memory_set: &mut MemorySet) -> usize {
+fn calculate_dynamic_heap_size(memory_set: &mut MemorySet) -> usize {
     extern "C" {
         fn ekernel();
     }
@@ -351,7 +329,7 @@ fn calculate_dynamic_heap_size(_memory_set: &mut MemorySet) -> usize {
     let memory_end_addr = super::get_memory_end();
 
     // Calculate available memory after kernel
-    let kernel_end = PhyAddr::from_usize(ekernel as usize);
+    let kernel_end = PhyAddr::from_usize(ekernel as *const () as usize);
     let memory_end = PhyAddr::from_usize(memory_end_addr as usize);
 
     // Start heap mapping after kernel, aligned to page boundary
@@ -365,23 +343,41 @@ fn calculate_dynamic_heap_size(_memory_set: &mut MemorySet) -> usize {
         return 0;
     }
 
-    // Calculate maximum possible heap size
-    let max_heap_size = memory_end.as_usize() - heap_start_phy.as_usize();
+    // Calculate heap region
+    let heap_start = heap_start_phy.as_usize();
+    let heap_end = memory_end.as_usize();
+    let heap_size = heap_end - heap_start;
 
     unsafe {
         unsafe_puts("Dynamic heap calculation:\r\n");
         unsafe_puts("  Kernel end: 0x");
         crate::console::unsafe_print_hex_u64(kernel_end.as_usize() as u64);
         unsafe_puts("\r\n  Heap start: 0x");
-        crate::console::unsafe_print_hex_u64(heap_start_phy.as_usize() as u64);
-        unsafe_puts("\r\n  Memory end: 0x");
-        crate::console::unsafe_print_hex_u64(memory_end.as_usize() as u64);
-        unsafe_puts("\r\n  Max heap size: 0x");
-        crate::console::unsafe_print_hex_u64(max_heap_size as u64);
+        crate::console::unsafe_print_hex_u64(heap_start as u64);
+        unsafe_puts("\r\n  Heap end: 0x");
+        crate::console::unsafe_print_hex_u64(heap_end as u64);
+        unsafe_puts("\r\n  Heap size: 0x");
+        crate::console::unsafe_print_hex_u64(heap_size as u64);
         unsafe_puts("\r\n");
+        unsafe_puts("Creating dedicated heap mapping...\r\n");
     }
 
-    max_heap_size
+    // Create dedicated heap mapping using memory_set
+    memory_set.push(
+        MapArea::new(
+            VirtAddr::from_usize(heap_start),
+            VirtAddr::from_usize(heap_end),
+            MapType::Identical,
+            MapPermission::R | MapPermission::W,
+        ),
+        None,
+    );
+
+    unsafe {
+        unsafe_puts("Heap mapping created successfully\r\n");
+    }
+
+    heap_size
 }
 
 pub fn activate_kernel_space() {
@@ -391,7 +387,7 @@ pub fn activate_kernel_space() {
         kernel_space.activate();
     }
 }
-#[allow(dead_code)]
+
 pub fn kernel_token() -> usize {
     let mut node = MCSNode::new();
     let kernel_space = KERNEL_SPACE.lock(&mut node);
@@ -403,9 +399,19 @@ pub fn kernel_token() -> usize {
 }
 
 pub fn get_heap_size() -> usize {
+    // Try to get heap size from kernel space MemorySet first
+    let mut node = MCSNode::new();
+    let kernel_space = KERNEL_SPACE.lock(&mut node);
+    if let Some(ref space) = *kernel_space {
+        if let Some(size) = space.get_heap_size() {
+            return size;
+        }
+    }
+
+    // Fallback: read from HEAP_SIZE atomic if not in MemorySet
     let heap_size = HEAP_SIZE.load(Ordering::Relaxed);
     if heap_size == 0 {
-        // Fallback calculation if not initialized yet
+        // Last resort: calculate from memory end
         extern "C" {
             fn ekernel();
         }
@@ -413,7 +419,7 @@ pub fn get_heap_size() -> usize {
 
         let memory_end_addr = super::get_memory_end();
 
-        let kernel_end = PhyAddr::from_usize(ekernel as usize);
+        let kernel_end = PhyAddr::from_usize(ekernel as *const () as usize);
         let memory_end = PhyAddr::from_usize(memory_end_addr as usize);
 
         if memory_end > kernel_end {

--- a/awkernel_lib/src/arch/rv64/vm.rs
+++ b/awkernel_lib/src/arch/rv64/vm.rs
@@ -250,7 +250,8 @@ impl MemorySet {
             None,
         );
 
-        // Note: Heap mapping is created separately in calculate_dynamic_heap_size()
+        // Note: The page-table-frame and heap regions are mapped separately when
+        // init_kernel_space() calls map_identity_region() / map_heap_region().
         memory_set
     }
 
@@ -302,17 +303,47 @@ static HEAP_SIZE: AtomicUsize = AtomicUsize::new(0);
 
 /// Initialize the kernel page table.
 ///
-/// `heap_start` and `memory_end` are the physical bounds of the heap region.
-/// They must not overlap with the frame allocator's region.
-pub fn init_kernel_space(heap_start: usize, memory_end: usize) {
+/// `[pt_start, heap_start)` is the frame allocator's region (page table frames)
+/// and `[heap_start, memory_end)` is the heap region. The page-table-frame
+/// region must be identity-mapped too: page table code dereferences those
+/// frames via their physical addresses (e.g. `PhysPageNum::get_pte_array()`),
+/// which must remain valid once translation is enabled.
+pub fn init_kernel_space(pt_start: usize, heap_start: usize, memory_end: usize) {
     let mut node = MCSNode::new();
     let mut kernel_space = KERNEL_SPACE.lock(&mut node);
     let mut memory_set = MemorySet::new_kernel();
 
+    map_identity_region(&mut memory_set, pt_start, heap_start, "Page table frame");
     map_heap_region(&mut memory_set, heap_start, memory_end);
     HEAP_SIZE.store(memory_end - heap_start, Ordering::Relaxed);
 
     *kernel_space = Some(memory_set);
+}
+
+/// Identity-map `[start, end)` with read/write permissions into the kernel page table.
+fn map_identity_region(memory_set: &mut MemorySet, start: usize, end: usize, name: &str) {
+    if end <= start {
+        return;
+    }
+
+    unsafe {
+        unsafe_puts(name);
+        unsafe_puts(" mapping:\r\n  start: 0x");
+        crate::console::unsafe_print_hex_u64(start as u64);
+        unsafe_puts("\r\n  end:   0x");
+        crate::console::unsafe_print_hex_u64(end as u64);
+        unsafe_puts("\r\n");
+    }
+
+    memory_set.push(
+        MapArea::new(
+            VirtAddr::from_usize(start),
+            VirtAddr::from_usize(end),
+            MapType::Identical,
+            MapPermission::R | MapPermission::W,
+        ),
+        None,
+    );
 }
 
 /// Map the heap physical region `[heap_start, memory_end)` into the kernel page table.

--- a/awkernel_lib/src/arch/rv64/vm.rs
+++ b/awkernel_lib/src/arch/rv64/vm.rs
@@ -257,8 +257,11 @@ impl MemorySet {
     pub fn activate(&self) {
         let satp = self.page_table.token();
         unsafe {
-            asm!("csrw satp, {}", in(reg) satp);
-            asm!("sfence.vma");
+            asm!(
+                "csrw satp, {satp}",
+                "sfence.vma",
+                satp = in(reg) satp,
+            );
         }
     }
 

--- a/awkernel_lib/src/interrupt.rs
+++ b/awkernel_lib/src/interrupt.rs
@@ -343,8 +343,8 @@ pub fn handle_irq(irq: u16) {
 }
 
 /// Handle all pending interrupt requests.
-/// This function will be used by only aarch64 and called from CPU's interrupt handlers.
-#[cfg(feature = "aarch64")]
+/// This is used by aarch64 and RISC-V, and called from CPU's interrupt handlers.
+#[cfg(any(feature = "aarch64", target_arch = "riscv32", target_arch = "riscv64"))]
 pub fn handle_irqs(is_task: bool) {
     use crate::{heap, unwind::catch_unwind};
     use core::mem::transmute;
@@ -401,57 +401,6 @@ pub fn handle_preemption() {
     let ptr = PREEMPT_FN.load(Ordering::Relaxed);
     let preemption = unsafe { transmute::<*mut (), fn()>(ptr) };
     preemption();
-}
-
-/// Handle all pending interrupt requests for RISC-V.
-/// This is called from the M-mode interrupt handler.
-#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
-pub fn handle_irqs(is_task: bool) {
-    use crate::{heap, unwind::catch_unwind};
-    use core::mem::transmute;
-
-    let handlers = IRQ_HANDLERS.read();
-    let mut need_preemption = false;
-
-    let controller = INTERRUPT_CONTROLLER.read();
-    if let Some(ctrl) = controller.as_ref() {
-        let iter = ctrl.pending_irqs();
-        drop(controller); // unlock
-
-        // Use the primary allocator.
-        #[cfg(not(feature = "std"))]
-        let _guard = {
-            let g = heap::TALLOC.save();
-            unsafe { heap::TALLOC.use_primary() };
-            g
-        };
-
-        for irq in iter {
-            if irq == PREEMPT_IRQ.load(Ordering::Relaxed) {
-                need_preemption = true;
-                continue;
-            }
-
-            if let Some((_, handler)) = handlers.get(&irq) {
-                if let Err(err) = catch_unwind(|| {
-                    handler(irq);
-                }) {
-                    log::warn!("an interrupt handler has been panicked\n{err:?}");
-                }
-            }
-        }
-    }
-
-    if need_preemption && is_task {
-        let ptr = PREEMPT_FN.load(Ordering::Relaxed);
-        let preemption = unsafe { transmute::<*mut (), fn()>(ptr) };
-        preemption();
-    }
-
-    // Because IPIs are edge-trigger,
-    // IPI sent during interrupt handlers will be ignored.
-    // To notify the interrupt again, we setup a timer.
-    crate::cpu::reset_wakeup_timer();
 }
 
 /// Disable interrupts and automatically restored the configuration.

--- a/kernel/ld/rv64-link.lds
+++ b/kernel/ld/rv64-link.lds
@@ -3,10 +3,11 @@ ENTRY(_start)
 
 SECTIONS
 {
-    . = 0x80200000;
+    /* Boot code at DRAM start for -bios none */
+    . = 0x80000000;
     PROVIDE (__executable_start = .);
     __ram_start = .;
-    
+
     PROVIDE (stext = .);
     .init : { KEEP(*(.init)) }
     .text : { *(.text .text.* .gnu.linkonce.t*) }

--- a/kernel/src/arch/rv64.rs
+++ b/kernel/src/arch/rv64.rs
@@ -1,3 +1,5 @@
 pub mod config;
 mod console;
+mod interrupt_controller;
 mod kernel_main;
+mod timer;

--- a/kernel/src/arch/rv64/boot.S
+++ b/kernel/src/arch/rv64/boot.S
@@ -7,13 +7,28 @@
   .attribute arch, "rv64gc"
 
 _start:
+  # Read hart ID from mhartid CSR (M-mode)
+  csrr a0, mhartid
+  mv tp, a0    # save hartid to thread pointer for later use
+
+  # Preserve DTB pointer that QEMU/firmware passes in a1
+  la t0, dtb_ptr
+  sd a1, 0(t0)
+
+  # set up a simple trap handler for M-mode
+  la t0, early_trap_handler
+  csrw mtvec, t0
+
+  # Initialize mscratch to 0 (will be set properly later if needed)
+  csrw mscratch, zero
+
   # set up the 8MB initial stack for each cpu.
   li sp, 0x80800000
-  li a0, 0x00800000
-  csrr a1, mhartid
-  addi a1, a1, 1
-  mul a0, a0, a1
-  add sp, sp, a0
+  li t0, 0x00800000
+  mv t1, a0    # use hartid
+  addi t1, t1, 1
+  mul t0, t0, t1
+  add sp, sp, t0
   # clear the BSS
   la t0, __bss_start
   la t1, __bss_end
@@ -25,3 +40,202 @@ _start:
   jal ra, kernel_main
 2:
   j 2b
+
+# M-mode trap handler - handles interrupts and exceptions
+.align 4
+early_trap_handler:
+  # Check if this is an interrupt or exception
+  csrr t0, mcause
+  blt t0, zero, handle_interrupt  # If MSB is set, it's an interrupt
+
+  # This is an exception - print debug info and halt
+  j unhandled_trap
+
+handle_interrupt:
+  # Get interrupt code (lower bits of mcause)
+  li t1, 0x7FFFFFFFFFFFFFFF
+  and t0, t0, t1
+
+  # Check interrupt type
+  li t1, 7  # M-mode timer interrupt
+  beq t0, t1, handle_timer_interrupt
+
+  li t1, 3  # M-mode software interrupt (IPI)
+  beq t0, t1, handle_software_interrupt
+
+  # Unknown interrupt - just return
+  mret
+
+handle_timer_interrupt:
+  # Save all registers that might be clobbered by the Rust handler
+  addi sp, sp, -256
+  sd ra, 0(sp)
+  sd t0, 8(sp)
+  sd t1, 16(sp)
+  sd t2, 24(sp)
+  sd a0, 32(sp)
+  sd a1, 40(sp)
+  sd a2, 48(sp)
+  sd a3, 56(sp)
+  sd a4, 64(sp)
+  sd a5, 72(sp)
+  sd a6, 80(sp)
+  sd a7, 88(sp)
+  sd t3, 96(sp)
+  sd t4, 104(sp)
+  sd t5, 112(sp)
+  sd t6, 120(sp)
+
+  # Disable timer interrupt temporarily by setting mtimecmp to max
+  # MTIMECMP base is 0x02004000, each hart has 8-byte register
+  csrr t0, mhartid
+  slli t0, t0, 3  # Multiply by 8
+  li t1, 0x02004000
+  add t0, t0, t1
+  li t1, -1
+  sd t1, 0(t0)
+
+  # Call the Rust timer handler
+  call riscv_handle_timer
+
+  # Restore registers
+  ld ra, 0(sp)
+  ld t0, 8(sp)
+  ld t1, 16(sp)
+  ld t2, 24(sp)
+  ld a0, 32(sp)
+  ld a1, 40(sp)
+  ld a2, 48(sp)
+  ld a3, 56(sp)
+  ld a4, 64(sp)
+  ld a5, 72(sp)
+  ld a6, 80(sp)
+  ld a7, 88(sp)
+  ld t3, 96(sp)
+  ld t4, 104(sp)
+  ld t5, 112(sp)
+  ld t6, 120(sp)
+  addi sp, sp, 256
+
+  # Return from interrupt
+  mret
+
+handle_software_interrupt:
+  # Save all registers that might be clobbered by the Rust handler
+  addi sp, sp, -256
+  sd ra, 0(sp)
+  sd t0, 8(sp)
+  sd t1, 16(sp)
+  sd t2, 24(sp)
+  sd a0, 32(sp)
+  sd a1, 40(sp)
+  sd a2, 48(sp)
+  sd a3, 56(sp)
+  sd a4, 64(sp)
+  sd a5, 72(sp)
+  sd a6, 80(sp)
+  sd a7, 88(sp)
+  sd t3, 96(sp)
+  sd t4, 104(sp)
+  sd t5, 112(sp)
+  sd t6, 120(sp)
+
+  # Clear the software interrupt by writing 0 to MSIP
+  # MSIP base is 0x02000000, each hart has 4-byte register
+  csrr t0, mhartid
+  slli t0, t0, 2  # Multiply by 4
+  li t1, 0x02000000
+  add t0, t0, t1
+  sw zero, 0(t0)   # Clear MSIP
+
+  # Call the Rust IPI handler
+  call riscv_handle_ipi
+
+  # Restore registers
+  ld ra, 0(sp)
+  ld t0, 8(sp)
+  ld t1, 16(sp)
+  ld t2, 24(sp)
+  ld a0, 32(sp)
+  ld a1, 40(sp)
+  ld a2, 48(sp)
+  ld a3, 56(sp)
+  ld a4, 64(sp)
+  ld a5, 72(sp)
+  ld a6, 80(sp)
+  ld a7, 88(sp)
+  ld t3, 96(sp)
+  ld t4, 104(sp)
+  ld t5, 112(sp)
+  ld t6, 120(sp)
+  addi sp, sp, 256
+
+  # Return from interrupt
+  mret
+
+unhandled_trap:
+  # Write 'TRAP!' to UART
+  li t0, 0x10000000
+  li t1, 'T'
+  sb t1, 0(t0)
+  li t1, 'R'
+  sb t1, 0(t0)
+  li t1, 'A'
+  sb t1, 0(t0)
+  li t1, 'P'
+  sb t1, 0(t0)
+  li t1, '!'
+  sb t1, 0(t0)
+  li t1, '\r'
+  sb t1, 0(t0)
+  li t1, '\n'
+  sb t1, 0(t0)
+
+  # Print mcause
+  csrr a0, mcause
+  call print_hex
+
+  # Print mepc
+  csrr a0, mepc
+  call print_hex
+
+  # Print mtval
+  csrr a0, mtval
+  call print_hex
+
+  # Infinite loop
+1:
+  j 1b
+
+# Helper function to print a hex value
+print_hex:
+  li t0, 0x10000000
+  li t2, 60  # shift amount: 60, 56, 52, ..., 0
+  li t3, 16  # counter
+1:
+  srl t1, a0, t2
+  andi t1, t1, 0xF
+  li t4, 10
+  blt t1, t4, 2f
+  addi t1, t1, 'A'-10
+  j 3f
+2:
+  addi t1, t1, '0'
+3:
+  sb t1, 0(t0)
+  addi t2, t2, -4
+  addi t3, t3, -1
+  bnez t3, 1b
+
+  # Print newline
+  li t1, '\r'
+  sb t1, 0(t0)
+  li t1, '\n'
+  sb t1, 0(t0)
+  ret
+
+  .section .data
+  .align 3
+  .global dtb_ptr
+dtb_ptr:
+  .dword 0

--- a/kernel/src/arch/rv64/boot.S
+++ b/kernel/src/arch/rv64/boot.S
@@ -74,6 +74,9 @@ handle_interrupt:
   li t1, 3  # M-mode software interrupt (IPI)
   beq t0, t1, handle_software_interrupt
 
+  li t1, 11  # M-mode external interrupt (PLIC)
+  beq t0, t1, handle_external_interrupt
+
   # Unknown interrupt - just return
   mret
 
@@ -161,6 +164,51 @@ handle_software_interrupt:
 
   # Call the Rust IPI handler
   call riscv_handle_ipi
+
+  # Restore registers
+  ld ra, 0(sp)
+  ld t0, 8(sp)
+  ld t1, 16(sp)
+  ld t2, 24(sp)
+  ld a0, 32(sp)
+  ld a1, 40(sp)
+  ld a2, 48(sp)
+  ld a3, 56(sp)
+  ld a4, 64(sp)
+  ld a5, 72(sp)
+  ld a6, 80(sp)
+  ld a7, 88(sp)
+  ld t3, 96(sp)
+  ld t4, 104(sp)
+  ld t5, 112(sp)
+  ld t6, 120(sp)
+  addi sp, sp, 256
+
+  # Return from interrupt
+  mret
+
+handle_external_interrupt:
+  # Save all registers that might be clobbered by the Rust handler
+  addi sp, sp, -256
+  sd ra, 0(sp)
+  sd t0, 8(sp)
+  sd t1, 16(sp)
+  sd t2, 24(sp)
+  sd a0, 32(sp)
+  sd a1, 40(sp)
+  sd a2, 48(sp)
+  sd a3, 56(sp)
+  sd a4, 64(sp)
+  sd a5, 72(sp)
+  sd a6, 80(sp)
+  sd a7, 88(sp)
+  sd t3, 96(sp)
+  sd t4, 104(sp)
+  sd t5, 112(sp)
+  sd t6, 120(sp)
+
+  # Call the Rust external interrupt handler (claims/completes via PLIC)
+  call riscv_handle_external
 
   # Restore registers
   ld ra, 0(sp)

--- a/kernel/src/arch/rv64/boot.S
+++ b/kernel/src/arch/rv64/boot.S
@@ -11,11 +11,7 @@ _start:
   csrr a0, mhartid
   mv tp, a0    # save hartid to thread pointer for later use
 
-  # Preserve DTB pointer that QEMU/firmware passes in a1
-  la t0, dtb_ptr
-  sd a1, 0(t0)
-
-  # set up a simple trap handler for M-mode
+  # set up a simple trap handler for M-mode (all harts)
   la t0, early_trap_handler
   csrw mtvec, t0
 
@@ -29,13 +25,28 @@ _start:
   addi t1, t1, 1
   mul t0, t0, t1
   add sp, sp, t0
-  # clear the BSS
+
+  # Only hart 0 saves the DTB pointer and clears BSS.
+  # Secondary harts skip straight to kernel_main and spin on
+  # PRIMARY_INITIALIZED until hart 0 has finished boot setup.
+  bnez a0, .Lskip_primary_init
+
+  # Preserve DTB pointer that QEMU/firmware passes in a1 (hart 0 only)
+  la t0, dtb_ptr
+  sd a1, 0(t0)
+
+  # clear the BSS (hart 0 only — avoids racing with PRIMARY_INITIALIZED)
   la t0, __bss_start
   la t1, __bss_end
 1:
   sd zero, 0(t0)
   addi t0, t0, 8
   bltu t0, t1, 1b
+
+  # Ensure BSS writes are visible before secondary harts read them
+  fence w, rw
+
+.Lskip_primary_init:
   # jump to kernel_main
   jal ra, kernel_main
 2:

--- a/kernel/src/arch/rv64/config.rs
+++ b/kernel/src/arch/rv64/config.rs
@@ -1,4 +1,2 @@
-pub const HEAP_START: usize = 0x0008_8000_0000;
-
 pub const PREEMPT_IRQ: u16 = 0;
 pub const WAKEUP_IRQ: u16 = 1;

--- a/kernel/src/arch/rv64/interrupt_controller.rs
+++ b/kernel/src/arch/rv64/interrupt_controller.rs
@@ -1,0 +1,197 @@
+use alloc::boxed::Box;
+use awkernel_lib::interrupt::InterruptController;
+use core::ptr::{read_volatile, write_volatile};
+use core::sync::atomic::Ordering;
+
+/// RISC-V PLIC (Platform-Level Interrupt Controller) implementation
+/// Combined with CLINT/ACLINT for IPI support
+pub struct RiscvPlic {
+    base_address: usize,
+    max_priority: u32,
+    num_sources: u16,
+}
+
+// CLINT/ACLINT base address for IPIs
+const ACLINT_BASE: usize = 0x0200_0000;
+const MSIP_OFFSET: usize = 0x0000; // Machine Software Interrupt Pending
+
+// Import the detected CPU count from kernel_main
+use super::kernel_main::NUM_CPUS;
+
+impl RiscvPlic {
+    /// Create a new RISC-V PLIC controller
+    pub const fn new(base_address: usize, num_sources: u16) -> Self {
+        Self {
+            base_address,
+            max_priority: 7, // Typical PLIC priority levels: 0-7
+            num_sources,
+        }
+    }
+
+    /// Get the priority register address for a given interrupt source
+    fn priority_reg(&self, source: u16) -> *mut u32 {
+        (self.base_address + (source as usize * 4)) as *mut u32
+    }
+
+    /// Get the enable register address for a given context and interrupt source
+    fn enable_reg(&self, context: usize, source: u16) -> *mut u32 {
+        let reg_index = source as usize / 32;
+        let base = self.base_address + 0x2000 + context * 0x80;
+        (base + reg_index * 4) as *mut u32
+    }
+
+    /// Get the threshold register address for a given context
+    fn threshold_reg(&self, context: usize) -> *mut u32 {
+        (self.base_address + 0x200000 + context * 0x1000) as *mut u32
+    }
+
+    /// Get the claim register address for a given context
+    fn claim_reg(&self, context: usize) -> *mut u32 {
+        (self.base_address + 0x200004 + context * 0x1000) as *mut u32
+    }
+
+    /// Set priority for an interrupt source
+    fn set_priority(&self, source: u16, priority: u32) {
+        if source > 0 && source <= self.num_sources && priority <= self.max_priority {
+            let reg = self.priority_reg(source);
+            unsafe { write_volatile(reg, priority) };
+        }
+    }
+
+    /// Enable interrupt for a specific context
+    fn enable_interrupt(&self, context: usize, source: u16) {
+        if source > 0 && source <= self.num_sources {
+            let reg = self.enable_reg(context, source);
+            let bit_pos = source as usize % 32;
+            unsafe {
+                let current = read_volatile(reg);
+                write_volatile(reg, current | (1 << bit_pos));
+            }
+        }
+    }
+
+    /// Disable interrupt for a specific context
+    fn disable_interrupt(&self, context: usize, source: u16) {
+        if source > 0 && source <= self.num_sources {
+            let reg = self.enable_reg(context, source);
+            let bit_pos = source as usize % 32;
+            unsafe {
+                let current = read_volatile(reg);
+                write_volatile(reg, current & !(1 << bit_pos));
+            }
+        }
+    }
+
+    /// Get the current hart ID (CPU ID)
+    fn get_hart_id(&self) -> usize {
+        // Use mhartid CSR to get hart ID
+        let hart_id: usize;
+        unsafe {
+            core::arch::asm!("csrr {}, mhartid", out(reg) hart_id);
+        }
+        hart_id
+    }
+
+    /// Get supervisor mode context for current hart
+    fn get_supervisor_context(&self) -> usize {
+        // Typically supervisor mode context = hartid * 2 + 1
+        self.get_hart_id() * 2 + 1
+    }
+
+    /// Send software interrupt (IPI) to a specific hart
+    fn send_software_interrupt(&self, hart_id: u32) {
+        // MSIP register for each hart is at ACLINT_BASE + MSIP_OFFSET + (hart_id * 4)
+        let msip_addr = (ACLINT_BASE + MSIP_OFFSET + (hart_id as usize * 4)) as *mut u32;
+        unsafe {
+            write_volatile(msip_addr, 1);
+        }
+    }
+
+    /// Enable machine software interrupts
+    fn enable_software_interrupts(&self) {
+        unsafe {
+            // Set MIE.MSIE (Machine Software Interrupt Enable) bit (bit 3)
+            core::arch::asm!("csrrs t0, mie, {}", in(reg) 1 << 3);
+        }
+    }
+}
+
+impl InterruptController for RiscvPlic {
+    fn enable_irq(&mut self, irq: u16) {
+        // Set a reasonable priority for the interrupt
+        self.set_priority(irq, 1);
+
+        // Enable for supervisor mode (we're running in supervisor mode)
+        let context = self.get_supervisor_context();
+        self.enable_interrupt(context, irq);
+    }
+
+    fn disable_irq(&mut self, irq: u16) {
+        let context = self.get_supervisor_context();
+        self.disable_interrupt(context, irq);
+    }
+
+    fn pending_irqs(&self) -> Box<dyn Iterator<Item = u16>> {
+        // Check pending interrupts by claiming them
+        let context = self.get_supervisor_context();
+        let claim_reg = self.claim_reg(context);
+
+        let mut pending = alloc::vec::Vec::new();
+
+        unsafe {
+            let claimed = read_volatile(claim_reg);
+            if claimed != 0 {
+                pending.push(claimed as u16);
+                // Complete the interrupt (write back the claim)
+                write_volatile(claim_reg, claimed);
+            }
+        }
+
+        Box::new(pending.into_iter())
+    }
+
+    fn send_ipi(&mut self, _irq: u16, cpu_id: u32) {
+        // Send machine software interrupt to the target hart
+        self.send_software_interrupt(cpu_id);
+    }
+
+    fn send_ipi_broadcast(&mut self, _irq: u16) {
+        // Send IPI to all CPUs
+        let num_cpus = NUM_CPUS.load(Ordering::Acquire) as u32;
+        for cpu_id in 0..num_cpus {
+            self.send_software_interrupt(cpu_id);
+        }
+    }
+
+    fn send_ipi_broadcast_without_self(&mut self, _irq: u16) {
+        // Send IPI to all CPUs except current
+        let current_hart = self.get_hart_id() as u32;
+        let num_cpus = NUM_CPUS.load(Ordering::Acquire) as u32;
+        for cpu_id in 0..num_cpus {
+            if cpu_id != current_hart {
+                self.send_software_interrupt(cpu_id);
+            }
+        }
+    }
+
+    fn init_non_primary(&mut self) {
+        // Set threshold to 0 to accept all interrupts
+        let context = self.get_supervisor_context();
+        let threshold_reg = self.threshold_reg(context);
+        unsafe { write_volatile(threshold_reg, 0) };
+
+        // Enable software interrupts for IPIs
+        self.enable_software_interrupts();
+    }
+
+    fn irq_range(&self) -> (u16, u16) {
+        // PLIC interrupt sources typically range from 1 to num_sources
+        (1, self.num_sources + 1)
+    }
+
+    fn irq_range_for_pnp(&self) -> (u16, u16) {
+        // Reserve lower IRQs for system use, higher for PnP
+        let start = self.num_sources / 2;
+        (start, self.num_sources + 1)
+    }
+}

--- a/kernel/src/arch/rv64/interrupt_controller.rs
+++ b/kernel/src/arch/rv64/interrupt_controller.rs
@@ -92,10 +92,10 @@ impl RiscvPlic {
         hart_id
     }
 
-    /// Get supervisor mode context for current hart
-    fn get_supervisor_context(&self) -> usize {
-        // Typically supervisor mode context = hartid * 2 + 1
-        self.get_hart_id() * 2 + 1
+    /// Get machine mode PLIC context for current hart (hartid * 2).
+    /// S-mode context would be hartid * 2 + 1, but this kernel runs in M-mode.
+    fn get_machine_context(&self) -> usize {
+        self.get_hart_id() * 2
     }
 
     /// Send software interrupt (IPI) to a specific hart
@@ -110,8 +110,7 @@ impl RiscvPlic {
     /// Enable machine software interrupts
     fn enable_software_interrupts(&self) {
         unsafe {
-            // Set MIE.MSIE (Machine Software Interrupt Enable) bit (bit 3)
-            core::arch::asm!("csrrs t0, mie, {}", in(reg) 1 << 3);
+            core::arch::asm!("csrrs {tmp}, mie, {val}", tmp = lateout(reg) _, val = in(reg) (1usize << 3));
         }
     }
 }
@@ -121,19 +120,18 @@ impl InterruptController for RiscvPlic {
         // Set a reasonable priority for the interrupt
         self.set_priority(irq, 1);
 
-        // Enable for supervisor mode (we're running in supervisor mode)
-        let context = self.get_supervisor_context();
+        let context = self.get_machine_context();
         self.enable_interrupt(context, irq);
     }
 
     fn disable_irq(&mut self, irq: u16) {
-        let context = self.get_supervisor_context();
+        let context = self.get_machine_context();
         self.disable_interrupt(context, irq);
     }
 
     fn pending_irqs(&self) -> Box<dyn Iterator<Item = u16>> {
         // Check pending interrupts by claiming them
-        let context = self.get_supervisor_context();
+        let context = self.get_machine_context();
         let claim_reg = self.claim_reg(context);
 
         let mut pending = alloc::vec::Vec::new();
@@ -176,7 +174,7 @@ impl InterruptController for RiscvPlic {
 
     fn init_non_primary(&mut self) {
         // Set threshold to 0 to accept all interrupts
-        let context = self.get_supervisor_context();
+        let context = self.get_machine_context();
         let threshold_reg = self.threshold_reg(context);
         unsafe { write_volatile(threshold_reg, 0) };
 

--- a/kernel/src/arch/rv64/interrupt_controller.rs
+++ b/kernel/src/arch/rv64/interrupt_controller.rs
@@ -1,5 +1,7 @@
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use awkernel_lib::interrupt::InterruptController;
+use awkernel_lib::sync::{mcs::MCSNode, mutex::Mutex};
 use core::ptr::{read_volatile, write_volatile};
 use core::sync::atomic::{AtomicU64, Ordering};
 
@@ -32,6 +34,20 @@ const MAX_HARTS: usize = awkernel_lib::cpu::NUM_MAX_CPU;
 /// records the logical IRQ (e.g. PREEMPT_IRQ vs WAKEUP_IRQ) here before raising
 /// MSIP, and `pending_irqs()` on the target hart drains it.
 static LOCAL_PENDING: [AtomicU64; MAX_HARTS] = [const { AtomicU64::new(0) }; MAX_HARTS];
+
+/// Per-hart list of PLIC sources claimed by `pending_irqs()` but not yet
+/// completed.
+///
+/// For level-triggered devices the PLIC completion (writing the claimed source
+/// id back to the claim register) must happen only after the registered handler
+/// has cleared the device-side interrupt condition. Completing earlier lets the
+/// PLIC gateway immediately re-forward the same source. `pending_irqs()` claims
+/// each source (which masks further claims for it) and records it here; `eoi()`
+/// writes the completions back after `handle_irqs()` has dispatched the handlers.
+///
+/// M-mode disables interrupts while a trap handler runs, so a hart never
+/// re-enters this path on top of itself; only the owning hart touches its slot.
+static CLAIMED: [Mutex<Vec<u16>>; MAX_HARTS] = [const { Mutex::new(Vec::new()) }; MAX_HARTS];
 
 /// Record a pending local interrupt for `hart_id` so the next `pending_irqs()`
 /// call on that hart reports `irq`.
@@ -200,8 +216,13 @@ impl InterruptController for RiscvPlic {
 
         // Then drain all pending PLIC external interrupts by claiming until the
         // claim register reads 0, so multiple pending sources are not starved.
+        // Claiming a source masks further claims for it until it is completed, so
+        // this loop terminates even though completion is deferred to eoi().
         let context = self.get_machine_context();
         let claim_reg = self.claim_reg(context);
+
+        let mut node = MCSNode::new();
+        let mut claimed_list = (hart_id < MAX_HARTS).then(|| CLAIMED[hart_id].lock(&mut node));
 
         loop {
             let claimed = unsafe { read_volatile(claim_reg) };
@@ -209,8 +230,14 @@ impl InterruptController for RiscvPlic {
                 break;
             }
             pending.push(claimed as u16);
-            // Complete the interrupt (write back the claim)
-            unsafe { write_volatile(claim_reg, claimed) };
+            // Defer completion until after the handler has cleared the device-side
+            // condition; eoi() writes the claim back once handlers have run.
+            match claimed_list {
+                Some(ref mut list) => list.push(claimed as u16),
+                // hart_id out of range: fall back to immediate completion rather
+                // than leaking the claim and wedging the source forever.
+                None => unsafe { write_volatile(claim_reg, claimed) },
+            }
         }
 
         Box::new(pending.into_iter())
@@ -251,6 +278,27 @@ impl InterruptController for RiscvPlic {
 
         // Enable software interrupts (IPIs) and external interrupts (PLIC)
         self.enable_machine_interrupts();
+    }
+
+    /// Complete every PLIC source claimed by the most recent `pending_irqs()`
+    /// call on this hart. Called after `handle_irqs()` has dispatched the
+    /// handlers, so by now any level-triggered device condition has been cleared
+    /// by its handler and writing the claim back will not immediately re-pend it.
+    fn eoi(&mut self) {
+        let hart_id = self.get_hart_id();
+        if hart_id >= MAX_HARTS {
+            return;
+        }
+
+        let context = self.get_machine_context();
+        let claim_reg = self.claim_reg(context);
+
+        let mut node = MCSNode::new();
+        let mut claimed = CLAIMED[hart_id].lock(&mut node);
+        for &source in claimed.iter() {
+            unsafe { write_volatile(claim_reg, source as u32) };
+        }
+        claimed.clear();
     }
 
     fn irq_range(&self) -> (u16, u16) {

--- a/kernel/src/arch/rv64/interrupt_controller.rs
+++ b/kernel/src/arch/rv64/interrupt_controller.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use awkernel_lib::interrupt::InterruptController;
 use core::ptr::{read_volatile, write_volatile};
-use core::sync::atomic::Ordering;
+use core::sync::atomic::{AtomicU64, Ordering};
 
 /// RISC-V PLIC (Platform-Level Interrupt Controller) implementation
 /// Combined with CLINT/ACLINT for IPI support
@@ -14,6 +14,38 @@ pub struct RiscvPlic {
 // CLINT/ACLINT base address for IPIs
 const ACLINT_BASE: usize = 0x0200_0000;
 const MSIP_OFFSET: usize = 0x0000; // Machine Software Interrupt Pending
+
+/// Logical IRQ ID used for the local machine timer (MTIP).
+///
+/// The RISC-V timer is a local interrupt (mcause = 7), not a PLIC source, so this
+/// ID is never claimed from the PLIC. It is delivered through `LOCAL_PENDING`
+/// instead. It must lie within `irq_range()` so the timer handler can be
+/// registered, be < 64 to fit the pending bitmask, and not collide with a PLIC
+/// source actually wired on the platform (QEMU virt uses 1-8 for virtio, 10 for
+/// UART, 32-35 for PCIe INTx).
+pub const TIMER_IRQ: u16 = 63;
+
+const MAX_HARTS: usize = awkernel_lib::cpu::NUM_MAX_CPU;
+
+/// Per-hart pending bitmask for local (non-PLIC) interrupts: IPI reasons and the
+/// local timer. MSIP is a single software-interrupt line per hart, so the sender
+/// records the logical IRQ (e.g. PREEMPT_IRQ vs WAKEUP_IRQ) here before raising
+/// MSIP, and `pending_irqs()` on the target hart drains it.
+static LOCAL_PENDING: [AtomicU64; MAX_HARTS] = [const { AtomicU64::new(0) }; MAX_HARTS];
+
+/// Record a pending local interrupt for `hart_id` so the next `pending_irqs()`
+/// call on that hart reports `irq`.
+pub(super) fn set_local_pending(hart_id: usize, irq: u16) {
+    if hart_id < MAX_HARTS && irq < 64 {
+        LOCAL_PENDING[hart_id].fetch_or(1 << irq, Ordering::Release);
+    }
+}
+
+/// Local interrupts (IPIs, timer) are delivered via MSIP/MTIP and `LOCAL_PENDING`,
+/// not the PLIC, so PLIC enable/disable must not touch their source numbers.
+fn is_local_irq(irq: u16) -> bool {
+    irq == crate::config::PREEMPT_IRQ || irq == crate::config::WAKEUP_IRQ || irq == TIMER_IRQ
+}
 
 // Import the detected CPU count from kernel_main
 use super::kernel_main::NUM_CPUS;
@@ -107,16 +139,34 @@ impl RiscvPlic {
         }
     }
 
-    /// Enable machine software interrupts
-    fn enable_software_interrupts(&self) {
+    /// Enable machine software (MSIE, bit 3) and external (MEIE, bit 11) interrupts
+    fn enable_machine_interrupts(&self) {
         unsafe {
-            core::arch::asm!("csrrs {tmp}, mie, {val}", tmp = lateout(reg) _, val = in(reg) (1usize << 3));
+            core::arch::asm!("csrrs {tmp}, mie, {val}", tmp = lateout(reg) _, val = in(reg) ((1usize << 3) | (1usize << 11)));
         }
+    }
+
+    /// Initialize the PLIC context for the primary hart.
+    ///
+    /// Sets the claim threshold to 0 (accept all priorities) and enables
+    /// software/external interrupts in `mie`. Secondary harts get the same
+    /// setup via `init_non_primary()`.
+    pub fn init_primary(&self) {
+        let context = self.get_machine_context();
+        let threshold_reg = self.threshold_reg(context);
+        unsafe { write_volatile(threshold_reg, 0) };
+
+        self.enable_machine_interrupts();
     }
 }
 
 impl InterruptController for RiscvPlic {
     fn enable_irq(&mut self, irq: u16) {
+        // Local interrupts (IPIs, timer) are not routed through the PLIC.
+        if is_local_irq(irq) {
+            return;
+        }
+
         // Set a reasonable priority for the interrupt
         self.set_priority(irq, 1);
 
@@ -125,48 +175,69 @@ impl InterruptController for RiscvPlic {
     }
 
     fn disable_irq(&mut self, irq: u16) {
+        if is_local_irq(irq) {
+            return;
+        }
+
         let context = self.get_machine_context();
         self.disable_interrupt(context, irq);
     }
 
     fn pending_irqs(&self) -> Box<dyn Iterator<Item = u16>> {
-        // Check pending interrupts by claiming them
+        let mut pending = alloc::vec::Vec::new();
+
+        // Local interrupts first: IPI reasons recorded by send_ipi() and the
+        // local timer (recorded by the M-mode trap handler).
+        let hart_id = self.get_hart_id();
+        if hart_id < MAX_HARTS {
+            let mut local = LOCAL_PENDING[hart_id].swap(0, Ordering::Acquire);
+            while local != 0 {
+                let irq = local.trailing_zeros() as u16;
+                pending.push(irq);
+                local &= local - 1;
+            }
+        }
+
+        // Then drain all pending PLIC external interrupts by claiming until the
+        // claim register reads 0, so multiple pending sources are not starved.
         let context = self.get_machine_context();
         let claim_reg = self.claim_reg(context);
 
-        let mut pending = alloc::vec::Vec::new();
-
-        unsafe {
-            let claimed = read_volatile(claim_reg);
-            if claimed != 0 {
-                pending.push(claimed as u16);
-                // Complete the interrupt (write back the claim)
-                write_volatile(claim_reg, claimed);
+        loop {
+            let claimed = unsafe { read_volatile(claim_reg) };
+            if claimed == 0 {
+                break;
             }
+            pending.push(claimed as u16);
+            // Complete the interrupt (write back the claim)
+            unsafe { write_volatile(claim_reg, claimed) };
         }
 
         Box::new(pending.into_iter())
     }
 
-    fn send_ipi(&mut self, _irq: u16, cpu_id: u32) {
-        // Send machine software interrupt to the target hart
+    fn send_ipi(&mut self, irq: u16, cpu_id: u32) {
+        // Record the logical IRQ for the target hart, then raise its MSIP.
+        set_local_pending(cpu_id as usize, irq);
         self.send_software_interrupt(cpu_id);
     }
 
-    fn send_ipi_broadcast(&mut self, _irq: u16) {
+    fn send_ipi_broadcast(&mut self, irq: u16) {
         // Send IPI to all CPUs
         let num_cpus = NUM_CPUS.load(Ordering::Acquire) as u32;
         for cpu_id in 0..num_cpus {
+            set_local_pending(cpu_id as usize, irq);
             self.send_software_interrupt(cpu_id);
         }
     }
 
-    fn send_ipi_broadcast_without_self(&mut self, _irq: u16) {
+    fn send_ipi_broadcast_without_self(&mut self, irq: u16) {
         // Send IPI to all CPUs except current
         let current_hart = self.get_hart_id() as u32;
         let num_cpus = NUM_CPUS.load(Ordering::Acquire) as u32;
         for cpu_id in 0..num_cpus {
             if cpu_id != current_hart {
+                set_local_pending(cpu_id as usize, irq);
                 self.send_software_interrupt(cpu_id);
             }
         }
@@ -178,8 +249,8 @@ impl InterruptController for RiscvPlic {
         let threshold_reg = self.threshold_reg(context);
         unsafe { write_volatile(threshold_reg, 0) };
 
-        // Enable software interrupts for IPIs
-        self.enable_software_interrupts();
+        // Enable software interrupts (IPIs) and external interrupts (PLIC)
+        self.enable_machine_interrupts();
     }
 
     fn irq_range(&self) -> (u16, u16) {

--- a/kernel/src/arch/rv64/kernel_main.rs
+++ b/kernel/src/arch/rv64/kernel_main.rs
@@ -1,76 +1,116 @@
 use super::console;
-use crate::{
-    config::{BACKUP_HEAP_SIZE, HEAP_START},
-    kernel_info::KernelInfo,
-};
+use crate::{config::BACKUP_HEAP_SIZE, kernel_info::KernelInfo};
 use awkernel_lib::{cpu, heap};
 use core::{
     arch::global_asm,
-    fmt::Write,
-    //    mem::MaybeUninit,
     sync::atomic::{AtomicBool, Ordering},
 };
-use ns16550a::Uart;
 
 const UART_BASE: usize = 0x1000_0000;
 
-const HEAP_SIZE: usize = 1024 * 1024 * 512;
-
-// TODO: set initial stack 4MB for each CPU on 0x8040_0000. see boot.S
-// const MAX_HARTS: usize = 8;
-// const INITIAL_STACK: usize = 0x8040_0000;
-// const INITIAL_STACK_SIZE: usize = 0x0040_0000;
-// #[repr(align(4096))]
-// struct InitialStack([MaybeUninit<u8>; INITIAL_STACK_SIZE * MAX_HARTS]);
-// #[no_mangle]
-// static INITIAL_STACK: InitialStack = unsafe { MaybeUninit::uninit().assume_init() };
+extern "C" {
+    static dtb_ptr: usize;
+}
 
 static PRIMARY_INITIALIZED: AtomicBool = AtomicBool::new(false);
+pub(super) static NUM_CPUS: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(4);
 
 global_asm!(include_str!("boot.S"));
 
+/// M-mode software interrupt (IPI) handler called from assembly
+///
+/// # Safety
+///
+/// This function is called from the M-mode trap handler in boot.S
 #[no_mangle]
-pub unsafe extern "C" fn kernel_main() {
-    unsafe { crate::config::init() };
+pub unsafe extern "C" fn riscv_handle_ipi() {
+    // Handle all pending interrupts, including IPI preemption
+    awkernel_lib::interrupt::handle_irqs(true);
+}
 
-    let hartid: usize = cpu::cpu_id();
-    if hartid == 0 {
-        primary_hart(hartid);
-    } else {
-        non_primary_hart(hartid);
+/// M-mode timer interrupt handler called from assembly
+///
+/// # Safety
+///
+/// This function is called from the M-mode trap handler in boot.S
+#[no_mangle]
+pub unsafe extern "C" fn riscv_handle_timer() {
+    // Timer interrupt is already disabled in assembly by setting mtimecmp to max
+    // Handle any pending interrupts (the timer handler will be invoked if registered)
+    awkernel_lib::interrupt::handle_irqs(true);
+}
+
+/// Write to UART during early boot for debugging
+///
+/// # Safety
+///
+/// UART must be initialized before calling this function
+#[inline]
+unsafe fn uart_debug_puts(s: &str) {
+    let uart_base = UART_BASE as *mut u8;
+    const LSR: usize = 5;
+    const THR: usize = 0;
+
+    for byte in s.bytes() {
+        while uart_base.add(LSR).read_volatile() & 0x20 == 0 {
+            core::hint::spin_loop();
+        }
+        uart_base.add(THR).write_volatile(byte);
     }
 }
 
-unsafe fn primary_hart(hartid: usize) {
-    // setup interrupt; TODO;
+fn register_boot_dtb_pointer() {
+    unsafe {
+        let addr = dtb_ptr;
+        if addr != 0 {
+            awkernel_lib::arch::rv64::set_boot_dtb_ptr(addr);
+        }
+    }
+}
+
+/// Initialize UART for early debugging and console output.
+///
+/// # Safety
+///
+/// Must be called during early boot on the primary hart.
+unsafe fn init_uart() {
+    let uart_base = UART_BASE as *mut u8;
+
+    // 16550 UART register offsets
+    const IER: usize = 1;
+    const FCR: usize = 2;
+    const LCR: usize = 3;
+    const MCR: usize = 4;
+    const LSR: usize = 5;
+    const THR: usize = 0;
+
+    // Initialize 16550 UART for early debugging
+    uart_base.add(IER).write_volatile(0x00); // Disable interrupts
+    uart_base.add(LCR).write_volatile(0x80); // Enable DLAB
+    uart_base.add(THR).write_volatile(0x03); // Baud rate divisor low
+    uart_base.add(IER).write_volatile(0x00); // Baud rate divisor high
+    uart_base.add(LCR).write_volatile(0x03); // 8N1
+    uart_base.add(FCR).write_volatile(0xC7); // Enable FIFO
+    uart_base.add(MCR).write_volatile(0x0B); // RTS/DTR
+
+    // Helper to write strings during early boot
+    let uart_puts = |s: &str| {
+        for byte in s.bytes() {
+            while uart_base.add(LSR).read_volatile() & 0x20 == 0 {
+                core::hint::spin_loop();
+            }
+            uart_base.add(THR).write_volatile(byte);
+        }
+    };
+
+    uart_puts("\r\n=== AWkernel RV64 Starting ===\r\n");
 
     super::console::init_port(UART_BASE);
+    uart_puts("Console port initialized\r\n");
 
-    // Initialize memory management (page allocator)
-    awkernel_lib::arch::rv64::init_page_allocator();
-
-    // Initialize virtual memory system
-    awkernel_lib::arch::rv64::init_kernel_space();
-
-    // Activate virtual memory (enable MMU and page tables)
-    awkernel_lib::arch::rv64::activate_kernel_space();
-
-    // Verify VM system is working by getting kernel token
-    let _kernel_token = awkernel_lib::arch::rv64::get_kernel_token();
-
-    // setup the VM
-    let backup_start = HEAP_START;
-    let backup_size = BACKUP_HEAP_SIZE;
-    let primary_start = HEAP_START + BACKUP_HEAP_SIZE;
-    let primary_size = HEAP_SIZE;
-
-    // enable heap allocator
-    heap::init_primary(primary_start, primary_size);
-    heap::init_backup(backup_start, backup_size);
-    heap::TALLOC.use_primary_then_backup(); // use backup allocator
-
-    // initialize serial device and dump booting logo
-    let mut port = Uart::new(UART_BASE);
+    // Initialize full UART driver
+    let mut port = ns16550a::Uart::new(UART_BASE);
     port.init(
         ns16550a::WordLength::EIGHT,
         ns16550a::StopBits::ONE,
@@ -82,39 +122,196 @@ unsafe fn primary_hart(hartid: usize) {
         ns16550a::Divisor::BAUD115200,
     );
 
-    let _ = port.write_str("\r\nAwkernel is booting\r\n\r\n");
+    use core::fmt::Write;
+    let _ = port.write_str("UART driver initialized\r\n");
+}
 
-    // initialize console driver to which log messages are dumped
+/// Initialize memory management including page allocator and virtual memory.
+///
+/// # Safety
+///
+/// Must be called after heap initialization on the primary hart.
+unsafe fn init_memory_management() {
+    uart_debug_puts("Initializing page allocator...\r\n");
+    awkernel_lib::arch::rv64::init_page_allocator();
+
+    uart_debug_puts("Initializing kernel space...\r\n");
+    awkernel_lib::arch::rv64::init_kernel_space();
+
+    uart_debug_puts("Activating kernel space...\r\n");
+    awkernel_lib::arch::rv64::activate_kernel_space();
+
+    uart_debug_puts("Virtual memory system initialized\r\n");
+}
+
+/// Setup dynamic heap allocation based on available memory.
+///
+/// # Safety
+///
+/// Must be called before memory management initialization on the primary hart.
+unsafe fn init_heap_allocation() {
+    uart_debug_puts("Setting up heap allocation...\r\n");
+
+    extern "C" {
+        fn ekernel();
+    }
+
+    let heap_start = (ekernel as usize + 0xfff) & !0xfff; // Align to 4K
+    let backup_size = BACKUP_HEAP_SIZE;
+    let total_heap_size = awkernel_lib::arch::rv64::get_heap_size();
+
+    if total_heap_size <= backup_size {
+        // Use minimal heap if not enough memory
+        uart_debug_puts("Using minimal heap configuration\r\n");
+        let primary_size = 64 * 1024 * 1024; // 64MB minimum
+        heap::init_primary(heap_start + backup_size, primary_size);
+        heap::init_backup(heap_start, backup_size);
+    } else {
+        // Use dynamic calculation
+        uart_debug_puts("Using dynamic heap configuration\r\n");
+        let primary_size = total_heap_size - backup_size;
+        heap::init_primary(heap_start + backup_size, primary_size);
+        heap::init_backup(heap_start, backup_size);
+    }
+
+    heap::TALLOC.use_primary_then_backup();
+    uart_debug_puts("Heap allocation complete\r\n");
+}
+
+/// Initialize timer and interrupt controller for RV64.
+///
+/// # Safety
+///
+/// Must be called after heap and memory management initialization on the primary hart.
+unsafe fn init_timer_and_interrupts() {
+    use super::interrupt_controller::RiscvPlic;
+    use super::timer::RiscvTimer;
+    use alloc::boxed::Box;
+
+    uart_debug_puts("Initializing RISC-V interrupt controller...\r\n");
+
+    // RISC-V PLIC (Platform-Level Interrupt Controller) base address
+    // This should match the device tree or platform specification
+    const PLIC_BASE: usize = 0x0c000000;
+    const NUM_SOURCES: u16 = 128; // Typical PLIC configuration
+    const TIMER_IRQ: u16 = 5; // Machine timer interrupt is typically IRQ 5 for PLIC
+
+    // Initialize and register interrupt controller
+    let plic = Box::new(RiscvPlic::new(PLIC_BASE, NUM_SOURCES));
+    awkernel_lib::interrupt::register_interrupt_controller(plic);
+
+    uart_debug_puts("Initializing RISC-V timer...\r\n");
+
+    // Initialize and register timer
+    let timer = Box::new(RiscvTimer::new(TIMER_IRQ));
+    awkernel_lib::timer::register_timer(timer);
+
+    uart_debug_puts("Timer and interrupt controller initialized\r\n");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn kernel_main() {
+    unsafe { crate::config::init() };
+
+    register_boot_dtb_pointer();
+
+    let hartid: usize = cpu::cpu_id();
+    if hartid == 0 {
+        primary_hart(hartid);
+    } else {
+        non_primary_hart(hartid);
+    }
+}
+
+/// Primary CPU initialization sequence.
+/// 1. Initialize UART for early debugging
+/// 2. Setup heap allocation FIRST (required for page tables)
+/// 3. Initialize memory management (page allocator and virtual memory)
+/// 4. Initialize architecture-specific features
+/// 5. Initialize console driver
+/// 6. Initialize timer and interrupt controller
+/// 7. Detect CPU count from device tree
+/// 8. Wake up secondary CPUs
+/// 9. Start the kernel main function
+///
+/// # Safety
+///
+/// Must be called exactly once by the primary hart during boot.
+unsafe fn primary_hart(hartid: usize) {
+    // 1. Initialize UART for early debugging
+    init_uart();
+
+    // 2. Setup heap allocation FIRST - page tables need this!
+    init_heap_allocation();
+
+    // 3. Initialize memory management (now that heap exists)
+    init_memory_management();
+
+    // 4. Initialize architecture-specific features
+    awkernel_lib::arch::rv64::init_primary();
+
+    // 5. Initialize console driver
     console::init(UART_BASE);
 
-    // switch to S-Mode; TODO;
-    // * currntly this impl. holds both kernel and userland
-    // * in M-Mode, which is the highest priority.
+    // 6. Initialize timer and interrupt controller
+    init_timer_and_interrupts();
 
-    // wake up another harts
+    // Enable software interrupts for IPIs on primary hart
+    unsafe {
+        core::arch::asm!("csrrs t0, mie, {}", in(reg) 1 << 3);
+    }
+
+    log::info!("AWkernel RV64 primary CPU initialization complete");
+
+    // 7. Detect CPU count from device tree and store it
+    let num_cpu = awkernel_lib::arch::rv64::detect_cpu_count();
+    NUM_CPUS.store(num_cpu, Ordering::Release);
+
+    // 8. Wake up secondary CPUs
     PRIMARY_INITIALIZED.store(true, Ordering::SeqCst);
 
     let kernel_info = KernelInfo {
         info: (),
         cpu_id: hartid,
-        num_cpu: 4, // TODO: get the number of CPUs
+        num_cpu,
     };
 
+    // 9. Start the kernel main function
     crate::main::<()>(kernel_info);
 }
 
+/// Secondary CPU initialization sequence.
+/// 1. Wait for primary CPU to complete initialization
+/// 2. Initialize architecture-specific features for non-primary CPUs
+/// 3. Setup heap allocator usage
+/// 4. Get CPU count from primary hart
+/// 5. Start the kernel main function
+///
+/// # Safety
+///
+/// Must be called by non-primary harts during boot.
 unsafe fn non_primary_hart(hartid: usize) {
+    // 1. Wait for primary CPU to complete initialization
     while !PRIMARY_INITIALIZED.load(Ordering::SeqCst) {
         core::hint::spin_loop();
     }
 
-    heap::TALLOC.use_primary_then_backup(); // use backup allocator
+    // 2. Initialize architecture-specific features for non-primary CPUs
+    awkernel_lib::arch::rv64::init_non_primary();
+    awkernel_lib::interrupt::init_non_primary();
+
+    // 3. Setup heap allocator usage
+    heap::TALLOC.use_primary_then_backup();
+
+    // 4. Get CPU count detected by primary hart
+    let num_cpu = NUM_CPUS.load(Ordering::Acquire);
 
     let kernel_info = KernelInfo {
         info: (),
         cpu_id: hartid,
-        num_cpu: 4, // TODO: get the number of CPUs
+        num_cpu,
     };
 
+    // 5. Start the kernel main function
     crate::main::<()>(kernel_info);
 }

--- a/kernel/src/arch/rv64/kernel_main.rs
+++ b/kernel/src/arch/rv64/kernel_main.rs
@@ -126,56 +126,55 @@ unsafe fn init_uart() {
     let _ = port.write_str("UART driver initialized\r\n");
 }
 
-/// Initialize memory management including page allocator and virtual memory.
+/// Initialise memory management with non-overlapping frame allocator and heap.
+///
+/// Physical layout after ekernel:
+///   [ekernel, ekernel + pt_frames_size)  — frame allocator (page table nodes)
+///   [ekernel + pt_frames_size, memory_end) — heap (backup + primary)
+///
+/// pt_frames_size is 10% of available RAM, clamped to [4 MiB, 256 MiB].
 ///
 /// # Safety
 ///
-/// Must be called after heap initialization on the primary hart.
-unsafe fn init_memory_management() {
-    uart_debug_puts("Initializing page allocator...\r\n");
-    awkernel_lib::arch::rv64::init_page_allocator();
+/// Must be called on the primary hart during early boot.
+unsafe fn init_memory(memory_end: usize) {
+    extern "C" {
+        fn ekernel();
+    }
+    let kernel_end = (ekernel as *const () as usize + 0xfff) & !0xfff;
 
+    // 10% of available RAM, floored at 4 MiB (tiny systems) and capped at
+    // 256 MiB (large automotive SoCs like Orin). Page-aligned.
+    let available = memory_end.saturating_sub(kernel_end);
+    let pt_frames_size =
+        ((available / 10).clamp(4 * 1024 * 1024, 256 * 1024 * 1024) + 0xfff) & !0xfff;
+
+    let pt_start = kernel_end;
+    let pt_end = kernel_end + pt_frames_size;
+    let heap_start = pt_end;
+
+    // 1. Frame allocator over [pt_start, pt_end) — no heap needed yet.
+    uart_debug_puts("Initializing frame allocator (PT frames: 0x");
+    awkernel_lib::console::unsafe_print_hex_u64(pt_frames_size as u64);
+    uart_debug_puts(" bytes)\r\n");
+    awkernel_lib::arch::rv64::init_page_allocator(pt_start, pt_end);
+
+    // 2. Heap over [heap_start, memory_end) — no overlap with frame allocator.
+    uart_debug_puts("Initializing heap...\r\n");
+    let backup_size = BACKUP_HEAP_SIZE;
+    let primary_size = memory_end - heap_start - backup_size;
+    heap::init_backup(heap_start, backup_size);
+    heap::init_primary(heap_start + backup_size, primary_size);
+    heap::TALLOC.use_primary_then_backup();
+
+    // 3. Build kernel page table (uses heap for Vec, frame allocator for PT nodes).
     uart_debug_puts("Initializing kernel space...\r\n");
-    awkernel_lib::arch::rv64::init_kernel_space();
+    awkernel_lib::arch::rv64::init_kernel_space(heap_start, memory_end);
 
     uart_debug_puts("Activating kernel space...\r\n");
     awkernel_lib::arch::rv64::activate_kernel_space();
 
-    uart_debug_puts("Virtual memory system initialized\r\n");
-}
-
-/// Setup dynamic heap allocation based on available memory.
-///
-/// # Safety
-///
-/// Must be called before memory management initialization on the primary hart.
-unsafe fn init_heap_allocation() {
-    uart_debug_puts("Setting up heap allocation...\r\n");
-
-    extern "C" {
-        fn ekernel();
-    }
-
-    let heap_start = (ekernel as usize + 0xfff) & !0xfff; // Align to 4K
-    let backup_size = BACKUP_HEAP_SIZE;
-    let total_heap_size = awkernel_lib::arch::rv64::get_heap_size();
-
-    if total_heap_size <= backup_size {
-        // Use minimal heap if not enough memory
-        uart_debug_puts("Using minimal heap configuration\r\n");
-        let primary_size = 64 * 1024 * 1024; // 64MB minimum
-        heap::init_primary(heap_start + backup_size, primary_size);
-        heap::init_backup(heap_start, backup_size);
-    } else {
-        // Use dynamic calculation
-        uart_debug_puts("Using dynamic heap configuration\r\n");
-        let primary_size = total_heap_size - backup_size;
-        heap::init_primary(heap_start + backup_size, primary_size);
-        heap::init_backup(heap_start, backup_size);
-    }
-
-    heap::TALLOC.use_primary_then_backup();
-    uart_debug_puts("Heap allocation complete\r\n");
+    uart_debug_puts("Memory initialized\r\n");
 }
 
 /// Initialize timer and interrupt controller for RV64.
@@ -241,11 +240,11 @@ unsafe fn primary_hart(hartid: usize) {
     // 1. Initialize UART for early debugging
     init_uart();
 
-    // 2. Setup heap allocation FIRST - page tables need this!
-    init_heap_allocation();
+    // 2. Detect physical memory end from DTB
+    let memory_end = awkernel_lib::arch::rv64::get_memory_end() as usize;
 
-    // 3. Initialize memory management (now that heap exists)
-    init_memory_management();
+    // 3. Frame allocator + heap + page tables with non-overlapping regions
+    init_memory(memory_end);
 
     // 4. Initialize architecture-specific features
     awkernel_lib::arch::rv64::init_primary();

--- a/kernel/src/arch/rv64/kernel_main.rs
+++ b/kernel/src/arch/rv64/kernel_main.rs
@@ -9,6 +9,15 @@ use core::{
 
 const UART_BASE: usize = 0x1000_0000;
 
+/// Base address of the initial per-hart boot stacks.
+///
+/// boot.S sets each hart's stack pointer to `BOOT_STACK_BASE +
+/// BOOT_STACK_SIZE_PER_HART * (hartid + 1)` and the stack grows down from there,
+/// so hart `i` occupies `[BOOT_STACK_BASE + SIZE * i, BOOT_STACK_BASE + SIZE *
+/// (i + 1))`. These constants MUST match the values in boot.S.
+const BOOT_STACK_BASE: usize = 0x8080_0000;
+const BOOT_STACK_SIZE_PER_HART: usize = 0x0080_0000;
+
 extern "C" {
     static dtb_ptr: usize;
 }
@@ -30,6 +39,9 @@ pub unsafe extern "C" fn riscv_handle_ipi() {
     // (preempt/wakeup) in the per-hart LOCAL_PENDING mask, which
     // pending_irqs() drains inside handle_irqs().
     awkernel_lib::interrupt::handle_irqs(true);
+    // pending_irqs() also drains any PLIC sources pending on this hart; complete
+    // them now that their handlers have run (see RiscvPlic::eoi).
+    awkernel_lib::interrupt::eoi();
 }
 
 /// M-mode timer interrupt handler called from assembly
@@ -45,6 +57,9 @@ pub unsafe extern "C" fn riscv_handle_timer() {
     // then dispatches the registered timer handler (which re-arms the timer).
     super::interrupt_controller::set_local_pending(cpu::cpu_id(), TIMER_IRQ);
     awkernel_lib::interrupt::handle_irqs(true);
+    // pending_irqs() also drains any PLIC sources pending on this hart; complete
+    // them now that their handlers have run (see RiscvPlic::eoi).
+    awkernel_lib::interrupt::eoi();
 }
 
 /// M-mode external interrupt handler called from assembly
@@ -54,9 +69,12 @@ pub unsafe extern "C" fn riscv_handle_timer() {
 /// This function is called from the M-mode trap handler in boot.S
 #[no_mangle]
 pub unsafe extern "C" fn riscv_handle_external() {
-    // PLIC-delivered device interrupts (mcause = 11): handle_irqs() claims and
-    // completes all pending sources via pending_irqs().
+    // PLIC-delivered device interrupts (mcause = 11): handle_irqs() claims all
+    // pending sources via pending_irqs() and dispatches their handlers.
     awkernel_lib::interrupt::handle_irqs(true);
+    // Complete the claimed PLIC sources now that their handlers have cleared the
+    // device-side condition (see RiscvPlic::eoi).
+    awkernel_lib::interrupt::eoi();
 }
 
 /// Write to UART during early boot for debugging
@@ -146,24 +164,37 @@ unsafe fn init_uart() {
 
 /// Initialise memory management with non-overlapping frame allocator and heap.
 ///
-/// Physical layout after ekernel:
-///   [ekernel, ekernel + pt_frames_size)  — frame allocator (page table nodes)
-///   [ekernel + pt_frames_size, memory_end) — heap (backup + primary)
+/// Physical layout after the reserved region:
+///   [alloc_base, alloc_base + pt_frames_size)  — frame allocator (page table nodes)
+///   [alloc_base + pt_frames_size, memory_end)  — heap (backup + primary)
+///
+/// `alloc_base` is the first free page above both the kernel image and the
+/// initial per-hart boot stacks placed by boot.S, so neither the frame allocator
+/// nor the heap can hand out memory that is still in use as a CPU stack.
 ///
 /// pt_frames_size is 10% of available RAM, clamped to [4 MiB, 256 MiB].
 ///
 /// # Safety
 ///
-/// Must be called on the primary hart during early boot.
-unsafe fn init_memory(memory_end: usize) {
+/// Must be called on the primary hart during early boot, with `num_cpus` equal
+/// to the number of harts that ran boot.S (and therefore have a boot stack).
+unsafe fn init_memory(memory_end: usize, num_cpus: usize) {
     extern "C" {
         fn ekernel();
     }
     let kernel_end = (ekernel as *const () as usize + 0xfff) & !0xfff;
 
+    // boot.S places each hart's initial stack at a fixed address above
+    // BOOT_STACK_BASE; these stacks are in active use throughout early boot. The
+    // page-table-frame region can be large (up to 256 MiB) and would otherwise
+    // overlap them, so start all allocations above both the kernel image and the
+    // boot-stack region.
+    let stack_region_end = BOOT_STACK_BASE + BOOT_STACK_SIZE_PER_HART * num_cpus;
+    let alloc_base = (kernel_end.max(stack_region_end) + 0xfff) & !0xfff;
+
     // 10% of available RAM, floored at 4 MiB (tiny systems) and capped at
     // 256 MiB (large automotive SoCs like Orin). Page-aligned.
-    let available = memory_end.saturating_sub(kernel_end);
+    let available = memory_end.saturating_sub(alloc_base);
     let pt_frames_size =
         ((available / 10).clamp(4 * 1024 * 1024, 256 * 1024 * 1024) + 0xfff) & !0xfff;
 
@@ -171,12 +202,12 @@ unsafe fn init_memory(memory_end: usize) {
     // beats handing the page allocator a range past the end of memory.
     if pt_frames_size > available {
         panic!(
-            "Insufficient RAM for page table frames: need at least 4 MiB after the kernel image"
+            "Insufficient RAM for page table frames: need at least 4 MiB after the kernel image and boot stacks"
         );
     }
 
-    let pt_start = kernel_end;
-    let pt_end = kernel_end + pt_frames_size;
+    let pt_start = alloc_base;
+    let pt_end = alloc_base + pt_frames_size;
     let heap_start = pt_end;
 
     // 1. Frame allocator over [pt_start, pt_end) — no heap needed yet.
@@ -266,12 +297,12 @@ pub unsafe extern "C" fn kernel_main() {
 
 /// Primary CPU initialization sequence.
 /// 1. Initialize UART for early debugging
-/// 2. Setup heap allocation FIRST (required for page tables)
-/// 3. Initialize memory management (page allocator and virtual memory)
-/// 4. Initialize architecture-specific features
-/// 5. Initialize console driver
-/// 6. Initialize timer and interrupt controller
-/// 7. Detect CPU count from device tree
+/// 2. Detect physical memory end from DTB
+/// 3. Detect CPU count from DTB (needed to reserve the boot-stack region)
+/// 4. Initialize memory management (frame allocator, heap, page tables)
+/// 5. Initialize architecture-specific features
+/// 6. Initialize console driver
+/// 7. Initialize timer and interrupt controller
 /// 8. Wake up secondary CPUs
 /// 9. Start the kernel main function
 ///
@@ -285,26 +316,29 @@ unsafe fn primary_hart(hartid: usize) {
     // 2. Detect physical memory end from DTB
     let memory_end = awkernel_lib::arch::rv64::get_memory_end() as usize;
 
-    // 3. Frame allocator + heap + page tables with non-overlapping regions
-    init_memory(memory_end);
+    // 3. Detect the CPU count from the DTB before initialising the allocator, so
+    //    init_memory() can reserve the boot-stack region (one stack per hart).
+    //    Both detection helpers parse the DTB without using the heap.
+    let num_cpu = awkernel_lib::arch::rv64::detect_cpu_count();
+    NUM_CPUS.store(num_cpu, Ordering::Release);
 
-    // 4. Initialize architecture-specific features
+    // 4. Frame allocator + heap + page tables with non-overlapping regions,
+    //    placed above the kernel image and the per-hart boot stacks.
+    init_memory(memory_end, num_cpu);
+
+    // 5. Initialize architecture-specific features
     awkernel_lib::arch::rv64::init_primary();
 
-    // 5. Initialize console driver
+    // 6. Initialize console driver
     console::init(UART_BASE);
 
-    // 6. Initialize timer and interrupt controller
+    // 7. Initialize timer and interrupt controller
     // (also enables software/external interrupts in mie via RiscvPlic::init_primary)
     init_timer_and_interrupts();
 
     log::info!("AWkernel RV64 primary CPU initialization complete");
 
-    // 7. Detect CPU count from device tree and store it
-    let num_cpu = awkernel_lib::arch::rv64::detect_cpu_count();
-    NUM_CPUS.store(num_cpu, Ordering::Release);
-
-    // 8. Wake up secondary CPUs
+    // 8. Wake up secondary CPUs (NUM_CPUS was stored in step 3)
     PRIMARY_INITIALIZED.store(true, Ordering::SeqCst);
 
     let kernel_info = KernelInfo {

--- a/kernel/src/arch/rv64/kernel_main.rs
+++ b/kernel/src/arch/rv64/kernel_main.rs
@@ -161,8 +161,21 @@ unsafe fn init_memory(memory_end: usize) {
 
     // 2. Heap over [heap_start, memory_end) — no overlap with frame allocator.
     uart_debug_puts("Initializing heap...\r\n");
-    let backup_size = BACKUP_HEAP_SIZE;
-    let primary_size = memory_end - heap_start - backup_size;
+    let heap_available = match memory_end.checked_sub(heap_start) {
+        Some(n) => n,
+        None => {
+            uart_debug_puts("Insufficient RAM for heap region\r\n");
+            return;
+        }
+    };
+    let backup_size = BACKUP_HEAP_SIZE.min(heap_available);
+    let primary_size = match heap_available.checked_sub(backup_size) {
+        Some(n) if n > 0 => n,
+        _ => {
+            uart_debug_puts("Insufficient RAM for primary heap after reserving backup\r\n");
+            return;
+        }
+    };
     heap::init_backup(heap_start, backup_size);
     heap::init_primary(heap_start + backup_size, primary_size);
     heap::TALLOC.use_primary_then_backup();
@@ -257,7 +270,7 @@ unsafe fn primary_hart(hartid: usize) {
 
     // Enable software interrupts for IPIs on primary hart
     unsafe {
-        core::arch::asm!("csrrs t0, mie, {}", in(reg) 1 << 3);
+        core::arch::asm!("csrrs {tmp}, mie, {val}", tmp = lateout(reg) _, val = in(reg) (1usize << 3));
     }
 
     log::info!("AWkernel RV64 primary CPU initialization complete");

--- a/kernel/src/arch/rv64/kernel_main.rs
+++ b/kernel/src/arch/rv64/kernel_main.rs
@@ -1,4 +1,5 @@
 use super::console;
+use super::interrupt_controller::TIMER_IRQ;
 use crate::{config::BACKUP_HEAP_SIZE, kernel_info::KernelInfo};
 use awkernel_lib::{cpu, heap};
 use core::{
@@ -25,7 +26,9 @@ global_asm!(include_str!("boot.S"));
 /// This function is called from the M-mode trap handler in boot.S
 #[no_mangle]
 pub unsafe extern "C" fn riscv_handle_ipi() {
-    // Handle all pending interrupts, including IPI preemption
+    // boot.S has already cleared MSIP. The sender recorded the logical IRQ
+    // (preempt/wakeup) in the per-hart LOCAL_PENDING mask, which
+    // pending_irqs() drains inside handle_irqs().
     awkernel_lib::interrupt::handle_irqs(true);
 }
 
@@ -36,8 +39,23 @@ pub unsafe extern "C" fn riscv_handle_ipi() {
 /// This function is called from the M-mode trap handler in boot.S
 #[no_mangle]
 pub unsafe extern "C" fn riscv_handle_timer() {
-    // Timer interrupt is already disabled in assembly by setting mtimecmp to max
-    // Handle any pending interrupts (the timer handler will be invoked if registered)
+    // Timer interrupt is already disabled in assembly by setting mtimecmp to max.
+    // MTIP is a local interrupt and never appears in the PLIC claim register, so
+    // record it in LOCAL_PENDING for pending_irqs() to report; handle_irqs()
+    // then dispatches the registered timer handler (which re-arms the timer).
+    super::interrupt_controller::set_local_pending(cpu::cpu_id(), TIMER_IRQ);
+    awkernel_lib::interrupt::handle_irqs(true);
+}
+
+/// M-mode external interrupt handler called from assembly
+///
+/// # Safety
+///
+/// This function is called from the M-mode trap handler in boot.S
+#[no_mangle]
+pub unsafe extern "C" fn riscv_handle_external() {
+    // PLIC-delivered device interrupts (mcause = 11): handle_irqs() claims and
+    // completes all pending sources via pending_irqs().
     awkernel_lib::interrupt::handle_irqs(true);
 }
 
@@ -149,6 +167,14 @@ unsafe fn init_memory(memory_end: usize) {
     let pt_frames_size =
         ((available / 10).clamp(4 * 1024 * 1024, 256 * 1024 * 1024) + 0xfff) & !0xfff;
 
+    // The 4 MiB floor may exceed the actually available RAM; refusing to boot
+    // beats handing the page allocator a range past the end of memory.
+    if pt_frames_size > available {
+        panic!(
+            "Insufficient RAM for page table frames: need at least 4 MiB after the kernel image"
+        );
+    }
+
     let pt_start = kernel_end;
     let pt_end = kernel_end + pt_frames_size;
     let heap_start = pt_end;
@@ -181,8 +207,10 @@ unsafe fn init_memory(memory_end: usize) {
     heap::TALLOC.use_primary_then_backup();
 
     // 3. Build kernel page table (uses heap for Vec, frame allocator for PT nodes).
+    // The page-table-frame region [pt_start, heap_start) must also be mapped:
+    // page table code dereferences those frames via their physical addresses.
     uart_debug_puts("Initializing kernel space...\r\n");
-    awkernel_lib::arch::rv64::init_kernel_space(heap_start, memory_end);
+    awkernel_lib::arch::rv64::init_kernel_space(pt_start, heap_start, memory_end);
 
     uart_debug_puts("Activating kernel space...\r\n");
     awkernel_lib::arch::rv64::activate_kernel_space();
@@ -206,15 +234,16 @@ unsafe fn init_timer_and_interrupts() {
     // This should match the device tree or platform specification
     const PLIC_BASE: usize = 0x0c000000;
     const NUM_SOURCES: u16 = 128; // Typical PLIC configuration
-    const TIMER_IRQ: u16 = 5; // Machine timer interrupt is typically IRQ 5 for PLIC
 
     // Initialize and register interrupt controller
     let plic = Box::new(RiscvPlic::new(PLIC_BASE, NUM_SOURCES));
+    plic.init_primary();
     awkernel_lib::interrupt::register_interrupt_controller(plic);
 
     uart_debug_puts("Initializing RISC-V timer...\r\n");
 
-    // Initialize and register timer
+    // Initialize and register timer. TIMER_IRQ is a synthetic logical IRQ for
+    // the local MTIP interrupt, dispatched via LOCAL_PENDING (not the PLIC).
     let timer = Box::new(RiscvTimer::new(TIMER_IRQ));
     awkernel_lib::timer::register_timer(timer);
 
@@ -266,12 +295,8 @@ unsafe fn primary_hart(hartid: usize) {
     console::init(UART_BASE);
 
     // 6. Initialize timer and interrupt controller
+    // (also enables software/external interrupts in mie via RiscvPlic::init_primary)
     init_timer_and_interrupts();
-
-    // Enable software interrupts for IPIs on primary hart
-    unsafe {
-        core::arch::asm!("csrrs {tmp}, mie, {val}", tmp = lateout(reg) _, val = in(reg) (1usize << 3));
-    }
 
     log::info!("AWkernel RV64 primary CPU initialization complete");
 

--- a/kernel/src/arch/rv64/timer.rs
+++ b/kernel/src/arch/rv64/timer.rs
@@ -1,0 +1,85 @@
+use core::ptr::{read_volatile, write_volatile};
+use core::time::Duration;
+
+/// RISC-V Timer Implementation
+/// Uses MTIME (machine time) and MTIMECMP (machine time compare) registers
+pub struct RiscvTimer {
+    irq: u16,
+}
+
+// RISC-V timer memory-mapped register addresses
+// These should match the device tree or platform configuration
+const ACLINT_MTIME_BASE: usize = 0x0200_0000 + 0x0000bff8;
+const ACLINT_MTIMECMP_BASE: usize = 0x0200_0000 + 0x00004000;
+const RISCV_TIMEBASE_FREQ: u64 = 10_000_000; // 10 MHz
+
+impl RiscvTimer {
+    pub const fn new(irq: u16) -> Self {
+        RiscvTimer { irq }
+    }
+
+    /// Get the current machine time
+    fn get_mtime() -> u64 {
+        let mtime = ACLINT_MTIME_BASE as *const u64;
+        unsafe { read_volatile(mtime) }
+    }
+
+    /// Get the current hart ID
+    fn get_hart_id() -> usize {
+        let hart_id: usize;
+        unsafe {
+            core::arch::asm!("csrr {}, mhartid", out(reg) hart_id);
+        }
+        hart_id
+    }
+
+    /// Set the machine time compare value
+    fn set_mtimecmp(&self, value: u64) {
+        // Each hart has its own MTIMECMP register at ACLINT_MTIMECMP_BASE + (hartid * 8)
+        let hart_id = Self::get_hart_id();
+        let mtimecmp = (ACLINT_MTIMECMP_BASE + (hart_id * 8)) as *mut u64;
+        unsafe { write_volatile(mtimecmp, value) };
+    }
+
+    /// Enable machine timer interrupt
+    fn enable_mti(&self) {
+        unsafe {
+            // Set MIE.MTIE (Machine Timer Interrupt Enable) bit
+            core::arch::asm!("csrrs t0, mie, {}", in(reg) 1 << 7);
+        }
+    }
+
+    /// Disable machine timer interrupt
+    fn disable_mti(&self) {
+        unsafe {
+            // Clear MIE.MTIE (Machine Timer Interrupt Enable) bit
+            core::arch::asm!("csrrc t0, mie, {}", in(reg) 1 << 7);
+        }
+    }
+}
+
+impl awkernel_lib::timer::Timer for RiscvTimer {
+    fn reset(&self, dur: Duration) {
+        let current_time = Self::get_mtime();
+        let ticks = (dur.as_nanos() as u64 * RISCV_TIMEBASE_FREQ) / 1_000_000_000;
+        let target_time = current_time.saturating_add(ticks);
+
+        // Set the compare value
+        self.set_mtimecmp(target_time);
+
+        // Enable machine timer interrupt
+        self.enable_mti();
+    }
+
+    fn irq_id(&self) -> u16 {
+        self.irq
+    }
+
+    fn disable(&self) {
+        // Disable machine timer interrupt
+        self.disable_mti();
+
+        // Set MTIMECMP to maximum value to prevent spurious interrupts
+        self.set_mtimecmp(u64::MAX);
+    }
+}

--- a/kernel/src/arch/rv64/timer.rs
+++ b/kernel/src/arch/rv64/timer.rs
@@ -44,16 +44,14 @@ impl RiscvTimer {
     /// Enable machine timer interrupt
     fn enable_mti(&self) {
         unsafe {
-            // Set MIE.MTIE (Machine Timer Interrupt Enable) bit
-            core::arch::asm!("csrrs t0, mie, {}", in(reg) 1 << 7);
+            core::arch::asm!("csrrs {tmp}, mie, {val}", tmp = lateout(reg) _, val = in(reg) (1usize << 7));
         }
     }
 
     /// Disable machine timer interrupt
     fn disable_mti(&self) {
         unsafe {
-            // Clear MIE.MTIE (Machine Timer Interrupt Enable) bit
-            core::arch::asm!("csrrc t0, mie, {}", in(reg) 1 << 7);
+            core::arch::asm!("csrrc {tmp}, mie, {val}", tmp = lateout(reg) _, val = in(reg) (1usize << 7));
         }
     }
 }


### PR DESCRIPTION
## Description
In order to close #463 .

Register and implement Interrupt Controller and Timer.

FDT Based Dynamic Decider is implemented as the following design.

1. Created FDT(Flattened Device Tree) parser for dynamic memory detection from device tree, with
fallback mechanisms. (Using [fdt](https://docs.rs/fdt/latest/fdt/) crate)

2. Dynamic Heap Size and Start Decider implementation in vm.rs
3. Dynamic CPU Counts implementation.

## How was this PR tested?

I tested this heap decider with QEMU memory size 512M, 1G,  and 2G. Test results are shown as the following.
Both heap and VM are initialized successfully by using Dynamic Heap Decider.

```shell
// 512M Memory Size

qemu-system-riscv64 -machine virt -bios none -kernel target/riscv64gc-unknown-none-elf/release/awkernel -m 512M -nographic -smp 4 -monitor telnet::5556,server,nowait

=== AWkernel RV64 Starting ===
Console port initialized
UART driver initialized
Setting up heap allocation...
Memory detected from boot DTB pointer at 0x00009fe09fe00000
Detected RAM size: 0x0000000020000000
Using dynamic heap configuration\r\nHeap allocation complete\r\nInitializing page allocator...
Initializing kernel space...
Memory detected from boot DTB pointer at 0x00009fe09fe00000
Detected RAM size: 0x0000000020000000
Mapping kernel text section...
Mapping kernel rodata section...
Mapping kernel data section...
Mapping kernel bss section...
Mapping physical memory...
  from ekernel: 0x800d7000
  to MEMORY_END: 0xa0000000 (dynamic)
Memory detected from boot DTB pointer at 0x00009fe09fe00000
Detected RAM size: 0x0000000020000000
Dynamic heap calculation:
  Kernel end: 0x800d7000
  Heap start: 0x800d7000
  Memory end: 0xa0000000
  Max heap size: 0x1ff29000
Activating kernel space...
Virtual memory system initialized
Initializing RISC-V interrupt controller...\r\nInitializing RISC-V timer...\r\nTimer and interrupt controller initialized\r\n[            3 INFO] AWkernel RV64 primary CPU initialization complete
[            5 INFO] CPU#0 is starting.
[            6 INFO] CPU#2 is starting.
[            6 INFO] CPU#3 is starting.
[            7 INFO] CPU#1 is starting.
[            8 INFO] interrupt::INTERRUPT_CONTROLLER has been initialized.
[            9 INFO] interrupt::PREEMPT_FN has been initialized.
[           10 INFO] timer::TIMER has been initialized.
[           12 INFO] A local timer has been initialized.
```

```shell
// 1G Memory Size

qemu-system-riscv64 -machine virt -bios none -kernel target/riscv64gc-unknown-none-elf/release/awkernel -m 1G -nographic -smp 4 -monitor telnet::5556,server,nowait

=== AWkernel RV64 Starting ===
Console port initialized
UART driver initialized
Setting up heap allocation...
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000040000000
Using dynamic heap configuration\r\nHeap allocation complete\r\nInitializing page allocator...
Initializing kernel space...
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000040000000
Mapping kernel text section...
Mapping kernel rodata section...
Mapping kernel data section...
Mapping kernel bss section...
Mapping physical memory...
  from ekernel: 0x800d7000
  to MEMORY_END: 0xc0000000 (dynamic)
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000040000000
Dynamic heap calculation:
  Kernel end: 0x800d7000
  Heap start: 0x800d7000
  Memory end: 0xc0000000
  Max heap size: 0x3ff29000
Activating kernel space...
Virtual memory system initialized
Initializing RISC-V interrupt controller...\r\nInitializing RISC-V timer...\r\nTimer and interrupt controller initialized\r\n[            3 INFO] AWkernel RV64 primary CPU initialization complete
[            5 INFO] CPU#0 is starting.
[            6 INFO] CPU#3 is starting.
[            6 INFO] CPU#1 is starting.
[            7 INFO] CPU#2 is starting.
[            7 INFO] interrupt::INTERRUPT_CONTROLLER has been initialized.
[            8 INFO] interrupt::PREEMPT_FN has been initialized.
[            9 INFO] timer::TIMER has been initialized.
[           11 INFO] A local timer has been initialized.
```

```shell
// 2G Memory Size

qemu-system-riscv64 -machine virt -bios none -kernel target/riscv64gc-unknown-none-elf/release/awkernel -m 2G -nographic -smp 4 -monitor telnet::5556,server,nowait

=== AWkernel RV64 Starting ===
Console port initialized
UART driver initialized
Setting up heap allocation...
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000080000000
Using dynamic heap configuration\r\nHeap allocation complete\r\nInitializing page allocator...
Initializing kernel space...
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000080000000
Mapping kernel text section...
Mapping kernel rodata section...
Mapping kernel data section...
Mapping kernel bss section...
Mapping physical memory...
  from ekernel: 0x800d7000
  to MEMORY_END: 0x00000000 (dynamic)
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000080000000
Dynamic heap calculation:
  Kernel end: 0x800d7000
  Heap start: 0x800d7000
  Memory end: 0x00000000
  Max heap size: 0x7ff29000
Activating kernel space...
Virtual memory system initialized
Initializing RISC-V interrupt controller...\r\nInitializing RISC-V timer...\r\nTimer and interrupt controller initialized\r\n[            3 INFO] AWkernel RV64 primary CPU initialization complete
[            6 INFO] CPU#0 is starting.
[            6 INFO] CPU#3 is starting.
[            7 INFO] CPU#2 is starting.
[            8 INFO] CPU#1 is starting.
[            8 INFO] interrupt::INTERRUPT_CONTROLLER has been initialized.
[            9 INFO] interrupt::PREEMPT_FN has been initialized.
[           10 INFO] timer::TIMER has been initialized.
[           12 INFO] A local timer has been initialized.
```
After Implementation of Interrupt Controller and timer, the RV64 version kernel worked well as the following.

```shell
// All basic function including timer, interrupt controller and dynamic cpu counts worked well
make qemu-riscv64
qemu-system-riscv64 -machine virt -bios none -kernel target/riscv64gc-unknown-none-elf/release/awkernel -m 1G -nographic -smp 4 -monitor telnet::5556,server,nowait

=== AWkernel RV64 Starting ===
Console port initialized
UART driver initialized
Setting up heap allocation...
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000040000000
Using dynamic heap configuration
Heap allocation complete
Initializing page allocator...
Initializing kernel space...
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000040000000
Mapping kernel text section...
Mapping kernel rodata section...
Mapping kernel data section...
Mapping kernel bss section...
Mapping physical memory...
  from ekernel: 0x00000000800df000
  to MEMORY_END: 0x00000000c0000000 (dynamic)
Memory detected from boot DTB pointer at 0x0000bfe0bfe00000
Detected RAM size: 0x0000000040000000
Dynamic heap calculation:
  Kernel end: 0x00000000800df000
  Heap start: 0x00000000800df000
  Memory end: 0x00000000c0000000
  Max heap size: 0x000000003ff21000
Activating kernel space...
Virtual memory system initialized
Initializing RISC-V interrupt controller...
Initializing RISC-V timer...
Timer and interrupt controller initialized
[            1 INFO] AWkernel RV64 primary CPU initialization complete
Detected 00000004 CPUs from boot DTB
[            5 INFO] CPU#0 is starting.
[            6 INFO] CPU#1 is starting.
[            6 INFO] CPU#2 is starting.
[            7 INFO] CPU#3 is starting.
[            7 INFO] interrupt::INTERRUPT_CONTROLLER has been initialized.
[            8 INFO] interrupt::PREEMPT_FN has been initialized.
[            9 INFO] timer::TIMER has been initialized.
[           12 INFO] A local timer has been initialized.
[           15 INFO] Starting [Awkernel] network service.
```