### PR TITLE
feat(x86): Add x86_64 power support and wire it into awkernel_shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ debug-x86_64:
 	cp ${OVMF_PATH}/vars.fd ${OVMF_PATH}/vars_qemu.fd
 	qemu-system-x86_64 $(QEMU_X86_ARGS) -s -S
 
-qemu-x86_64_nographic:
+qemu-x86_64-nographic:
 	cp ${OVMF_PATH}/vars.fd ${OVMF_PATH}/vars_qemu.fd
 	qemu-system-x86_64 $(QEMU_X86_ARGS) -nographic
 
@@ -278,4 +278,3 @@ clean: FORCE
 
 monitor : FORCE
 	telnet localhost $(QEMUPORT)
-

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,10 @@ debug-x86_64:
 	cp ${OVMF_PATH}/vars.fd ${OVMF_PATH}/vars_qemu.fd
 	qemu-system-x86_64 $(QEMU_X86_ARGS) -s -S
 
+qemu-x86_64_nographic:
+	cp ${OVMF_PATH}/vars.fd ${OVMF_PATH}/vars_qemu.fd
+	qemu-system-x86_64 $(QEMU_X86_ARGS) -nographic
+
 gdb-x86_64:
 	cp ${OVMF_PATH}/vars.fd ${OVMF_PATH}/vars_qemu.fd
 	gdb-multiarch -x scripts/x86-debug.gdb

--- a/applications/awkernel_shell/src/lib.rs
+++ b/applications/awkernel_shell/src/lib.rs
@@ -48,6 +48,8 @@ async fn console_handler() -> TaskResult {
         Box::new(TaskFfi),
         Box::new(InterruptFfi),
         Box::new(IfconfigFfi),
+        Box::new(RebootFfi),
+        Box::new(ShutdownFfi),
     ];
 
     #[cfg(feature = "perf")]
@@ -166,6 +168,12 @@ const CODE: &str = "(export factorial (n) (Pure (-> (Int) Int))
 
 (export ifconfig () (IO (-> () []))
     (ifconfig_ffi))
+
+(export reboot () (IO (-> () []))
+    (reboot_ffi))
+
+(export shutdown () (IO (-> () []))
+    (shutdown_ffi))
 ";
 
 const PERF_CODE: &str = "(export perf () (IO (-> () []))
@@ -184,6 +192,8 @@ fn help_ffi() {
     lines.push_str("(task)      ; print tasks\r\n");
     lines.push_str("(interrupt) ; print interrupt information\r\n");
     lines.push_str("(ifconfig)  ; print network interfaces\r\n");
+    lines.push_str("(reboot)    ; reboot x86_64 systems\r\n");
+    lines.push_str("(shutdown)  ; power off x86_64 systems\r\n");
 
     #[cfg(feature = "perf")]
     lines.push_str("(perf)      ; print performance information\r\n");
@@ -234,6 +244,32 @@ fn ifconfig_ffi() {
     for netif in ifs.iter() {
         let msg = format!("{netif}\r\n\r\n");
         console::print(&msg);
+    }
+}
+
+#[embedded]
+fn reboot_ffi() {
+    #[cfg(all(target_arch = "x86_64", target_os = "none"))]
+    {
+        awkernel_lib::arch::x86_64::power::reboot();
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", target_os = "none")))]
+    {
+        console::print("reboot is unsupported on this architecture\r\n");
+    }
+}
+
+#[embedded]
+fn shutdown_ffi() {
+    #[cfg(all(target_arch = "x86_64", target_os = "none"))]
+    {
+        awkernel_lib::arch::x86_64::power::shutdown();
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", target_os = "none")))]
+    {
+        console::print("shutdown is unsupported on this architecture\r\n");
     }
 }
 

--- a/awkernel_lib/Cargo.toml
+++ b/awkernel_lib/Cargo.toml
@@ -37,6 +37,10 @@ optional = true
 git = "https://github.com/ytakano/acpi.git"
 optional = true
 
+[dependencies.aml]
+git = "https://github.com/ytakano/acpi.git"
+optional = true
+
 [dependencies.bootloader_api]
 version = "0.11"
 optional = true
@@ -76,6 +80,7 @@ default = ["x86"]
 x86 = [
     "dep:x86_64",
     "dep:acpi",
+    "dep:aml",
     "dep:bootloader_api",
     "awkernel_sync/x86",
     "awkernel_sync/x86_mwait",

--- a/awkernel_lib/src/arch/x86_64.rs
+++ b/awkernel_lib/src/arch/x86_64.rs
@@ -25,10 +25,13 @@ pub fn init(
     page_table: &mut page_table::PageTable,
     page_allocator: &mut VecPageAllocator,
 ) -> Result<(), &'static str> {
+    // Initialize timer before AML-driven power initialization can invoke
+    // delay-backed Stall/Sleep handlers.
+    delay::init(acpi, page_table, page_allocator)?;
+
     if let Err(err) = power::init(acpi) {
         log::warn!("Failed to initialize x86 power control. {err}");
     }
 
-    // Initialize timer.
-    delay::init(acpi, page_table, page_allocator)
+    Ok(())
 }

--- a/awkernel_lib/src/arch/x86_64.rs
+++ b/awkernel_lib/src/arch/x86_64.rs
@@ -14,6 +14,7 @@ pub mod msr;
 pub mod page_allocator;
 pub mod page_table;
 pub(super) mod paging;
+pub mod power;
 
 pub struct X86;
 
@@ -24,6 +25,10 @@ pub fn init(
     page_table: &mut page_table::PageTable,
     page_allocator: &mut VecPageAllocator,
 ) -> Result<(), &'static str> {
+    if let Err(err) = power::init(acpi) {
+        log::warn!("Failed to initialize x86 power control. {err}");
+    }
+
     // Initialize timer.
     delay::init(acpi, page_table, page_allocator)
 }

--- a/awkernel_lib/src/arch/x86_64/power.rs
+++ b/awkernel_lib/src/arch/x86_64/power.rs
@@ -1,7 +1,6 @@
 use super::acpi::AcpiMapper;
 use crate::{
-    delay,
-    interrupt,
+    delay, interrupt,
     mmio::{ReadOnlyOffset, WriteOnlyOffset},
     sync::mutex::{MCSNode, Mutex},
 };

--- a/awkernel_lib/src/arch/x86_64/power.rs
+++ b/awkernel_lib/src/arch/x86_64/power.rs
@@ -24,7 +24,7 @@ use x86_64::{
 };
 
 const SCI_EN: u64 = 1 << 0;
-const SLP_TYP_SHIFT: u16 = 10;
+const SLP_TYP_SHIFT: u32 = 10;
 const SLP_EN: u16 = 1 << 13;
 const SLP_TYP_MASK: u64 = 0x7 << SLP_TYP_SHIFT;
 
@@ -59,8 +59,10 @@ struct AcpiRegister {
 pub fn init(acpi: &AcpiTables<AcpiMapper>) -> Result<(), &'static str> {
     let mut node = MCSNode::new();
     let mut state = POWER_CONTROL.lock(&mut node);
-    if !matches!(*state, PowerControlState::Uninitialized) {
-        return Ok(());
+    match *state {
+        PowerControlState::Uninitialized => {}
+        PowerControlState::Ready(_) => return Ok(()),
+        PowerControlState::Failed(err) => return Err(err),
     }
 
     match init_power_control(acpi) {
@@ -341,11 +343,16 @@ fn parse_aml_table(
 ) -> Result<(), &'static str> {
     let mapping =
         unsafe { handler.map_physical_region::<u8>(table.address, table.length as usize) };
-    let data =
-        unsafe { slice::from_raw_parts(mapping.virtual_start().as_ptr(), mapping.region_length()) };
-    context
-        .parse_table(data)
-        .map_err(|_| "Failed to parse AML table.")
+    let result = {
+        let data = unsafe {
+            slice::from_raw_parts(mapping.virtual_start().as_ptr(), mapping.region_length())
+        };
+        context
+            .parse_table(data)
+            .map_err(|_| "Failed to parse AML table.")
+    };
+    AcpiMapper::unmap_physical_region(&mapping);
+    result
 }
 
 fn parse_sleep_types(value: &AmlValue, context: &AmlContext) -> Result<(u16, u16), &'static str> {

--- a/awkernel_lib/src/arch/x86_64/power.rs
+++ b/awkernel_lib/src/arch/x86_64/power.rs
@@ -1,6 +1,7 @@
 use super::acpi::AcpiMapper;
 use crate::{
     delay,
+    interrupt,
     mmio::{ReadOnlyOffset, WriteOnlyOffset},
     sync::mutex::{MCSNode, Mutex},
 };
@@ -14,7 +15,7 @@ use aml::{
     value::{AmlValue, Args},
     AmlContext, AmlName, DebugVerbosity, Handler,
 };
-use core::{ptr, slice};
+use core::{convert::TryFrom, ptr, slice};
 use x86_64::{
     instructions::{
         hlt,
@@ -29,6 +30,7 @@ const SLP_EN: u16 = 1 << 13;
 const SLP_TYP_MASK: u64 = 0x7 << SLP_TYP_SHIFT;
 
 static POWER_CONTROL: Mutex<PowerControlState> = Mutex::new(PowerControlState::Uninitialized);
+static PCI_CONFIG_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Clone, Copy)]
 enum PowerControlState {
@@ -56,6 +58,7 @@ struct AcpiRegister {
     address: u64,
 }
 
+/// Initialize x86_64 power control after `delay::init` has completed.
 pub fn init(acpi: &AcpiTables<AcpiMapper>) -> Result<(), &'static str> {
     let mut node = MCSNode::new();
     let mut state = POWER_CONTROL.lock(&mut node);
@@ -77,7 +80,10 @@ pub fn init(acpi: &AcpiTables<AcpiMapper>) -> Result<(), &'static str> {
     }
 }
 
+/// Enter ACPI S5 and fall back to the QEMU/Bochs shutdown ports if needed.
 pub fn shutdown() -> ! {
+    interrupt::disable();
+
     let control = match current_power_control() {
         Ok(control) => control,
         Err(err) => {
@@ -105,8 +111,15 @@ pub fn shutdown() -> ! {
     wait_for_power_transition();
 }
 
+/// Reboot via the ACPI reset register and then fall back to legacy reset ports.
 pub fn reboot() -> ! {
+    interrupt::disable();
+
     if let Ok(control) = current_power_control() {
+        if let Err(err) = enable_acpi(&control) {
+            log::warn!("Failed to enable ACPI mode before reboot. {err}");
+        }
+
         if let Some(reset_reg) = control.reset_reg {
             if let Err(err) = write_register(reset_reg, control.reset_value as u64) {
                 log::warn!("ACPI reset register reboot failed. {err}");
@@ -146,11 +159,19 @@ fn init_power_control(acpi: &AcpiTables<AcpiMapper>) -> Result<PowerControl, &'s
         .transpose()?;
 
     let (slp_typa, slp_typb) = parse_s5_sleep_types(acpi, fadt.handler().clone())?;
+    let smi_cmd_port = if fadt.smi_cmd_port == 0 {
+        None
+    } else {
+        Some(
+            u16::try_from(fadt.smi_cmd_port)
+                .map_err(|_| "SMI command port exceeds 16-bit port range.")?,
+        )
+    };
 
     Ok(PowerControl {
         reset_reg,
         reset_value: fadt.reset_value,
-        smi_cmd_port: (fadt.smi_cmd_port != 0).then_some(fadt.smi_cmd_port as u16),
+        smi_cmd_port,
         acpi_enable: fadt.acpi_enable,
         pm1a_control,
         pm1b_control,
@@ -495,6 +516,7 @@ impl Handler for AmlHandler {
     }
 
     fn read_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u16 {
+        let offset = offset & !1;
         (read_pci_config(segment, bus, device, function, offset & !3)
             >> (((offset & 2) * 8) as u32)) as u16
     }
@@ -524,6 +546,7 @@ impl Handler for AmlHandler {
         offset: u16,
         value: u16,
     ) {
+        let offset = offset & !1;
         write_pci_partial(segment, bus, device, function, offset, value as u32, 0xFFFF);
     }
 
@@ -549,37 +572,11 @@ impl Handler for AmlHandler {
 }
 
 fn read_pci_config(segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
-    if segment != 0 {
-        return 0;
-    }
-
-    let address = 0x8000_0000u32
-        | ((bus as u32) << 16)
-        | ((device as u32) << 11)
-        | ((function as u32) << 8)
-        | ((offset as u32) & 0xFC);
-
-    unsafe {
-        PortWriteOnly::<u32>::new(0xCF8).write(address);
-        PortReadOnly::<u32>::new(0xCFC).read()
-    }
+    with_pci_config_lock(|| read_pci_config_raw(segment, bus, device, function, offset))
 }
 
 fn write_pci_config(segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
-    if segment != 0 {
-        return;
-    }
-
-    let address = 0x8000_0000u32
-        | ((bus as u32) << 16)
-        | ((device as u32) << 11)
-        | ((function as u32) << 8)
-        | ((offset as u32) & 0xFC);
-
-    unsafe {
-        PortWriteOnly::<u32>::new(0xCF8).write(address);
-        PortWriteOnly::<u32>::new(0xCFC).write(value);
-    }
+    with_pci_config_lock(|| write_pci_config_raw(segment, bus, device, function, offset, value));
 }
 
 fn write_pci_partial(
@@ -591,9 +588,51 @@ fn write_pci_partial(
     value: u32,
     mask: u32,
 ) {
-    let aligned = offset & !3;
-    let shift = ((offset & 3) * 8) as u32;
-    let current = read_pci_config(segment, bus, device, function, aligned);
-    let value = (current & !(mask << shift)) | ((value & mask) << shift);
-    write_pci_config(segment, bus, device, function, aligned, value);
+    with_pci_config_lock(|| {
+        let aligned = offset & !3;
+        let shift = ((offset & 3) * 8) as u32;
+        let current = read_pci_config_raw(segment, bus, device, function, aligned);
+        let value = (current & !(mask << shift)) | ((value & mask) << shift);
+        write_pci_config_raw(segment, bus, device, function, aligned, value);
+    });
+}
+
+fn with_pci_config_lock<T>(f: impl FnOnce() -> T) -> T {
+    let mut node = MCSNode::new();
+    let _guard = PCI_CONFIG_LOCK.lock(&mut node);
+    f()
+}
+
+fn read_pci_config_raw(segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+    if segment != 0 {
+        return 0;
+    }
+
+    let address = pci_config_address(bus, device, function, offset);
+
+    unsafe {
+        PortWriteOnly::<u32>::new(0xCF8).write(address);
+        PortReadOnly::<u32>::new(0xCFC).read()
+    }
+}
+
+fn write_pci_config_raw(segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+    if segment != 0 {
+        return;
+    }
+
+    let address = pci_config_address(bus, device, function, offset);
+
+    unsafe {
+        PortWriteOnly::<u32>::new(0xCF8).write(address);
+        PortWriteOnly::<u32>::new(0xCFC).write(value);
+    }
+}
+
+fn pci_config_address(bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+    0x8000_0000u32
+        | ((bus as u32) << 16)
+        | ((device as u32) << 11)
+        | ((function as u32) << 8)
+        | ((offset as u32) & 0xFC)
 }

--- a/awkernel_lib/src/arch/x86_64/power.rs
+++ b/awkernel_lib/src/arch/x86_64/power.rs
@@ -304,7 +304,10 @@ fn parse_s5_sleep_types(
     acpi: &AcpiTables<AcpiMapper>,
     handler: AcpiMapper,
 ) -> Result<(u16, u16), &'static str> {
-    let mut context = AmlContext::new(Box::new(AmlHandler::new(handler.clone())), DebugVerbosity::None);
+    let mut context = AmlContext::new(
+        Box::new(AmlHandler::new(handler.clone())),
+        DebugVerbosity::None,
+    );
 
     parse_aml_table(
         &mut context,

--- a/awkernel_lib/src/arch/x86_64/power.rs
+++ b/awkernel_lib/src/arch/x86_64/power.rs
@@ -1,6 +1,7 @@
 use super::acpi::AcpiMapper;
 use crate::{
     delay,
+    mmio::{ReadOnlyOffset, WriteOnlyOffset},
     sync::mutex::{MCSNode, Mutex},
 };
 use acpi::{
@@ -25,6 +26,7 @@ use x86_64::{
 const SCI_EN: u64 = 1 << 0;
 const SLP_TYP_SHIFT: u16 = 10;
 const SLP_EN: u16 = 1 << 13;
+const SLP_TYP_MASK: u64 = 0x7 << SLP_TYP_SHIFT;
 
 static POWER_CONTROL: Mutex<PowerControlState> = Mutex::new(PowerControlState::Uninitialized);
 
@@ -78,7 +80,7 @@ pub fn shutdown() -> ! {
         Ok(control) => control,
         Err(err) => {
             log::error!("Shutdown is unavailable. {err}");
-            wait_for_power_transition();
+            qemu_shutdown_fallback();
         }
     };
 
@@ -86,21 +88,19 @@ pub fn shutdown() -> ! {
         log::warn!("Failed to enable ACPI mode before shutdown. {err}");
     }
 
-    let value_a = SLP_EN | (control.slp_typa << SLP_TYP_SHIFT);
-    if let Err(err) = write_register(control.pm1a_control, value_a as u64) {
+    if let Err(err) = write_sleep_control(control.pm1a_control, control.slp_typa) {
         log::error!("Failed to write PM1a control block. {err}");
         qemu_shutdown_fallback();
     }
 
     if let Some(pm1b) = control.pm1b_control {
-        let value_b = SLP_EN | (control.slp_typb << SLP_TYP_SHIFT);
-        if let Err(err) = write_register(pm1b, value_b as u64) {
+        if let Err(err) = write_sleep_control(pm1b, control.slp_typb) {
             log::error!("Failed to write PM1b control block. {err}");
             qemu_shutdown_fallback();
         }
     }
 
-    qemu_shutdown_fallback();
+    wait_for_power_transition();
 }
 
 pub fn reboot() -> ! {
@@ -177,8 +177,19 @@ fn convert_register(
     }
 
     let address = match register.address_space {
-        AddressSpace::SystemIo => register.address,
+        AddressSpace::SystemIo => {
+            if register.address > u16::MAX as u64 {
+                return Err("System I/O register address exceeds 16-bit port range.");
+            }
+            if !matches!(width_bytes, 1 | 2 | 4) {
+                return Err("Unsupported I/O register width.");
+            }
+            register.address
+        }
         AddressSpace::SystemMemory => {
+            if !matches!(width_bytes, 1 | 2 | 4 | 8) {
+                return Err("Unsupported memory register width.");
+            }
             let virt = VirtAddr::new(physical_memory_offset as u64) + register.address;
             virt.as_u64()
         }
@@ -218,15 +229,13 @@ fn read_register(register: AcpiRegister) -> Result<u64, &'static str> {
                 _ => return Err("Unsupported I/O register width."),
             })
         },
-        AddressSpace::SystemMemory => unsafe {
-            Ok(match register.width_bytes {
-                1 => ptr::read_volatile(register.address as *const u8) as u64,
-                2 => ptr::read_volatile(register.address as *const u16) as u64,
-                4 => ptr::read_volatile(register.address as *const u32) as u64,
-                8 => ptr::read_volatile(register.address as *const u64),
-                _ => return Err("Unsupported memory register width."),
-            })
-        },
+        AddressSpace::SystemMemory => Ok(match register.width_bytes {
+            1 => ReadOnlyOffset::<0, u8>::new().read(register.address as usize) as u64,
+            2 => ReadOnlyOffset::<0, u16>::new().read(register.address as usize) as u64,
+            4 => ReadOnlyOffset::<0, u32>::new().read(register.address as usize) as u64,
+            8 => ReadOnlyOffset::<0, u64>::new().read(register.address as usize),
+            _ => return Err("Unsupported memory register width."),
+        }),
         _ => Err("Unsupported ACPI register address space."),
     }
 }
@@ -241,19 +250,26 @@ fn write_register(register: AcpiRegister, value: u64) -> Result<(), &'static str
                 _ => return Err("Unsupported I/O register width."),
             }
         },
-        AddressSpace::SystemMemory => unsafe {
-            match register.width_bytes {
-                1 => ptr::write_volatile(register.address as *mut u8, value as u8),
-                2 => ptr::write_volatile(register.address as *mut u16, value as u16),
-                4 => ptr::write_volatile(register.address as *mut u32, value as u32),
-                8 => ptr::write_volatile(register.address as *mut u64, value),
-                _ => return Err("Unsupported memory register width."),
-            }
+        AddressSpace::SystemMemory => match register.width_bytes {
+            1 => WriteOnlyOffset::<0, u8>::new().write(value as u8, register.address as usize),
+            2 => WriteOnlyOffset::<0, u16>::new().write(value as u16, register.address as usize),
+            4 => WriteOnlyOffset::<0, u32>::new().write(value as u32, register.address as usize),
+            8 => WriteOnlyOffset::<0, u64>::new().write(value, register.address as usize),
+            _ => return Err("Unsupported memory register width."),
         },
         _ => return Err("Unsupported ACPI register address space."),
     }
 
     Ok(())
+}
+
+fn write_sleep_control(register: AcpiRegister, slp_typ: u16) -> Result<(), &'static str> {
+    let current = read_register(register)?;
+    let sleep_type = ((slp_typ as u64) << SLP_TYP_SHIFT) & SLP_TYP_MASK;
+    let prepared = (current & !(SLP_TYP_MASK | SLP_EN as u64)) | sleep_type;
+
+    write_register(register, prepared)?;
+    write_register(register, prepared | SLP_EN as u64)
 }
 
 fn enable_acpi(control: &PowerControl) -> Result<(), &'static str> {
@@ -288,7 +304,7 @@ fn parse_s5_sleep_types(
     acpi: &AcpiTables<AcpiMapper>,
     handler: AcpiMapper,
 ) -> Result<(u16, u16), &'static str> {
-    let mut context = AmlContext::new(Box::new(AmlHandler), DebugVerbosity::None);
+    let mut context = AmlContext::new(Box::new(AmlHandler::new(handler.clone())), DebugVerbosity::None);
 
     parse_aml_table(
         &mut context,
@@ -377,39 +393,66 @@ fn wait_for_power_transition() -> ! {
     }
 }
 
-struct AmlHandler;
+struct AmlHandler {
+    mapper: AcpiMapper,
+}
+
+impl AmlHandler {
+    fn new(mapper: AcpiMapper) -> Self {
+        Self { mapper }
+    }
+
+    fn read_system_memory<T: Copy>(&self, address: usize) -> T {
+        let mapping = unsafe {
+            self.mapper
+                .map_physical_region::<T>(address, core::mem::size_of::<T>())
+        };
+        let value = ReadOnlyOffset::<0, T>::new().read(mapping.virtual_start().as_ptr() as usize);
+        AcpiMapper::unmap_physical_region(&mapping);
+        value
+    }
+
+    fn write_system_memory<T: Copy>(&mut self, address: usize, value: T) {
+        let mapping = unsafe {
+            self.mapper
+                .map_physical_region::<T>(address, core::mem::size_of::<T>())
+        };
+        WriteOnlyOffset::<0, T>::new().write(value, mapping.virtual_start().as_ptr() as usize);
+        AcpiMapper::unmap_physical_region(&mapping);
+    }
+}
 
 impl Handler for AmlHandler {
     fn read_u8(&self, address: usize) -> u8 {
-        unsafe { ptr::read_volatile(address as *const u8) }
+        self.read_system_memory(address)
     }
 
     fn read_u16(&self, address: usize) -> u16 {
-        unsafe { ptr::read_volatile(address as *const u16) }
+        self.read_system_memory(address)
     }
 
     fn read_u32(&self, address: usize) -> u32 {
-        unsafe { ptr::read_volatile(address as *const u32) }
+        self.read_system_memory(address)
     }
 
     fn read_u64(&self, address: usize) -> u64 {
-        unsafe { ptr::read_volatile(address as *const u64) }
+        self.read_system_memory(address)
     }
 
     fn write_u8(&mut self, address: usize, value: u8) {
-        unsafe { ptr::write_volatile(address as *mut u8, value) }
+        self.write_system_memory(address, value)
     }
 
     fn write_u16(&mut self, address: usize, value: u16) {
-        unsafe { ptr::write_volatile(address as *mut u16, value) }
+        self.write_system_memory(address, value)
     }
 
     fn write_u32(&mut self, address: usize, value: u32) {
-        unsafe { ptr::write_volatile(address as *mut u32, value) }
+        self.write_system_memory(address, value)
     }
 
     fn write_u64(&mut self, address: usize, value: u64) {
-        unsafe { ptr::write_volatile(address as *mut u64, value) }
+        self.write_system_memory(address, value)
     }
 
     fn read_io_u8(&self, port: u16) -> u8 {

--- a/awkernel_lib/src/arch/x86_64/power.rs
+++ b/awkernel_lib/src/arch/x86_64/power.rs
@@ -1,0 +1,546 @@
+use super::acpi::AcpiMapper;
+use crate::{
+    delay,
+    sync::mutex::{MCSNode, Mutex},
+};
+use acpi::{
+    address::{AccessSize, AddressSpace, GenericAddress},
+    fadt::Fadt,
+    AcpiHandler, AcpiTables,
+};
+use alloc::boxed::Box;
+use aml::{
+    value::{AmlValue, Args},
+    AmlContext, AmlName, DebugVerbosity, Handler,
+};
+use core::{ptr, slice};
+use x86_64::{
+    instructions::{
+        hlt,
+        port::{PortReadOnly, PortWriteOnly},
+    },
+    VirtAddr,
+};
+
+const SCI_EN: u64 = 1 << 0;
+const SLP_TYP_SHIFT: u16 = 10;
+const SLP_EN: u16 = 1 << 13;
+
+static POWER_CONTROL: Mutex<PowerControlState> = Mutex::new(PowerControlState::Uninitialized);
+
+#[derive(Clone, Copy)]
+enum PowerControlState {
+    Uninitialized,
+    Ready(PowerControl),
+    Failed(&'static str),
+}
+
+#[derive(Clone, Copy)]
+struct PowerControl {
+    reset_reg: Option<AcpiRegister>,
+    reset_value: u8,
+    smi_cmd_port: Option<u16>,
+    acpi_enable: u8,
+    pm1a_control: AcpiRegister,
+    pm1b_control: Option<AcpiRegister>,
+    slp_typa: u16,
+    slp_typb: u16,
+}
+
+#[derive(Clone, Copy)]
+struct AcpiRegister {
+    address_space: AddressSpace,
+    width_bytes: u8,
+    address: u64,
+}
+
+pub fn init(acpi: &AcpiTables<AcpiMapper>) -> Result<(), &'static str> {
+    let mut node = MCSNode::new();
+    let mut state = POWER_CONTROL.lock(&mut node);
+    if !matches!(*state, PowerControlState::Uninitialized) {
+        return Ok(());
+    }
+
+    match init_power_control(acpi) {
+        Ok(control) => {
+            *state = PowerControlState::Ready(control);
+            Ok(())
+        }
+        Err(err) => {
+            *state = PowerControlState::Failed(err);
+            Err(err)
+        }
+    }
+}
+
+pub fn shutdown() -> ! {
+    let control = match current_power_control() {
+        Ok(control) => control,
+        Err(err) => {
+            log::error!("Shutdown is unavailable. {err}");
+            wait_for_power_transition();
+        }
+    };
+
+    if let Err(err) = enable_acpi(&control) {
+        log::warn!("Failed to enable ACPI mode before shutdown. {err}");
+    }
+
+    let value_a = SLP_EN | (control.slp_typa << SLP_TYP_SHIFT);
+    if let Err(err) = write_register(control.pm1a_control, value_a as u64) {
+        log::error!("Failed to write PM1a control block. {err}");
+        qemu_shutdown_fallback();
+    }
+
+    if let Some(pm1b) = control.pm1b_control {
+        let value_b = SLP_EN | (control.slp_typb << SLP_TYP_SHIFT);
+        if let Err(err) = write_register(pm1b, value_b as u64) {
+            log::error!("Failed to write PM1b control block. {err}");
+            qemu_shutdown_fallback();
+        }
+    }
+
+    qemu_shutdown_fallback();
+}
+
+pub fn reboot() -> ! {
+    if let Ok(control) = current_power_control() {
+        if let Some(reset_reg) = control.reset_reg {
+            if let Err(err) = write_register(reset_reg, control.reset_value as u64) {
+                log::warn!("ACPI reset register reboot failed. {err}");
+            }
+        }
+    } else {
+        log::warn!("ACPI reboot is unavailable, using legacy reset paths.");
+    }
+
+    legacy_reboot();
+}
+
+fn init_power_control(acpi: &AcpiTables<AcpiMapper>) -> Result<PowerControl, &'static str> {
+    let fadt = acpi
+        .find_table::<Fadt>()
+        .map_err(|_| "Failed to locate FADT.")?;
+    let physical_memory_offset = fadt.virtual_start().as_ptr() as usize - fadt.physical_start();
+    let flags = unsafe { ptr::addr_of!(fadt.flags).read_unaligned() };
+    let supports_fadt_reset = flags.supports_system_reset_via_fadt();
+
+    let reset_reg = match fadt.reset_register() {
+        Ok(register) if supports_fadt_reset => {
+            Some(convert_register(register, physical_memory_offset)?)
+        }
+        _ => None,
+    };
+
+    let pm1a_control = convert_register(
+        fadt.pm1a_control_block()
+            .map_err(|_| "Failed to locate PM1a control block.")?,
+        physical_memory_offset,
+    )?;
+    let pm1b_control = fadt
+        .pm1b_control_block()
+        .map_err(|_| "Failed to locate PM1b control block.")?
+        .map(|register| convert_register(register, physical_memory_offset))
+        .transpose()?;
+
+    let (slp_typa, slp_typb) = parse_s5_sleep_types(acpi, fadt.handler().clone())?;
+
+    Ok(PowerControl {
+        reset_reg,
+        reset_value: fadt.reset_value,
+        smi_cmd_port: (fadt.smi_cmd_port != 0).then_some(fadt.smi_cmd_port as u16),
+        acpi_enable: fadt.acpi_enable,
+        pm1a_control,
+        pm1b_control,
+        slp_typa,
+        slp_typb,
+    })
+}
+
+fn current_power_control() -> Result<PowerControl, &'static str> {
+    let mut node = MCSNode::new();
+    let state = POWER_CONTROL.lock(&mut node);
+    match *state {
+        PowerControlState::Ready(control) => Ok(control),
+        PowerControlState::Failed(err) => Err(err),
+        PowerControlState::Uninitialized => Err("x86 power control is not initialized."),
+    }
+}
+
+fn convert_register(
+    register: GenericAddress,
+    physical_memory_offset: usize,
+) -> Result<AcpiRegister, &'static str> {
+    let width_bytes = register_width_bytes(&register)?;
+    if register.bit_offset != 0 {
+        return Err("ACPI register bit offsets are not supported.");
+    }
+
+    let address = match register.address_space {
+        AddressSpace::SystemIo => register.address,
+        AddressSpace::SystemMemory => {
+            let virt = VirtAddr::new(physical_memory_offset as u64) + register.address;
+            virt.as_u64()
+        }
+        _ => return Err("Unsupported ACPI register address space."),
+    };
+
+    Ok(AcpiRegister {
+        address_space: register.address_space,
+        width_bytes,
+        address,
+    })
+}
+
+fn register_width_bytes(register: &GenericAddress) -> Result<u8, &'static str> {
+    match register.access_size {
+        AccessSize::ByteAccess => Ok(1),
+        AccessSize::WordAccess => Ok(2),
+        AccessSize::DWordAccess => Ok(4),
+        AccessSize::QWordAccess => Ok(8),
+        AccessSize::Undefined => match register.bit_width {
+            0..=8 => Ok(1),
+            9..=16 => Ok(2),
+            17..=32 => Ok(4),
+            33..=64 => Ok(8),
+            _ => Err("Unsupported ACPI register width."),
+        },
+    }
+}
+
+fn read_register(register: AcpiRegister) -> Result<u64, &'static str> {
+    match register.address_space {
+        AddressSpace::SystemIo => unsafe {
+            Ok(match register.width_bytes {
+                1 => PortReadOnly::<u8>::new(register.address as u16).read() as u64,
+                2 => PortReadOnly::<u16>::new(register.address as u16).read() as u64,
+                4 => PortReadOnly::<u32>::new(register.address as u16).read() as u64,
+                _ => return Err("Unsupported I/O register width."),
+            })
+        },
+        AddressSpace::SystemMemory => unsafe {
+            Ok(match register.width_bytes {
+                1 => ptr::read_volatile(register.address as *const u8) as u64,
+                2 => ptr::read_volatile(register.address as *const u16) as u64,
+                4 => ptr::read_volatile(register.address as *const u32) as u64,
+                8 => ptr::read_volatile(register.address as *const u64),
+                _ => return Err("Unsupported memory register width."),
+            })
+        },
+        _ => Err("Unsupported ACPI register address space."),
+    }
+}
+
+fn write_register(register: AcpiRegister, value: u64) -> Result<(), &'static str> {
+    match register.address_space {
+        AddressSpace::SystemIo => unsafe {
+            match register.width_bytes {
+                1 => PortWriteOnly::<u8>::new(register.address as u16).write(value as u8),
+                2 => PortWriteOnly::<u16>::new(register.address as u16).write(value as u16),
+                4 => PortWriteOnly::<u32>::new(register.address as u16).write(value as u32),
+                _ => return Err("Unsupported I/O register width."),
+            }
+        },
+        AddressSpace::SystemMemory => unsafe {
+            match register.width_bytes {
+                1 => ptr::write_volatile(register.address as *mut u8, value as u8),
+                2 => ptr::write_volatile(register.address as *mut u16, value as u16),
+                4 => ptr::write_volatile(register.address as *mut u32, value as u32),
+                8 => ptr::write_volatile(register.address as *mut u64, value),
+                _ => return Err("Unsupported memory register width."),
+            }
+        },
+        _ => return Err("Unsupported ACPI register address space."),
+    }
+
+    Ok(())
+}
+
+fn enable_acpi(control: &PowerControl) -> Result<(), &'static str> {
+    let Some(smi_cmd_port) = control.smi_cmd_port else {
+        return Ok(());
+    };
+
+    if control.acpi_enable == 0 {
+        return Ok(());
+    }
+
+    if read_register(control.pm1a_control)? & SCI_EN != 0 {
+        return Ok(());
+    }
+
+    unsafe {
+        PortWriteOnly::<u8>::new(smi_cmd_port).write(control.acpi_enable);
+    }
+
+    for _ in 0..300 {
+        if read_register(control.pm1a_control)? & SCI_EN != 0 {
+            return Ok(());
+        }
+
+        delay::wait_millisec(10);
+    }
+
+    Err("Timed out while waiting for SCI_EN.")
+}
+
+fn parse_s5_sleep_types(
+    acpi: &AcpiTables<AcpiMapper>,
+    handler: AcpiMapper,
+) -> Result<(u16, u16), &'static str> {
+    let mut context = AmlContext::new(Box::new(AmlHandler), DebugVerbosity::None);
+
+    parse_aml_table(
+        &mut context,
+        handler.clone(),
+        acpi.dsdt().map_err(|_| "Failed to locate DSDT.")?,
+    )?;
+    for ssdt in acpi.ssdts() {
+        parse_aml_table(&mut context, handler.clone(), ssdt)?;
+    }
+
+    let path = AmlName::from_str("\\_S5").map_err(|_| "Invalid AML name for _S5.")?;
+    let value = match context
+        .namespace
+        .get_by_path(&path)
+        .map_err(|_| "Failed to locate \\_S5 in AML.")?
+        .clone()
+    {
+        AmlValue::Method { .. } => context
+            .invoke_method(&path, Args::default())
+            .map_err(|_| "Failed to evaluate \\_S5 AML method.")?,
+        value => value,
+    };
+
+    parse_sleep_types(&value, &context)
+}
+
+fn parse_aml_table(
+    context: &mut AmlContext,
+    handler: AcpiMapper,
+    table: acpi::AmlTable,
+) -> Result<(), &'static str> {
+    let mapping =
+        unsafe { handler.map_physical_region::<u8>(table.address, table.length as usize) };
+    let data =
+        unsafe { slice::from_raw_parts(mapping.virtual_start().as_ptr(), mapping.region_length()) };
+    context
+        .parse_table(data)
+        .map_err(|_| "Failed to parse AML table.")
+}
+
+fn parse_sleep_types(value: &AmlValue, context: &AmlContext) -> Result<(u16, u16), &'static str> {
+    let AmlValue::Package(values) = value else {
+        return Err("\\_S5 is not an AML package.");
+    };
+
+    if values.is_empty() {
+        return Err("\\_S5 package is empty.");
+    }
+
+    let typa = values[0]
+        .as_integer(context)
+        .map_err(|_| "Failed to decode \\_S5 sleep type A.")? as u16;
+    let typb = if values.len() >= 2 {
+        values[1]
+            .as_integer(context)
+            .map_err(|_| "Failed to decode \\_S5 sleep type B.")? as u16
+    } else {
+        typa
+    };
+
+    Ok((typa, typb))
+}
+
+fn qemu_shutdown_fallback() -> ! {
+    unsafe {
+        PortWriteOnly::<u16>::new(0x604).write(0x2000);
+        PortWriteOnly::<u16>::new(0xB004).write(0x2000);
+    }
+
+    wait_for_power_transition();
+}
+
+fn legacy_reboot() -> ! {
+    unsafe {
+        PortWriteOnly::<u8>::new(0xCF9).write(0x02);
+        PortWriteOnly::<u8>::new(0xCF9).write(0x06);
+        PortWriteOnly::<u8>::new(0x64).write(0xFE);
+    }
+
+    wait_for_power_transition();
+}
+
+fn wait_for_power_transition() -> ! {
+    loop {
+        hlt();
+    }
+}
+
+struct AmlHandler;
+
+impl Handler for AmlHandler {
+    fn read_u8(&self, address: usize) -> u8 {
+        unsafe { ptr::read_volatile(address as *const u8) }
+    }
+
+    fn read_u16(&self, address: usize) -> u16 {
+        unsafe { ptr::read_volatile(address as *const u16) }
+    }
+
+    fn read_u32(&self, address: usize) -> u32 {
+        unsafe { ptr::read_volatile(address as *const u32) }
+    }
+
+    fn read_u64(&self, address: usize) -> u64 {
+        unsafe { ptr::read_volatile(address as *const u64) }
+    }
+
+    fn write_u8(&mut self, address: usize, value: u8) {
+        unsafe { ptr::write_volatile(address as *mut u8, value) }
+    }
+
+    fn write_u16(&mut self, address: usize, value: u16) {
+        unsafe { ptr::write_volatile(address as *mut u16, value) }
+    }
+
+    fn write_u32(&mut self, address: usize, value: u32) {
+        unsafe { ptr::write_volatile(address as *mut u32, value) }
+    }
+
+    fn write_u64(&mut self, address: usize, value: u64) {
+        unsafe { ptr::write_volatile(address as *mut u64, value) }
+    }
+
+    fn read_io_u8(&self, port: u16) -> u8 {
+        unsafe { PortReadOnly::<u8>::new(port).read() }
+    }
+
+    fn read_io_u16(&self, port: u16) -> u16 {
+        unsafe { PortReadOnly::<u16>::new(port).read() }
+    }
+
+    fn read_io_u32(&self, port: u16) -> u32 {
+        unsafe { PortReadOnly::<u32>::new(port).read() }
+    }
+
+    fn write_io_u8(&self, port: u16, value: u8) {
+        unsafe { PortWriteOnly::<u8>::new(port).write(value) }
+    }
+
+    fn write_io_u16(&self, port: u16, value: u16) {
+        unsafe { PortWriteOnly::<u16>::new(port).write(value) }
+    }
+
+    fn write_io_u32(&self, port: u16, value: u32) {
+        unsafe { PortWriteOnly::<u32>::new(port).write(value) }
+    }
+
+    fn read_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u8 {
+        (read_pci_config(segment, bus, device, function, offset & !3)
+            >> (((offset & 3) * 8) as u32)) as u8
+    }
+
+    fn read_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u16 {
+        (read_pci_config(segment, bus, device, function, offset & !3)
+            >> (((offset & 2) * 8) as u32)) as u16
+    }
+
+    fn read_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+        read_pci_config(segment, bus, device, function, offset & !3)
+    }
+
+    fn write_pci_u8(
+        &self,
+        segment: u16,
+        bus: u8,
+        device: u8,
+        function: u8,
+        offset: u16,
+        value: u8,
+    ) {
+        write_pci_partial(segment, bus, device, function, offset, value as u32, 0xFF);
+    }
+
+    fn write_pci_u16(
+        &self,
+        segment: u16,
+        bus: u8,
+        device: u8,
+        function: u8,
+        offset: u16,
+        value: u16,
+    ) {
+        write_pci_partial(segment, bus, device, function, offset, value as u32, 0xFFFF);
+    }
+
+    fn write_pci_u32(
+        &self,
+        segment: u16,
+        bus: u8,
+        device: u8,
+        function: u8,
+        offset: u16,
+        value: u32,
+    ) {
+        write_pci_config(segment, bus, device, function, offset, value);
+    }
+
+    fn stall(&self, microseconds: u64) {
+        delay::wait_microsec(microseconds);
+    }
+
+    fn sleep(&self, milliseconds: u64) {
+        delay::wait_millisec(milliseconds);
+    }
+}
+
+fn read_pci_config(segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+    if segment != 0 {
+        return 0;
+    }
+
+    let address = 0x8000_0000u32
+        | ((bus as u32) << 16)
+        | ((device as u32) << 11)
+        | ((function as u32) << 8)
+        | ((offset as u32) & 0xFC);
+
+    unsafe {
+        PortWriteOnly::<u32>::new(0xCF8).write(address);
+        PortReadOnly::<u32>::new(0xCFC).read()
+    }
+}
+
+fn write_pci_config(segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+    if segment != 0 {
+        return;
+    }
+
+    let address = 0x8000_0000u32
+        | ((bus as u32) << 16)
+        | ((device as u32) << 11)
+        | ((function as u32) << 8)
+        | ((offset as u32) & 0xFC);
+
+    unsafe {
+        PortWriteOnly::<u32>::new(0xCF8).write(address);
+        PortWriteOnly::<u32>::new(0xCFC).write(value);
+    }
+}
+
+fn write_pci_partial(
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+    offset: u16,
+    value: u32,
+    mask: u32,
+) {
+    let aligned = offset & !3;
+    let shift = ((offset & 3) * 8) as u32;
+    let current = read_pci_config(segment, bus, device, function, aligned);
+    let value = (current & !(mask << shift)) | ((value & mask) << shift);
+    write_pci_config(segment, bus, device, function, aligned, value);
+}


### PR DESCRIPTION
## Description

This PR adds an x86_64 power support module and integrates it into the current build and shell environment.

The main changes are:
- add a new `awkernel_lib/src/arch/x86_64/power.rs`
- export and wire the new x86_64 power functionality through `awkernel_lib`
- update `applications/awkernel_shell` to use the new functionality
- update build configuration (`Cargo.toml`, `Makefile`) accordingly

Overall, this PR introduces the initial power-related support on x86_64 and connects it to the existing user-facing shell path so that the functionality can be exercised more easily.

## Related links

- Branch: `ytakano/awkernel:x86_power`
- Upstream repository: `tier4/awkernel`

## How was this PR tested?

- built the updated tree with the modified build configuration
- confirmed that the new x86_64 power module is compiled and linked correctly
- verified that the shell-side integration builds successfully
- shutdown and reboot work correctly on physical and virtual machines

## Notes for reviewers

Please focus on:
- the architecture and API design of `arch/x86_64/power.rs`
- whether the new power-related interfaces fit the existing `awkernel_lib` structure
- whether the shell integration is the right place and shape for exposing this functionality
- whether the build system changes are minimal and appropriate