### PR TITLE
fix(igc): do not use `num_cpu()` when slecting the number of queues

### DIFF
--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -1494,17 +1494,15 @@ fn igc_is_valid_ether_addr(addr: &[u8; 6]) -> bool {
 
 /// Select the number of Rx/Tx queue pairs to enable.
 ///
-/// The result is constrained by three factors:
+/// The result is constrained by two factors:
 /// 1. **MSI-X vectors**: one vector per queue plus one for link events.
-/// 2. **CPU count**: no benefit in having more queues than CPUs.
-/// 3. **Hardware cap**: IGC/I225 supports at most 4 RSS queues.
+/// 2. **Hardware cap**: IGC/I225 supports at most 4 RSS queues.
 ///
 /// The result is rounded down to the nearest power of two (1, 2, or 4) so that
 /// the 128-entry RSS redirection table divides evenly among queues, giving each
 /// queue an equal share of hashed flows.
 fn igc_select_num_queues(available_vectors: usize) -> usize {
-    let cpu_count = core::cmp::max(1, awkernel_lib::cpu::num_cpu());
-    let available = core::cmp::min(core::cmp::min(available_vectors, cpu_count), 4);
+    let available = core::cmp::min(available_vectors, 4);
 
     if available >= 4 {
         4

--- a/awkernel_drivers/src/pcie/intel/igc.rs
+++ b/awkernel_drivers/src/pcie/intel/igc.rs
@@ -1501,6 +1501,12 @@ fn igc_is_valid_ether_addr(addr: &[u8; 6]) -> bool {
 /// The result is rounded down to the nearest power of two (1, 2, or 4) so that
 /// the 128-entry RSS redirection table divides evenly among queues, giving each
 /// queue an equal share of hashed flows.
+///
+/// Note: for future extensibility
+///
+/// `num_cpu()` is not available when this function is called during device initialization.
+/// If the number of CPU cores is needed to determine the number of queues, the driver should
+/// find the number of CPU cores through other means (e.g., ACPI tables).
 fn igc_select_num_queues(available_vectors: usize) -> usize {
     let available = core::cmp::min(available_vectors, 4);
 


### PR DESCRIPTION
## Description

`num_cpu()` is not available when initializing `igc`.
So, this PR removes `num_cpu()` usage in `igc_select_num_queues()`.

## Related links

#335 

## How was this PR tested?

Tested on a physical machine.

## Notes for reviewers
