### PR TITLE
feat(error): implement core::error::Error for error types

### DIFF
--- a/awkernel_drivers/src/hal/raspi/uart.rs
+++ b/awkernel_drivers/src/hal/raspi/uart.rs
@@ -243,6 +243,14 @@ impl Drop for Uart {
     }
 }
 
+impl core::fmt::Display for UartError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for UartError {}
+
 impl embedded_hal_nb::serial::Error for UartError {
     fn kind(&self) -> embedded_hal_nb::serial::ErrorKind {
         match self {

--- a/awkernel_drivers/src/mii.rs
+++ b/awkernel_drivers/src/mii.rs
@@ -157,6 +157,14 @@ pub enum MiiError {
     Media,
 }
 
+impl core::fmt::Display for MiiError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for MiiError {}
+
 pub struct MiiDev {
     mii_data: MiiData,
     phys: BTreeMap<u32, Box<dyn MiiPhy + Send + Sync>>,

--- a/awkernel_drivers/src/pcie.rs
+++ b/awkernel_drivers/src/pcie.rs
@@ -102,6 +102,8 @@ impl fmt::Display for PCIeDeviceErr {
     }
 }
 
+impl core::error::Error for PCIeDeviceErr {}
+
 pub(crate) mod registers {
     use alloc::vec::Vec;
     use core::fmt;

--- a/awkernel_drivers/src/pcie/intel/igb.rs
+++ b/awkernel_drivers/src/pcie/intel/igb.rs
@@ -395,6 +395,8 @@ impl fmt::Display for IgbDriverErr {
     }
 }
 
+impl core::error::Error for IgbDriverErr {}
+
 impl IgbInner {
     fn new(mut info: PCIeInfo) -> Result<Self, PCIeDeviceErr> {
         let mut hw = igb_hw::IgbHw::new(&mut info)?;

--- a/awkernel_drivers/src/pcie/intel/ixgbe.rs
+++ b/awkernel_drivers/src/pcie/intel/ixgbe.rs
@@ -290,6 +290,8 @@ impl fmt::Display for IxgbeDriverErr {
     }
 }
 
+impl core::error::Error for IxgbeDriverErr {}
+
 impl IxgbeInner {
     fn new(mut info: PCIeInfo) -> Result<Self, PCIeDeviceErr> {
         let (mut hw, ops) = ixgbe_hw::IxgbeHw::new(&mut info)?;

--- a/awkernel_drivers/src/pcie/nvme.rs
+++ b/awkernel_drivers/src/pcie/nvme.rs
@@ -1042,6 +1042,14 @@ impl From<NvmeDriverErr> for PCIeDeviceErr {
     }
 }
 
+impl core::fmt::Display for NvmeDriverErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for NvmeDriverErr {}
+
 #[inline(always)]
 pub fn write_reg(info: &PCIeInfo, offset: usize, value: u32) -> Result<(), NvmeDriverErr> {
     let mut bar0 = info.get_bar(0).ok_or(NvmeDriverErr::NoBar0)?;

--- a/awkernel_drivers/src/pcie/virtio.rs
+++ b/awkernel_drivers/src/pcie/virtio.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use core::fmt;
 
 use super::{PCIeDevice, PCIeDeviceErr, PCIeInfo};
 
@@ -35,6 +36,14 @@ pub enum VirtioDriverErr {
     DMAPool,
     NoSlot,
 }
+
+impl fmt::Display for VirtioDriverErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for VirtioDriverErr {}
 
 impl From<VirtioDriverErr> for PCIeDeviceErr {
     fn from(value: VirtioDriverErr) -> Self {

--- a/awkernel_drivers/src/rtc.rs
+++ b/awkernel_drivers/src/rtc.rs
@@ -34,3 +34,11 @@ pub enum RtcError {
     HardwareError,
     NotSupported,
 }
+
+impl core::fmt::Display for RtcError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for RtcError {}

--- a/awkernel_lib/src/device_tree/error.rs
+++ b/awkernel_lib/src/device_tree/error.rs
@@ -11,3 +11,11 @@ pub enum DeviceTreeError {
     InvalidSemantics,
     NotFound,
 }
+
+impl core::fmt::Display for DeviceTreeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for DeviceTreeError {}

--- a/awkernel_lib/src/file/vfs/error.rs
+++ b/awkernel_lib/src/file/vfs/error.rs
@@ -168,5 +168,7 @@ impl fmt::Display for VfsIoError {
     }
 }
 
+impl core::error::Error for VfsIoError {}
+
 /// The result type of this crate
 pub type VfsResult<T> = core::result::Result<T, VfsError>;

--- a/awkernel_lib/src/graphics.rs
+++ b/awkernel_lib/src/graphics.rs
@@ -6,9 +6,18 @@ use embedded_graphics::{
 };
 use embedded_graphics_core::pixelcolor::Rgb888;
 
+#[derive(Debug)]
 pub enum FrameBufferError {
     NoFrameBuffer,
 }
+
+impl core::fmt::Display for FrameBufferError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for FrameBufferError {}
 
 static mut FRAME_BUFFER: Option<&'static mut dyn FrameBuffer> = None;
 

--- a/awkernel_lib/src/net.rs
+++ b/awkernel_lib/src/net.rs
@@ -71,6 +71,14 @@ pub enum NetManagerError {
     DeviceError(NetDevError),
 }
 
+impl core::fmt::Display for NetManagerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for NetManagerError {}
+
 #[derive(Debug)]
 pub struct IfStatus {
     pub interface_id: u64,

--- a/awkernel_lib/src/net/net_device.rs
+++ b/awkernel_lib/src/net/net_device.rs
@@ -132,6 +132,14 @@ pub enum NetDevError {
     MulticastAddrError,
 }
 
+impl core::fmt::Display for NetDevError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for NetDevError {}
+
 #[derive(Debug, Clone)]
 pub struct EtherFrameRef<'a> {
     pub data: &'a [u8],

--- a/awkernel_lib/src/storage/storage_device.rs
+++ b/awkernel_lib/src/storage/storage_device.rs
@@ -19,6 +19,14 @@ pub enum StorageDevError {
     NotSupported,
 }
 
+impl core::fmt::Display for StorageDevError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl core::error::Error for StorageDevError {}
+
 pub trait StorageDevice: Send + Sync {
     fn device_id(&self) -> u64;
 


### PR DESCRIPTION
## Description
ref(https://github.com/tier4/awkernel/issues/204)
implementing core::error::Error for error types across awkernel_drivers and awkernel_lib.

For error types that already had a `fmt::Display` implementation, only `impl core::error::Error for T {}` was added:

- `PCIeDeviceErr`
- `IxgbeDriverErr`
- `IgbDriverErr`
- `VfsIoError`

For error types that had no `Display` implementation, a `Display` impl delegating to `Debug` via `write!(f, "{self:?}")` was added alongside `core::error::Error`:

- `VirtioDriverErr`
- `NvmeDriverErr`
- `MiiError`
- `RtcError`
- `UartError`
- `DeviceTreeError`
- `FrameBufferError` 
- `NetManagerError`
- `NetDevError`
- `StorageDevError`

The following error types remain unaddressed and are left for a follow-up:

- `IgcDriverErr`
- `GenetError`
- `StorageManagerError`
- `VfsErrorKind`
- `InMemoryDiskError`
- `InitErr`
- `VtdError`
- `MapError`
- `DmaError`
- `RecvErr`, `SendErr`
- `DagError`
- `TcpSocketError`
- `UdpSocketError`

## Related links

## How was this PR tested?

## Notes for reviewers
